### PR TITLE
Add .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: objective-c
+script: xcodebuild -project ResearchKit.xcodeproj -scheme ResearchKit test
+


### PR DESCRIPTION
Travis CI is an open-source hosted, distributed continuous integration
service used to build and test projects hosted on GitHub. By adding a
.travis.yml file to the root directory of ResearchKit, the owners of
ResearchKit could configure Travis CI to run unit tests against each
pull request to the repository. GitHub surfaces the results of the tests
on their website, making it easy to tell whether the tests pass for any
given pull request.