### PR TITLE
Uses modern version detection API instead of floating point comparison.

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -81,14 +81,12 @@ NSString *ORKQuestionTypeString(ORKQuestionType questionType)
     if (self) {
         _healthStore = healthStore;
         
-#if __IPHONE_8_2
         if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){8, 2, 0}]) {
             [[NSNotificationCenter defaultCenter] addObserver:self
                                                      selector:@selector(healthKitUserPreferencesDidChange:)
                                                          name:HKUserPreferencesDidChangeNotification
                                                        object:healthStore];
         }
-#endif
     }
     return self;
 }
@@ -196,7 +194,6 @@ NSString *ORKQuestionTypeString(ORKQuestionType questionType)
 - (HKUnit *)defaultHealthKitUnitForAnswerFormat:(ORKAnswerFormat *)answerFormat {
     
     __block HKUnit *unit = [answerFormat healthKitUnit];
-#if __IPHONE_8_2
     HKObjectType *objectType = [answerFormat healthKitObjectType];
     if (![[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){8, 2, 0}]) {
         return unit;
@@ -226,8 +223,7 @@ NSString *ORKQuestionTypeString(ORKQuestionType questionType)
             _unitsTable[objectType] = unit;
         }
     }
-#endif
-    
+
     return unit;
 }
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -82,7 +82,7 @@ NSString *ORKQuestionTypeString(ORKQuestionType questionType)
         _healthStore = healthStore;
         
 #if __IPHONE_8_2
-        if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.2) {
+        if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){8, 2, 0}]) {
             [[NSNotificationCenter defaultCenter] addObserver:self
                                                      selector:@selector(healthKitUserPreferencesDidChange:)
                                                          name:HKUserPreferencesDidChangeNotification
@@ -198,7 +198,7 @@ NSString *ORKQuestionTypeString(ORKQuestionType questionType)
     __block HKUnit *unit = [answerFormat healthKitUnit];
 #if __IPHONE_8_2
     HKObjectType *objectType = [answerFormat healthKitObjectType];
-    if ([[[UIDevice currentDevice] systemVersion] floatValue] < 8.2) {
+    if (![[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){8, 2, 0}]) {
         return unit;
     }
     

--- a/ResearchKit/Common/ORKHealthAnswerFormat.m
+++ b/ResearchKit/Common/ORKHealthAnswerFormat.m
@@ -34,9 +34,6 @@
 #import "ORKHelpers.h"
 #import "ORKDefines_Private.h"
 
-
-#define HKBiologicalSexOther 3
-
 #pragma mark - ORKHealthAnswerFormat
 
 NSString *ORKHKBiologicalSexString(HKBiologicalSex biologicalSex) {

--- a/ResearchKit/Common/ORKHealthAnswerFormat.m
+++ b/ResearchKit/Common/ORKHealthAnswerFormat.m
@@ -35,9 +35,7 @@
 #import "ORKDefines_Private.h"
 
 
-#if !defined(__IPHONE_8_2)
 #define HKBiologicalSexOther 3
-#endif
 
 #pragma mark - ORKHealthAnswerFormat
 
@@ -46,14 +44,7 @@ NSString *ORKHKBiologicalSexString(HKBiologicalSex biologicalSex) {
     switch (biologicalSex) {
         case HKBiologicalSexFemale: string = @"HKBiologicalSexFemale"; break;
         case HKBiologicalSexMale:   string = @"HKBiologicalSexMale";   break;
-#if !defined(__IPHONE_8_2)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wswitch"
-#endif
         case HKBiologicalSexOther:  string = @"HKBiologicalSexOther";  break;
-#if !defined(__IPHONE_8_2)
-#pragma clang diagnostic pop
-#endif
         case HKBiologicalSexNotSet: break;
     }
     return string;

--- a/ResearchKit/Common/ORKHelpers.m
+++ b/ResearchKit/Common/ORKHelpers.m
@@ -410,11 +410,9 @@ CGFloat ORKTableViewLeftMargin(UITableView *tableView){
 
 UIFont *ORKThinFontWithSize(CGFloat size) {
     UIFont *font = nil;
-#if __IPHONE_8_2
     if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){8, 2, 0}]) {
         font = [UIFont systemFontOfSize:size weight:UIFontWeightThin];
     } else
-#endif
     {
         font = [UIFont fontWithName:@".HelveticaNeueInterface-Thin" size:size];
         if (! font) {
@@ -426,11 +424,9 @@ UIFont *ORKThinFontWithSize(CGFloat size) {
 
 UIFont *ORKMediumFontWithSize(CGFloat size) {
     UIFont *font = nil;
-#if __IPHONE_8_2
     if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){8, 2, 0}]) {
         font = [UIFont systemFontOfSize:size weight:UIFontWeightMedium];
     } else
-#endif
     {
         font = [UIFont fontWithName:@"HelveticaNeue-Medium" size:size];
         if (! font) {
@@ -442,11 +438,9 @@ UIFont *ORKMediumFontWithSize(CGFloat size) {
 
 UIFont *ORKLightFontWithSize(CGFloat size) {
     UIFont *font = nil;
-#if __IPHONE_8_2
     if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){8, 2, 0}]) {
         font = [UIFont systemFontOfSize:size weight:UIFontWeightLight];
     } else
-#endif
     {
         font = [UIFont fontWithName:@".HelveticaNeueInterface-Light" size:size];
         if (! font) {

--- a/ResearchKit/Common/ORKHelpers.m
+++ b/ResearchKit/Common/ORKHelpers.m
@@ -411,7 +411,7 @@ CGFloat ORKTableViewLeftMargin(UITableView *tableView){
 UIFont *ORKThinFontWithSize(CGFloat size) {
     UIFont *font = nil;
 #if __IPHONE_8_2
-    if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.2) {
+    if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){8, 2, 0}]) {
         font = [UIFont systemFontOfSize:size weight:UIFontWeightThin];
     } else
 #endif
@@ -427,7 +427,7 @@ UIFont *ORKThinFontWithSize(CGFloat size) {
 UIFont *ORKMediumFontWithSize(CGFloat size) {
     UIFont *font = nil;
 #if __IPHONE_8_2
-    if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.2) {
+    if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){8, 2, 0}]) {
         font = [UIFont systemFontOfSize:size weight:UIFontWeightMedium];
     } else
 #endif
@@ -443,7 +443,7 @@ UIFont *ORKMediumFontWithSize(CGFloat size) {
 UIFont *ORKLightFontWithSize(CGFloat size) {
     UIFont *font = nil;
 #if __IPHONE_8_2
-    if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.2) {
+    if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){8, 2, 0}]) {
         font = [UIFont systemFontOfSize:size weight:UIFontWeightLight];
     } else
 #endif

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -483,11 +483,9 @@ static NSString * const _ChildNavigationControllerRestorationKey = @"childNaviga
                                   if ([[error domain] isEqualToString:CMErrorDomain]) {
                                       switch (error.code) {
                                           case CMErrorMotionActivityNotAuthorized:
-#if defined(__IPHONE_8_2)
                                           case CMErrorNotAuthorized:
                                           case CMErrorNotAvailable:
                                           case CMErrorNotEntitled:
-#endif
                                           case CMErrorMotionActivityNotAvailable:
                                           case CMErrorMotionActivityNotEntitled:
                                               success = NO;


### PR DESCRIPTION
While the current way of checking for the version is not deprecated,
converting the system version string to float isn’t a good idea either.

The framework is for iOS 8 and above, so we can use the new Foundation API.