### PR TITLE
Add closing p tag to fix formatting in section 2

### DIFF
--- a/docs/Survey/CreatingSurveys-template.markdown
+++ b/docs/Survey/CreatingSurveys-template.markdown
@@ -179,7 +179,7 @@ The screenshots below show the standard answer formats that the ResearchKit fram
 <p style="float: left; font-size: 9pt; text-align: center; width: 25%; margin-right: 5%; margin-bottom: 0.5em;"><img src="SurveyImages/NumericAnswerFormat.png" style="width: 100%;border: solid black 1px; ">Numeric answer format</p><p style="float: left; font-size: 9pt; text-align: center; width: 25%; margin-right: 5%; margin-bottom: 0.5em;"><img src="SurveyImages/TimeOfTheDayAnswerFormat.png" style="width: 100%;border: solid black 1px;">TimeOfTheDay answer format</p><p style="float: left; font-size: 9pt; text-align: center; width: 25%; margin-right: 3%; margin-bottom: 0.5em;"><img src="SurveyImages/DateAnswerFormat.png" style="width: 100%;border: solid black 1px;">Date answer format</p>
 <p style="clear: both;">
 <p style="float: left; font-size: 9pt; text-align: center; width: 25%; margin-right: 5%; margin-bottom: 0.5em;"><img src="SurveyImages/TextAnswerFormat_1.png" style="width: 100%;border: solid black 1px; ">Text answer format (unlimited text entry)</p><p style="float: left; font-size: 9pt; text-align: center; width: 25%; margin-right: 5%; margin-bottom: 0.5em;"><img src="SurveyImages/TextAnswerFormat_2.png" style="width: 100%;border: solid black 1px;">Text answer format (limited text entry) </p>
-<p style="clear: both;">
+<p style="clear: both;"></p>
 
 In addition to the preceding answer formats, the ResearchKit framework provides
 special answer formats for asking questions about quantities or


### PR DESCRIPTION
-The code isn't formatting correctly in section 2. By adding a closing p tag, the documentation can be read more easily.

After:
![screen shot 2015-04-14 at 1 25 23 pm](https://cloud.githubusercontent.com/assets/7283641/7146643/e9a5385c-e2a9-11e4-81fc-8ff66ae2a67a.png)

Before:
![screen shot 2015-04-14 at 1 25 08 pm](https://cloud.githubusercontent.com/assets/7283641/7146647/f5952ece-e2a9-11e4-873f-f987a3dfd6e7.png)