### PR TITLE
Removed spaces between colon and parameters according to Apple's cocoa coding style.

### DIFF
--- a/ResearchKit/Common/ORKResult.m
+++ b/ResearchKit/Common/ORKResult.m
@@ -1208,7 +1208,7 @@
 
 @interface ORKCollectionResult ()
 
-- (void)setResultsCopyObjects: (NSArray *)results;
+- (void)setResultsCopyObjects:(NSArray *)results;
 
 @end
 
@@ -1266,7 +1266,7 @@
 }
 
 
-- (void)setResultsCopyObjects: (NSArray *)results {
+- (void)setResultsCopyObjects:(NSArray *)results {
     _results = ORKArrayCopyObjects(results);
 }
 

--- a/ResearchKitTests/ORKRecorderTests.m
+++ b/ResearchKitTests/ORKRecorderTests.m
@@ -340,7 +340,7 @@ static const NSInteger kNumberOfSamples = 5;
     _result = nil;
 }
 
-- (ORKRecorder *)createRecorder: (ORKRecorderConfiguration *)conf {
+- (ORKRecorder *)createRecorder:(ORKRecorderConfiguration *)conf {
     ORKRecorder *recorder = [conf recorderForStep:[[ORKStep alloc] initWithIdentifier:@"step"]
                                                                     outputDirectory:[NSURL fileURLWithPath:_outputPath]];
     recorder.delegate = self;


### PR DESCRIPTION
Removed space between colon and parameters according to  cocoa coding style guide.
This issue is related to pull #26 .
