### PR TITLE
Add vertical scale answer format

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -44,9 +44,6 @@ typedef NS_ENUM(NSInteger, ORKQuestionType) {
     
     /// The scale question type asks participants to place a mark at an appropriate position on a continuous or discrete line.
     ORKQuestionTypeScale,
-    
-    /// The vertical scale question type asks participants to place a mark at an appropriate position on a continuous or discrete vertical line.
-    ORKQuestionTypeVerticalScale,
 
     /// In a single choice question, the participant can pick only one predefined option.
     ORKQuestionTypeSingleChoice,

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -141,10 +141,20 @@ ORK_CLASS_AVAILABLE
                                                    step:(NSInteger)step
                                            defaultValue:(NSInteger)defaultValue;
 
++ (ORKScaleAnswerFormat *)verticalScaleAnswerFormatWithMaxValue:(NSInteger)scaleMax
+                                                       minValue:(NSInteger)scaleMin
+                                                           step:(NSInteger)step
+                                                   defaultValue:(NSInteger)defaultValue;
+
 + (ORKContinuousScaleAnswerFormat *)continuousScaleAnswerFormatWithMaxValue:(double)scaleMax
                                                                    minValue:(double)scaleMin
                                                                defaultValue:(double)defaultValue
                                                       maximumFractionDigits:(NSInteger)maximumFractionDigits;
+
++ (ORKContinuousScaleAnswerFormat *)continuousVerticalScaleAnswerFormatWithMaxValue:(double)scaleMax
+                                                                           minValue:(double)scaleMin
+                                                                       defaultValue:(double)defaultValue
+                                                              maximumFractionDigits:(NSInteger)maximumFractionDigits;
 
 + (ORKBooleanAnswerFormat *)booleanAnswerFormat;
 
@@ -179,8 +189,8 @@ ORK_CLASS_AVAILABLE
 + (ORKTimeIntervalAnswerFormat *)timeIntervalAnswerFormat;
 + (ORKTimeIntervalAnswerFormat *)timeIntervalAnswerFormatWithDefaultInterval:(NSTimeInterval)defaultInterval step:(NSInteger)step;
 
-/// @name Validation
 
+/// @name Validation
 
 /**
  Validates the parameters of the answer format to ensure that they can be displayed.
@@ -211,7 +221,7 @@ ORK_CLASS_AVAILABLE
  
  @param maximumValue   The upper bound of the scale.
  @param minimumValue   The lower bound of the scale.
- @param step  The size of each discrete offset on the scale.
+ @param step   The size of each discrete offset on the scale.
  @param defaultValue   The default value of the scale. If this value is out of range, the slider is displayed without a default value.
  @return An initialized scale answer format.
  */
@@ -229,7 +239,6 @@ ORK_CLASS_AVAILABLE
  The lower bound of the scale. (read-only)
  */
 @property (readonly) NSInteger minimum;
-
 
 /**
  The size of each discrete offset on the scale. (read-only)
@@ -250,6 +259,21 @@ ORK_CLASS_AVAILABLE
 
 @end
 
+
+
+/**
+ The `ORKVerticalScaleAnswerFormat `class represents an answer format that includes a vertical slider control.
+ 
+ The vertical scale answer format produces an `ORKScaleQuestionResult` object that contains an integer whose
+ value is between the scale's minimum and maximum values, and represents one of the quantized step values.
+ */
+ORK_CLASS_AVAILABLE
+@interface ORKVerticalScaleAnswerFormat : ORKScaleAnswerFormat
+
+@end
+
+
+
 /**
  The `ORKContinuousScaleAnswerFormat` class represents an answer format that lets participants
  select a value on a continuous scale.
@@ -259,7 +283,17 @@ ORK_CLASS_AVAILABLE
 ORK_CLASS_AVAILABLE
 @interface ORKContinuousScaleAnswerFormat : ORKAnswerFormat
 
-
+/**
+ Returns an initialized continous scale answer format using the specified values.
+ 
+ This method is the designated initializer.
+ 
+ @param maximumValue   The upper bound of the scale.
+ @param minimumValue   The lower bound of the scale.
+ @param defaultValue   The default value of the scale. If this value is out of range, the slider is displayed without a default value.
+ @param maximumFractionDigits    The maximum number of fractional digits to display.
+ @return An initialized scale answer format.
+ */
 - (instancetype)initWithMaximumValue:(double)maximumValue
                         minimumValue:(double)minimumValue
                         defaultValue:(double)defaultValue
@@ -288,6 +322,21 @@ ORK_CLASS_AVAILABLE
 @property (readonly) NSInteger maximumFractionDigits;
 
 @end
+
+
+
+/**
+ The `ORKContinuousVerticalScaleAnswerFormat` class represents an answer format that lets participants
+ select a value on a continuous vertical scale.
+ 
+ The continuous vertical scale answer format produces an `ORKScaleQuestionResult` object that has a real-number value.
+ */
+ORK_CLASS_AVAILABLE
+@interface ORKContinuousVerticalScaleAnswerFormat : ORKContinuousScaleAnswerFormat
+
+@end
+
+
 
 /**
  The `ORKValuePickerAnswerFormat` class represents an answer format that lets participants use a value picker 
@@ -323,6 +372,8 @@ ORK_CLASS_AVAILABLE
 
 @end
 
+
+
 /**
  The `ORKImageChoiceAnswerFormat` class represents an answer format that lets participants choose one image from a fixed set of images in a single choice question.
  
@@ -352,6 +403,8 @@ ORK_CLASS_AVAILABLE
 @property (readonly, copy) NSArray *imageChoices;
 
 @end
+
+
 
 /**
  The `ORKTextChoiceAnswerFormat` class represents an answer format that lets participants choose from a fixed set of text choices in a multiple or single choice question.

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -136,25 +136,17 @@ ORK_CLASS_AVAILABLE
 
 /// @name Factory methods
 
-+ (ORKScaleAnswerFormat *)scaleAnswerFormatWithMaxValue:(NSInteger)scaleMax
-                                               minValue:(NSInteger)scaleMin
-                                                   step:(NSInteger)step
-                                           defaultValue:(NSInteger)defaultValue;
++ (ORKScaleAnswerFormat *)scaleAnswerFormatWithMaximumValue:(NSInteger)scaleMaximum
+                                               minimumValue:(NSInteger)scaleMinimum
+                                               defaultValue:(NSInteger)defaultValue
+                                                       step:(NSInteger)step
+                                                   vertical:(BOOL)verticalFlag;
 
-+ (ORKScaleAnswerFormat *)verticalScaleAnswerFormatWithMaxValue:(NSInteger)scaleMax
-                                                       minValue:(NSInteger)scaleMin
-                                                           step:(NSInteger)step
-                                                   defaultValue:(NSInteger)defaultValue;
-
-+ (ORKContinuousScaleAnswerFormat *)continuousScaleAnswerFormatWithMaxValue:(double)scaleMax
-                                                                   minValue:(double)scaleMin
-                                                               defaultValue:(double)defaultValue
-                                                      maximumFractionDigits:(NSInteger)maximumFractionDigits;
-
-+ (ORKContinuousScaleAnswerFormat *)continuousVerticalScaleAnswerFormatWithMaxValue:(double)scaleMax
-                                                                           minValue:(double)scaleMin
-                                                                       defaultValue:(double)defaultValue
-                                                              maximumFractionDigits:(NSInteger)maximumFractionDigits;
++ (ORKContinuousScaleAnswerFormat *)continuousScaleAnswerFormatWithMaximumValue:(double)scaleMaximum
+                                                                   minimumValue:(double)scaleMinimum
+                                                                   defaultValue:(double)defaultValue
+                                                          maximumFractionDigits:(NSInteger)maximumFractionDigits
+                                                                       vertical:(BOOL)verticalFlag;
 
 + (ORKBooleanAnswerFormat *)booleanAnswerFormat;
 
@@ -221,14 +213,32 @@ ORK_CLASS_AVAILABLE
  
  @param maximumValue   The upper bound of the scale.
  @param minimumValue   The lower bound of the scale.
- @param step   The size of each discrete offset on the scale.
  @param defaultValue   The default value of the scale. If this value is out of range, the slider is displayed without a default value.
+ @param step   The size of each discrete offset on the scale.
+ @param vertical   Pass YES to use a vertical scale; for the default horizontal scale, pass NO.
  @return An initialized scale answer format.
  */
 - (instancetype)initWithMaximumValue:(NSInteger)maximumValue
                         minimumValue:(NSInteger)minimumValue
+                        defaultValue:(NSInteger)defaultValue
                                 step:(NSInteger)step
-                        defaultValue:(NSInteger)defaultValue NS_DESIGNATED_INITIALIZER;
+                            vertical:(BOOL)verticalFlag NS_DESIGNATED_INITIALIZER;
+
+/**
+ Returns an initialized horizontal scale answer format using the specified values.
+ 
+ This method is a convenience initializer.
+
+ @param maximumValue   The upper bound of the scale.
+ @param minimumValue   The lower bound of the scale.
+ @param defaultValue   The default value of the scale. If this value is out of range, the slider is displayed without a default value.
+ @param step   The size of each discrete offset on the scale.
+ @return An initialized scale answer format.
+ */
+- (instancetype)initWithMaximumValue:(NSInteger)maximumValue
+                        minimumValue:(NSInteger)minimumValue
+                        defaultValue:(NSInteger)defaultValue
+                                step:(NSInteger)step;
 
 /**
  The upper bound of the scale. (read-only)
@@ -257,18 +267,10 @@ ORK_CLASS_AVAILABLE
  */
 @property (readonly) NSInteger defaultValue;
 
-@end
-
-
-
 /**
- The `ORKVerticalScaleAnswerFormat `class represents an answer format that includes a vertical slider control.
- 
- The vertical scale answer format produces an `ORKScaleQuestionResult` object that contains an integer whose
- value is between the scale's minimum and maximum values, and represents one of the quantized step values.
+ A Boolean value indicating whether the scale is oriented vertically. (read-only)
  */
-ORK_CLASS_AVAILABLE
-@interface ORKVerticalScaleAnswerFormat : ORKScaleAnswerFormat
+@property (readonly, getter=isVertical) BOOL vertical;
 
 @end
 
@@ -292,12 +294,30 @@ ORK_CLASS_AVAILABLE
  @param minimumValue   The lower bound of the scale.
  @param defaultValue   The default value of the scale. If this value is out of range, the slider is displayed without a default value.
  @param maximumFractionDigits    The maximum number of fractional digits to display.
+ @param vertical   Pass YES to use a vertical scale; for the default horizontal scale, pass NO.
  @return An initialized scale answer format.
  */
 - (instancetype)initWithMaximumValue:(double)maximumValue
                         minimumValue:(double)minimumValue
                         defaultValue:(double)defaultValue
-               maximumFractionDigits:(NSInteger)maximumFractionDigits NS_DESIGNATED_INITIALIZER;
+               maximumFractionDigits:(NSInteger)maximumFractionDigits
+                            vertical:(BOOL)verticalFlag NS_DESIGNATED_INITIALIZER;
+
+/**
+ Returns an initialized horizontal continous scale answer format using the specified values.
+ 
+ This method is a convenience initializer.
+ 
+ @param maximumValue   The upper bound of the scale.
+ @param minimumValue   The lower bound of the scale.
+ @param step   The size of each discrete offset on the scale.
+ @param maximumFractionDigits    The maximum number of fractional digits to display.
+ @return An initialized scale answer format.
+ */
+- (instancetype)initWithMaximumValue:(double)maximumValue
+                        minimumValue:(double)minimumValue
+                        defaultValue:(double)defaultValue
+               maximumFractionDigits:(NSInteger)maximumFractionDigits;
 
 /**
  The upper bound of the scale. (read-only)
@@ -321,18 +341,10 @@ ORK_CLASS_AVAILABLE
  */
 @property (readonly) NSInteger maximumFractionDigits;
 
-@end
-
-
-
 /**
- The `ORKContinuousVerticalScaleAnswerFormat` class represents an answer format that lets participants
- select a value on a continuous vertical scale.
- 
- The continuous vertical scale answer format produces an `ORKScaleQuestionResult` object that has a real-number value.
+ A Boolean value indicating whether the scale is oriented vertically. (read-only)
  */
-ORK_CLASS_AVAILABLE
-@interface ORKContinuousVerticalScaleAnswerFormat : ORKContinuousScaleAnswerFormat
+@property (readonly, getter=isVertical) BOOL vertical;
 
 @end
 

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -143,13 +143,13 @@ ORK_CLASS_AVAILABLE
                                                minimumValue:(NSInteger)scaleMinimum
                                                defaultValue:(NSInteger)defaultValue
                                                        step:(NSInteger)step
-                                                   vertical:(BOOL)verticalFlag;
+                                                   vertical:(BOOL)vertical;
 
 + (ORKContinuousScaleAnswerFormat *)continuousScaleAnswerFormatWithMaximumValue:(double)scaleMaximum
                                                                    minimumValue:(double)scaleMinimum
                                                                    defaultValue:(double)defaultValue
                                                           maximumFractionDigits:(NSInteger)maximumFractionDigits
-                                                                       vertical:(BOOL)verticalFlag;
+                                                                       vertical:(BOOL)vertical;
 
 + (ORKBooleanAnswerFormat *)booleanAnswerFormat;
 
@@ -225,7 +225,7 @@ ORK_CLASS_AVAILABLE
                         minimumValue:(NSInteger)minimumValue
                         defaultValue:(NSInteger)defaultValue
                                 step:(NSInteger)step
-                            vertical:(BOOL)verticalFlag NS_DESIGNATED_INITIALIZER;
+                            vertical:(BOOL)vertical NS_DESIGNATED_INITIALIZER;
 
 /**
  Returns an initialized horizontal scale answer format using the specified values.
@@ -304,7 +304,7 @@ ORK_CLASS_AVAILABLE
                         minimumValue:(double)minimumValue
                         defaultValue:(double)defaultValue
                maximumFractionDigits:(NSInteger)maximumFractionDigits
-                            vertical:(BOOL)verticalFlag NS_DESIGNATED_INITIALIZER;
+                            vertical:(BOOL)vertical NS_DESIGNATED_INITIALIZER;
 
 /**
  Returns an initialized horizontal continous scale answer format using the specified values.

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -45,6 +45,9 @@ typedef NS_ENUM(NSInteger, ORKQuestionType) {
     /// The scale question type asks participants to place a mark at an appropriate position on a continuous or discrete line.
     ORKQuestionTypeScale,
     
+    /// The vertical scale question type asks participants to place a mark at an appropriate position on a continuous or discrete vertical line.
+    ORKQuestionTypeVerticalScale,
+
     /// In a single choice question, the participant can pick only one predefined option.
     ORKQuestionTypeSingleChoice,
     

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -251,17 +251,29 @@ NSString *ORKQuestionTypeString(ORKQuestionType questionType)
 + (ORKScaleAnswerFormat *)scaleAnswerFormatWithMaxValue:(NSInteger)scaleMax
                                               minValue:(NSInteger)scaleMin
                                                   step:(NSInteger)step
-                                          defaultValue:(NSInteger)defaultValue
-{
+                                          defaultValue:(NSInteger)defaultValue {
     return [[ORKScaleAnswerFormat alloc] initWithMaximumValue:scaleMax minimumValue:scaleMin step:step defaultValue:defaultValue];
 }
 
++ (ORKScaleAnswerFormat *)verticalScaleAnswerFormatWithMaxValue:(NSInteger)scaleMax
+                                                       minValue:(NSInteger)scaleMin
+                                                           step:(NSInteger)step
+                                                   defaultValue:(NSInteger)defaultValue {
+    return [[ORKVerticalScaleAnswerFormat alloc] initWithMaximumValue:scaleMax minimumValue:scaleMin step:step defaultValue:defaultValue];
+}
 
 + (ORKContinuousScaleAnswerFormat *)continuousScaleAnswerFormatWithMaxValue:(double)scaleMax
                                                                   minValue:(double)scaleMin
                                                               defaultValue:(double)defaultValue
                                                      maximumFractionDigits:(NSInteger)maximumFractionDigits {
     return [[ORKContinuousScaleAnswerFormat alloc] initWithMaximumValue:scaleMax minimumValue:scaleMin defaultValue:defaultValue maximumFractionDigits:maximumFractionDigits];
+}
+
++ (ORKContinuousScaleAnswerFormat *)continuousVerticalScaleAnswerFormatWithMaxValue:(double)scaleMax
+                                                                           minValue:(double)scaleMin
+                                                                       defaultValue:(double)defaultValue
+                                                              maximumFractionDigits:(NSInteger)maximumFractionDigits {
+    return [[ORKContinuousVerticalScaleAnswerFormat alloc] initWithMaximumValue:scaleMax minimumValue:scaleMin defaultValue:defaultValue maximumFractionDigits:maximumFractionDigits];
 }
 
 + (ORKBooleanAnswerFormat *)booleanAnswerFormat {
@@ -1304,9 +1316,10 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
 
 @end
 
+
 #pragma mark - ORKScaleAnswerFormat
 
-@implementation ORKScaleAnswerFormat : ORKAnswerFormat
+@implementation ORKScaleAnswerFormat
 
 - (Class)questionResultClass {
     return [ORKScaleQuestionResult class];
@@ -1456,6 +1469,17 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
 @end
 
 
+#pragma mark - ORKVerticalScaleAnswerFormat
+
+@implementation ORKVerticalScaleAnswerFormat
+
+- (BOOL)isVertical {
+    return YES;
+}
+
+@end
+
+
 #pragma mark - ORKContinuousScaleAnswerFormat
 
 @implementation ORKContinuousScaleAnswerFormat {
@@ -1597,9 +1621,19 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
     return ORKQuestionTypeScale;
 }
 
-
 @end
 
+
+#pragma mark - ORKContinuousScaleAnswerFormat
+
+@implementation ORKContinuousVerticalScaleAnswerFormat
+
+- (BOOL)isVertical {
+    return YES;
+}
+
+@end
+    
 
 #pragma mark - ORKTextAnswerFormat
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -49,7 +49,6 @@ NSString *ORKQuestionTypeString(ORKQuestionType questionType)
     {
             SQT_CASE(None);
             SQT_CASE(Scale);
-            SQT_CASE(VerticalScale);
             SQT_CASE(SingleChoice);
             SQT_CASE(MultipleChoice);
             SQT_CASE(Decimal);
@@ -1471,7 +1470,7 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
 
 - (ORKQuestionType) questionType
 {
-    return _vertical ? ORKQuestionTypeVerticalScale : ORKQuestionTypeScale;
+    return ORKQuestionTypeScale;
 }
 
 @end
@@ -1625,7 +1624,7 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
 
 - (ORKQuestionType) questionType
 {
-    return _vertical ? ORKQuestionTypeVerticalScale : ORKQuestionTypeScale;
+    return ORKQuestionTypeScale;
 }
 
 @end

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -248,32 +248,28 @@ NSString *ORKQuestionTypeString(ORKQuestionType questionType)
 
 @implementation ORKAnswerFormat
 
-+ (ORKScaleAnswerFormat *)scaleAnswerFormatWithMaxValue:(NSInteger)scaleMax
-                                              minValue:(NSInteger)scaleMin
-                                                  step:(NSInteger)step
-                                          defaultValue:(NSInteger)defaultValue {
-    return [[ORKScaleAnswerFormat alloc] initWithMaximumValue:scaleMax minimumValue:scaleMin step:step defaultValue:defaultValue];
++ (ORKScaleAnswerFormat *)scaleAnswerFormatWithMaximumValue:(NSInteger)scaleMaximum
+                                               minimumValue:(NSInteger)scaleMinimum
+                                               defaultValue:(NSInteger)defaultValue
+                                                       step:(NSInteger)step
+                                                   vertical:(BOOL)verticalFlag {
+    return [[ORKScaleAnswerFormat alloc] initWithMaximumValue:scaleMaximum
+                                                 minimumValue:scaleMinimum
+                                                 defaultValue:defaultValue
+                                                         step:step
+                                                     vertical:verticalFlag];
 }
 
-+ (ORKScaleAnswerFormat *)verticalScaleAnswerFormatWithMaxValue:(NSInteger)scaleMax
-                                                       minValue:(NSInteger)scaleMin
-                                                           step:(NSInteger)step
-                                                   defaultValue:(NSInteger)defaultValue {
-    return [[ORKVerticalScaleAnswerFormat alloc] initWithMaximumValue:scaleMax minimumValue:scaleMin step:step defaultValue:defaultValue];
-}
-
-+ (ORKContinuousScaleAnswerFormat *)continuousScaleAnswerFormatWithMaxValue:(double)scaleMax
-                                                                  minValue:(double)scaleMin
-                                                              defaultValue:(double)defaultValue
-                                                     maximumFractionDigits:(NSInteger)maximumFractionDigits {
-    return [[ORKContinuousScaleAnswerFormat alloc] initWithMaximumValue:scaleMax minimumValue:scaleMin defaultValue:defaultValue maximumFractionDigits:maximumFractionDigits];
-}
-
-+ (ORKContinuousScaleAnswerFormat *)continuousVerticalScaleAnswerFormatWithMaxValue:(double)scaleMax
-                                                                           minValue:(double)scaleMin
-                                                                       defaultValue:(double)defaultValue
-                                                              maximumFractionDigits:(NSInteger)maximumFractionDigits {
-    return [[ORKContinuousVerticalScaleAnswerFormat alloc] initWithMaximumValue:scaleMax minimumValue:scaleMin defaultValue:defaultValue maximumFractionDigits:maximumFractionDigits];
++ (ORKContinuousScaleAnswerFormat *)continuousScaleAnswerFormatWithMaximumValue:(double)scaleMaximum
+                                                                   minimumValue:(double)scaleMinimum
+                                                               defaultValue:(double)defaultValue
+                                                      maximumFractionDigits:(NSInteger)maximumFractionDigits
+                                                                       vertical:(BOOL)verticalFlag {
+    return [[ORKContinuousScaleAnswerFormat alloc] initWithMaximumValue:scaleMaximum
+                                                           minimumValue:scaleMinimum
+                                                           defaultValue:defaultValue
+                                                  maximumFractionDigits:maximumFractionDigits
+                                                               vertical:verticalFlag];
 }
 
 + (ORKBooleanAnswerFormat *)booleanAnswerFormat {
@@ -1328,23 +1324,32 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
 
 - (instancetype)initWithMaximumValue:(NSInteger)maximumValue
                         minimumValue:(NSInteger)minimumValue
+                        defaultValue:(NSInteger)defaultValue
                                 step:(NSInteger)step
-                        defaultValue:(NSInteger)defaultValue {
+                            vertical:(BOOL)verticalFlag {
     self = [super init];
     if (self) {
 
         _minimum = minimumValue;
         _maximum = maximumValue;
-        _step = step;
         _defaultValue = defaultValue;
+        _step = step;
+        _vertical = verticalFlag;
         
         [self validateParameters];
     }
     return self;
 }
 
-- (BOOL)isVertical {
-    return NO;
+- (instancetype)initWithMaximumValue:(NSInteger)maximumValue
+                        minimumValue:(NSInteger)minimumValue
+                        defaultValue:(NSInteger)defaultValue
+                                step:(NSInteger)step {
+    return [self initWithMaximumValue:maximumValue
+                         minimumValue:minimumValue
+                         defaultValue:defaultValue
+                                 step:step
+                             vertical:NO];
 }
 
 - (NSNumber *)minimumNumber {
@@ -1469,16 +1474,6 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
 @end
 
 
-#pragma mark - ORKVerticalScaleAnswerFormat
-
-@implementation ORKVerticalScaleAnswerFormat
-
-- (BOOL)isVertical {
-    return YES;
-}
-
-@end
-
 
 #pragma mark - ORKContinuousScaleAnswerFormat
 
@@ -1490,11 +1485,11 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
     return [ORKScaleQuestionResult class];
 }
 
-
 - (instancetype)initWithMaximumValue:(double)maximumValue
                         minimumValue:(double)minimumValue
                         defaultValue:(double)defaultValue
-               maximumFractionDigits:(NSInteger)maximumFractionDigits {
+               maximumFractionDigits:(NSInteger)maximumFractionDigits
+                            vertical:(BOOL)verticalFlag {
     self = [super init];
     if (self) {
         
@@ -1502,15 +1497,22 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
         _maximum = maximumValue;
         _defaultValue = defaultValue;
         _maximumFractionDigits = maximumFractionDigits;
+        _vertical = verticalFlag;
         
         [self validateParameters];
     }
     return self;
 }
 
-
-- (BOOL)isVertical {
-    return NO;
+- (instancetype)initWithMaximumValue:(double)maximumValue
+                        minimumValue:(double)minimumValue
+                        defaultValue:(double)defaultValue
+               maximumFractionDigits:(NSInteger)maximumFractionDigits {
+    return [self initWithMaximumValue:maximumValue
+                         minimumValue:minimumValue
+                         defaultValue:defaultValue
+                maximumFractionDigits:maximumFractionDigits
+                             vertical:NO];
 }
 
 - (NSNumber *)minimumNumber {
@@ -1624,16 +1626,6 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
 @end
 
 
-#pragma mark - ORKContinuousScaleAnswerFormat
-
-@implementation ORKContinuousVerticalScaleAnswerFormat
-
-- (BOOL)isVertical {
-    return YES;
-}
-
-@end
-    
 
 #pragma mark - ORKTextAnswerFormat
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -253,24 +253,24 @@ NSString *ORKQuestionTypeString(ORKQuestionType questionType)
                                                minimumValue:(NSInteger)scaleMinimum
                                                defaultValue:(NSInteger)defaultValue
                                                        step:(NSInteger)step
-                                                   vertical:(BOOL)verticalFlag {
+                                                   vertical:(BOOL)vertical {
     return [[ORKScaleAnswerFormat alloc] initWithMaximumValue:scaleMaximum
                                                  minimumValue:scaleMinimum
                                                  defaultValue:defaultValue
                                                          step:step
-                                                     vertical:verticalFlag];
+                                                     vertical:vertical];
 }
 
 + (ORKContinuousScaleAnswerFormat *)continuousScaleAnswerFormatWithMaximumValue:(double)scaleMaximum
                                                                    minimumValue:(double)scaleMinimum
                                                                defaultValue:(double)defaultValue
                                                       maximumFractionDigits:(NSInteger)maximumFractionDigits
-                                                                       vertical:(BOOL)verticalFlag {
+                                                                       vertical:(BOOL)vertical {
     return [[ORKContinuousScaleAnswerFormat alloc] initWithMaximumValue:scaleMaximum
                                                            minimumValue:scaleMinimum
                                                            defaultValue:defaultValue
                                                   maximumFractionDigits:maximumFractionDigits
-                                                               vertical:verticalFlag];
+                                                               vertical:vertical];
 }
 
 + (ORKBooleanAnswerFormat *)booleanAnswerFormat {

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1436,6 +1436,7 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
         ORK_DECODE_INTEGER(aDecoder, minimum);
         ORK_DECODE_INTEGER(aDecoder, step);
         ORK_DECODE_INTEGER(aDecoder, defaultValue);
+        ORK_DECODE_BOOL(aDecoder, vertical);
     }
     return self;
 }
@@ -1447,6 +1448,7 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
     ORK_ENCODE_INTEGER(aCoder, minimum);
     ORK_ENCODE_INTEGER(aCoder, step);
     ORK_ENCODE_INTEGER(aCoder, defaultValue);
+    ORK_ENCODE_BOOL(aCoder, vertical);
 }
 
 + (BOOL)supportsSecureCoding
@@ -1588,6 +1590,7 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
         ORK_DECODE_DOUBLE(aDecoder, minimum);
         ORK_DECODE_DOUBLE(aDecoder, defaultValue);
         ORK_DECODE_INTEGER(aDecoder, maximumFractionDigits);
+        ORK_DECODE_BOOL(aDecoder, vertical);
     }
     return self;
 }
@@ -1599,6 +1602,7 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
     ORK_ENCODE_DOUBLE(aCoder, minimum);
     ORK_ENCODE_DOUBLE(aCoder, defaultValue);
     ORK_ENCODE_INTEGER(aCoder, maximumFractionDigits);
+    ORK_ENCODE_BOOL(aCoder, vertical);
 }
 
 + (BOOL)supportsSecureCoding

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1327,7 +1327,7 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
                         minimumValue:(NSInteger)minimumValue
                         defaultValue:(NSInteger)defaultValue
                                 step:(NSInteger)step
-                            vertical:(BOOL)verticalFlag {
+                            vertical:(BOOL)vertical {
     self = [super init];
     if (self) {
 
@@ -1335,7 +1335,7 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
         _maximum = maximumValue;
         _defaultValue = defaultValue;
         _step = step;
-        _vertical = verticalFlag;
+        _vertical = vertical;
         
         [self validateParameters];
     }
@@ -1492,7 +1492,7 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
                         minimumValue:(double)minimumValue
                         defaultValue:(double)defaultValue
                maximumFractionDigits:(NSInteger)maximumFractionDigits
-                            vertical:(BOOL)verticalFlag {
+                            vertical:(BOOL)vertical {
     self = [super init];
     if (self) {
         
@@ -1500,7 +1500,7 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
         _maximum = maximumValue;
         _defaultValue = defaultValue;
         _maximumFractionDigits = maximumFractionDigits;
-        _vertical = verticalFlag;
+        _vertical = vertical;
         
         [self validateParameters];
     }

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -49,6 +49,7 @@ NSString *ORKQuestionTypeString(ORKQuestionType questionType)
     {
             SQT_CASE(None);
             SQT_CASE(Scale);
+            SQT_CASE(VerticalScale);
             SQT_CASE(SingleChoice);
             SQT_CASE(MultipleChoice);
             SQT_CASE(Decimal);
@@ -1468,7 +1469,7 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
 
 - (ORKQuestionType) questionType
 {
-    return ORKQuestionTypeScale;
+    return _vertical ? ORKQuestionTypeVerticalScale : ORKQuestionTypeScale;
 }
 
 @end
@@ -1620,7 +1621,7 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
 
 - (ORKQuestionType) questionType
 {
-    return ORKQuestionTypeScale;
+    return _vertical ? ORKQuestionTypeVerticalScale : ORKQuestionTypeScale;
 }
 
 @end

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1330,6 +1330,9 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
     return self;
 }
 
+- (BOOL)isVertical {
+    return NO;
+}
 
 - (NSNumber *)minimumNumber {
     return @(_minimum);
@@ -1481,6 +1484,10 @@ static NSArray *ork_processTextChoices(NSArray *textChoices)
     return self;
 }
 
+
+- (BOOL)isVertical {
+    return NO;
+}
 
 - (NSNumber *)minimumNumber {
     return @(_minimum);

--- a/ResearchKit/Common/ORKAnswerFormat_Internal.h
+++ b/ResearchKit/Common/ORKAnswerFormat_Internal.h
@@ -117,6 +117,7 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTimeIntervalAnswerFormat)
 - (nullable NSString *)localizedStringForNumber:(nullable NSNumber *)number;
 - (NSInteger)numberOfSteps;
 - (nullable NSNumber *)normalizedValueForNumber:(nullable NSNumber *)number;
+- (BOOL)isVertical;
 
 @end
 

--- a/ResearchKit/Common/ORKAnswerFormat_Internal.h
+++ b/ResearchKit/Common/ORKAnswerFormat_Internal.h
@@ -129,14 +129,6 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTimeIntervalAnswerFormat)
 
 @end
 
-@interface ORKVerticalScaleAnswerFormat() <ORKScaleAnswerFormatProvider>
-
-@end
-
-@interface ORKContinuousVerticalScaleAnswerFormat() <ORKScaleAnswerFormatProvider>
-
-@end
-
 
 @interface ORKTextChoice() <ORKAnswerOption>
 

--- a/ResearchKit/Common/ORKAnswerFormat_Internal.h
+++ b/ResearchKit/Common/ORKAnswerFormat_Internal.h
@@ -109,7 +109,7 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTimeIntervalAnswerFormat)
 
 @end
 
-@protocol ORKScaleAnswerFormatProvider<NSObject>
+@protocol ORKScaleAnswerFormatProvider <NSObject>
 
 - (nullable NSNumber *)minimumNumber;
 - (nullable NSNumber *)maximumNumber;
@@ -126,6 +126,14 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTimeIntervalAnswerFormat)
 @end
 
 @interface ORKContinuousScaleAnswerFormat() <ORKScaleAnswerFormatProvider>
+
+@end
+
+@interface ORKVerticalScaleAnswerFormat() <ORKScaleAnswerFormatProvider>
+
+@end
+
+@interface ORKContinuousVerticalScaleAnswerFormat() <ORKScaleAnswerFormatProvider>
 
 @end
 

--- a/ResearchKit/Common/ORKQuestionStep.m
+++ b/ResearchKit/Common/ORKQuestionStep.m
@@ -34,6 +34,7 @@
 #import "ORKAnswerFormat_Internal.h"
 #import "ORKStep_Private.h"
 #import "ORKQuestionStepViewController.h"
+#import "ORKDefines_Private.h"
 
 @implementation ORKQuestionStep
 
@@ -139,7 +140,6 @@
     return YES;
 }
 
-
 - (BOOL)isFormatImmediateNavigation {
     ORKQuestionType questionType = self.questionType;
     return (self.optional == NO) && ((questionType == ORKQuestionTypeBoolean) || (questionType == ORKQuestionTypeSingleChoice));
@@ -155,14 +155,19 @@
 }
 
 - (BOOL)isFormatTextfield {
-    ORKTextAnswerFormat *textAnswerFormat = (ORKTextAnswerFormat *)[self impliedAnswerFormat];
-    return [textAnswerFormat isKindOfClass:[ORKTextAnswerFormat class]] && ![textAnswerFormat multipleLines];
+    ORKAnswerFormat *impliedAnswerFormat = [self impliedAnswerFormat];
+    return [impliedAnswerFormat isKindOfClass:[ORKTextAnswerFormat class]] && ![(ORKTextAnswerFormat *)impliedAnswerFormat multipleLines];
 }
 
 - (BOOL)isFormatFitsChoiceCells {
-    return ((self.questionType == ORKQuestionTypeSingleChoice && NO==[self isFormatChoiceWithImageOptions] && NO==[self isFormatChoiceValuePicker])||
-            (self.questionType == ORKQuestionTypeMultipleChoice && NO==[self isFormatChoiceWithImageOptions])||
+    return ((self.questionType == ORKQuestionTypeSingleChoice && NO==[self isFormatChoiceWithImageOptions] && NO==[self isFormatChoiceValuePicker]) ||
+            (self.questionType == ORKQuestionTypeMultipleChoice && NO==[self isFormatChoiceWithImageOptions]) ||
             self.questionType == ORKQuestionTypeBoolean);
+}
+
+- (BOOL)isFormatVertical {
+    return (ORKDynamicCast([self impliedAnswerFormat], ORKScaleAnswerFormat).isVertical ||
+            ORKDynamicCast([self impliedAnswerFormat], ORKContinuousScaleAnswerFormat).isVertical);
 }
 
 - (BOOL)formatRequiresTableView {

--- a/ResearchKit/Common/ORKQuestionStep.m
+++ b/ResearchKit/Common/ORKQuestionStep.m
@@ -165,7 +165,7 @@
             self.questionType == ORKQuestionTypeBoolean);
 }
 
-- (BOOL)isFormatVertical {
+- (BOOL)isFormatVerticalScale {
     return (ORKDynamicCast([self impliedAnswerFormat], ORKScaleAnswerFormat).isVertical ||
             ORKDynamicCast([self impliedAnswerFormat], ORKContinuousScaleAnswerFormat).isVertical);
 }

--- a/ResearchKit/Common/ORKQuestionStepViewController.m
+++ b/ResearchKit/Common/ORKQuestionStepViewController.m
@@ -563,7 +563,6 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection)
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         typeAndCellMapping = @{@(ORKQuestionTypeScale): [ORKSurveyAnswerCellForScale class],
-                               @(ORKQuestionTypeVerticalScale): [ORKSurveyAnswerCellForVerticalScale class],
                                @(ORKQuestionTypeDecimal) : [ORKSurveyAnswerCellForNumber class],
                                @(ORKQuestionTypeText) : [ORKSurveyAnswerCellForText class],
                                @(ORKQuestionTypeTimeOfDay) : [ORKSurveyAnswerCellForPicker class],
@@ -577,7 +576,7 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection)
     // SingleSelectionPicker Cell && Other Cells
     Class class = typeAndCellMapping[@(self.questionStep.questionType)];
     
-    if([self.questionStep isFormatChoiceWithImageOptions])
+    if ([self.questionStep isFormatChoiceWithImageOptions])
     {
         class = [ORKSurveyAnswerCellForImageSelection class];
     }
@@ -588,6 +587,9 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection)
     }
     else if ([[self.questionStep impliedAnswerFormat] isKindOfClass:[ORKValuePickerAnswerFormat class]]) {
         class = [ORKSurveyAnswerCellForPicker class];
+    }
+    else if ([self.questionStep isFormatVertical]) {
+        class = [ORKSurveyAnswerCellForVerticalScale class];
     }
     
     identifier = NSStringFromClass(class);
@@ -782,11 +784,12 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection)
         }
             break;
         case ORKQuestionTypeScale:{
-            height = [ORKSurveyAnswerCellForScale suggestedCellHeightForView:tableView];
-        }
-            break;
-        case ORKQuestionTypeVerticalScale:{
-            height = [ORKSurveyAnswerCellForVerticalScale suggestedCellHeightForView:tableView];
+            if ([self.questionStep isFormatVertical]) {
+                height = [ORKSurveyAnswerCellForVerticalScale suggestedCellHeightForView:tableView];
+            }
+            else {
+                height = [ORKSurveyAnswerCellForScale suggestedCellHeightForView:tableView];
+            }
         }
             break;
         default:{

--- a/ResearchKit/Common/ORKQuestionStepViewController.m
+++ b/ResearchKit/Common/ORKQuestionStepViewController.m
@@ -588,7 +588,7 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection)
     else if ([[self.questionStep impliedAnswerFormat] isKindOfClass:[ORKValuePickerAnswerFormat class]]) {
         class = [ORKSurveyAnswerCellForPicker class];
     }
-    else if ([self.questionStep isFormatVertical]) {
+    else if ([self.questionStep isFormatVerticalScale]) {
         class = [ORKSurveyAnswerCellForVerticalScale class];
     }
     
@@ -784,7 +784,7 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection)
         }
             break;
         case ORKQuestionTypeScale:{
-            if ([self.questionStep isFormatVertical]) {
+            if ([self.questionStep isFormatVerticalScale]) {
                 height = [ORKSurveyAnswerCellForVerticalScale suggestedCellHeightForView:tableView];
             }
             else {

--- a/ResearchKit/Common/ORKQuestionStepViewController.m
+++ b/ResearchKit/Common/ORKQuestionStepViewController.m
@@ -563,6 +563,7 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection)
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         typeAndCellMapping = @{@(ORKQuestionTypeScale): [ORKSurveyAnswerCellForScale class],
+                               @(ORKQuestionTypeVerticalScale): [ORKSurveyAnswerCellForVerticalScale class],
                                @(ORKQuestionTypeDecimal) : [ORKSurveyAnswerCellForNumber class],
                                @(ORKQuestionTypeText) : [ORKSurveyAnswerCellForText class],
                                @(ORKQuestionTypeTimeOfDay) : [ORKSurveyAnswerCellForPicker class],
@@ -784,8 +785,11 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection)
             height = [ORKSurveyAnswerCellForScale suggestedCellHeightForView:tableView];
         }
             break;
+        case ORKQuestionTypeVerticalScale:{
+            height = [ORKSurveyAnswerCellForVerticalScale suggestedCellHeightForView:tableView];
+        }
+            break;
         default:{
-            
         }
             break;
     }

--- a/ResearchKit/Common/ORKQuestionStep_Internal.h
+++ b/ResearchKit/Common/ORKQuestionStep_Internal.h
@@ -39,6 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isFormatChoiceWithImageOptions;
 - (BOOL)isFormatFitsChoiceCells;
 - (BOOL)isFormatTextfield;
+- (BOOL)isFormatVertical;
 
 - (BOOL)formatRequiresTableView;
 

--- a/ResearchKit/Common/ORKQuestionStep_Internal.h
+++ b/ResearchKit/Common/ORKQuestionStep_Internal.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isFormatChoiceWithImageOptions;
 - (BOOL)isFormatFitsChoiceCells;
 - (BOOL)isFormatTextfield;
-- (BOOL)isFormatVertical;
+- (BOOL)isFormatVerticalScale;
 
 - (BOOL)formatRequiresTableView;
 

--- a/ResearchKit/Common/ORKScaleSlider.h
+++ b/ResearchKit/Common/ORKScaleSlider.h
@@ -37,7 +37,7 @@
 
 @property (nonatomic, assign) NSUInteger numberOfSteps;
 
-@property (nonatomic, assign) BOOL isVertical;
+@property (nonatomic, assign, getter=isVertical) BOOL vertical;
 
 @end
 

--- a/ResearchKit/Common/ORKScaleSlider.h
+++ b/ResearchKit/Common/ORKScaleSlider.h
@@ -37,6 +37,8 @@
 
 @property (nonatomic, assign) NSUInteger numberOfSteps;
 
+@property (nonatomic, assign) BOOL isVertical;
+
 @end
 
 

--- a/ResearchKit/Common/ORKScaleSlider.m
+++ b/ResearchKit/Common/ORKScaleSlider.m
@@ -99,7 +99,7 @@
     UIView *view = nil;
     if (_vertical)
     {
-        // In vertical mode, we need to ignore the touch are for the needed extra width
+        // In vertical mode, we need to ignore the touch area for the needed extra width
         const CGFloat desiredSliderWidth = 36.0;
         const CGFloat actualWidth = self.bounds.size.width;
         const CGFloat centerX = actualWidth / 2;

--- a/ResearchKit/Common/ORKScaleSlider.m
+++ b/ResearchKit/Common/ORKScaleSlider.m
@@ -80,7 +80,7 @@
     }
 }
 
-- (UIView *)_thumbImageSubview {
+- (UIView *)thumbImageSubview {
     UIView *thumbImageSubview = nil;
     CGRect trackRect = [self trackRectForBounds:self.bounds];
     CGRect thumbRect = [self thumbRectForBounds:self.bounds trackRect:trackRect value:self.value];
@@ -97,7 +97,8 @@
     [super layoutSubviews];
     if (_thumbImageNeedsTransformUpdate)
     {
-        [self _thumbImageSubview].transform = _vertical ? CGAffineTransformMakeRotation(M_PI_2) : CGAffineTransformIdentity;
+        _thumbImageNeedsTransformUpdate = NO;
+        [self thumbImageSubview].transform = _vertical ? CGAffineTransformMakeRotation(M_PI_2) : CGAffineTransformIdentity;
     }
 }
 

--- a/ResearchKit/Common/ORKScaleSlider.m
+++ b/ResearchKit/Common/ORKScaleSlider.m
@@ -125,7 +125,7 @@
     UIView *view = nil;
     if (_vertical) {
         // In vertical mode, we need to ignore the touch area for the needed extra width
-        const CGFloat desiredSliderWidth = 36.0;
+        const CGFloat desiredSliderWidth = 44.0;
         const CGFloat actualWidth = [self bounds].size.width;
         const CGFloat centerX = actualWidth / 2;
         if (fabs(point.y - centerX) < desiredSliderWidth / 2) {

--- a/ResearchKit/Common/ORKScaleSlider.m
+++ b/ResearchKit/Common/ORKScaleSlider.m
@@ -34,17 +34,18 @@
 #import "ORKDefines_Private.h"
 #import "ORKAnswerFormat_Internal.h"
 
+
 @interface ORKScaleSlider ()
 
 @end
+
 
 @implementation ORKScaleSlider {
     CFAbsoluteTime _axLastOutputTime;
     BOOL _thumbImageNeedsTransformUpdate;
 }
 
-- (id)initWithFrame:(CGRect)frame
-{
+- (id)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
         UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(sliderTouched:)];
@@ -66,15 +67,12 @@
     return self;
 }
 
-- (void)setShowThumb:(BOOL)showThumb
-{
+- (void)setShowThumb:(BOOL)showThumb {
     _showThumb = showThumb;
 }
 
-- (void)setVertical:(BOOL)vertical
-{
-    if (vertical != _vertical)
-    {
+- (void)setVertical:(BOOL)vertical {
+    if (vertical != _vertical) {
         _vertical = vertical;
         self.transform = _vertical ? CGAffineTransformMakeRotation(-M_PI_2) : CGAffineTransformIdentity;
         _thumbImageNeedsTransformUpdate = YES;
@@ -116,29 +114,24 @@
     }
 }
 
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
-{
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
     UIView *view = nil;
-    if (_vertical)
-    {
+    if (_vertical) {
         // In vertical mode, we need to ignore the touch area for the needed extra width
         const CGFloat desiredSliderWidth = 36.0;
         const CGFloat actualWidth = self.bounds.size.width;
         const CGFloat centerX = actualWidth / 2;
-        if (fabs(point.y - centerX) < desiredSliderWidth / 2)
-        {
+        if (fabs(point.y - centerX) < desiredSliderWidth / 2) {
             view = [super hitTest:point withEvent:event];
         }
     }
-    else
-    {
+    else {
         view = [super hitTest:point withEvent:event];
     }
     return view;
 }
 
-- (void)sliderTouched:(UIGestureRecognizer *)gesture
-{
+- (void)sliderTouched:(UIGestureRecognizer *)gesture {
     self.showThumb = YES;
     
     CGPoint touchPoint = [gesture locationInView:self];
@@ -153,7 +146,7 @@
     if (touchPoint.x < 0) {
         touchPoint.x = 0;
     }
-    CGRect trackRect = [self trackRectForBounds:[self bounds]];
+    CGRect trackRect = [self trackRectForBounds:self.bounds];
     CGFloat position = (touchPoint.x - CGRectGetMinX(trackRect)) / CGRectGetWidth(trackRect);
     
     CGFloat newValue = position * ([self maximumValue] - [self minimumValue]) + [self minimumValue];
@@ -168,10 +161,9 @@
 }
 
 static CGFloat kLineWidth = 1.0;
-- (void)drawRect:(CGRect)rect
-{
-    CGRect trackRect = [self trackRectForBounds:[self bounds]];
-    CGFloat centerY = [self bounds].size.height / 2.0;
+- (void)drawRect:(CGRect)rect {
+    CGRect trackRect = [self trackRectForBounds:self.bounds];
+    CGFloat centerY = self.bounds.size.height / 2.0;
     
     [[UIColor blackColor] set];
     
@@ -187,18 +179,15 @@ static CGFloat kLineWidth = 1.0;
             [path addLineToPoint:CGPointMake(x, centerY + 3.5)];
         }
         [path stroke];
-        
     }
     
     [[UIBezierPath bezierPathWithRect:trackRect] fill];
 }
+
 static CGFloat kPadding = 2.0;
-- (CGRect)trackRectForBounds:(CGRect)bounds
-{
-    
+- (CGRect)trackRectForBounds:(CGRect)bounds {
     CGFloat centerY = bounds.size.height / 2.0 - kLineWidth/2;
     CGRect rect = CGRectMake(bounds.origin.x + kPadding, centerY, bounds.size.width - 2 * kPadding, 1.0);
-    
     return rect;
 }
 

--- a/ResearchKit/Common/ORKScaleSlider.m
+++ b/ResearchKit/Common/ORKScaleSlider.m
@@ -87,6 +87,7 @@
     for (UIView *subview in self.subviews) {
         if (CGRectEqualToRect(thumbRect, subview.frame)) {
             thumbImageSubview = subview;
+            break;
         }
     }
     return thumbImageSubview;

--- a/ResearchKit/Common/ORKScaleSlider.m
+++ b/ResearchKit/Common/ORKScaleSlider.m
@@ -69,19 +69,19 @@
     _showThumb = showThumb;
 }
 
-- (void)setIsVertical:(BOOL)isVertical
+- (void)setVertical:(BOOL)vertical
 {
-    if (isVertical != _isVertical)
+    if (vertical != _vertical)
     {
-        _isVertical = isVertical;
-        self.transform = isVertical ? CGAffineTransformMakeRotation(-M_PI_2) : CGAffineTransformIdentity;
+        _vertical = vertical;
+        self.transform = vertical ? CGAffineTransformMakeRotation(-M_PI_2) : CGAffineTransformIdentity;
     }
 }
 
 - (void)addConstraint:(NSLayoutConstraint *)constraint
 {
     [super addConstraint:constraint];
-    if (_isVertical && constraint.firstItem == self && constraint.firstAttribute == NSLayoutAttributeHeight)
+    if (_vertical && constraint.firstItem == self && constraint.firstAttribute == NSLayoutAttributeHeight)
     {
         // In vertical mode, the slider needs to be of square size for the drawn area to have the appropriate height (due to using self.transform)
         [self addConstraint:[NSLayoutConstraint constraintWithItem:self
@@ -97,7 +97,7 @@
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
     UIView *view = nil;
-    if (_isVertical)
+    if (_vertical)
     {
         // In vertical mode, we need to ignore the touch are for the needed extra width
         const CGFloat desiredSliderWidth = 36.0;

--- a/ResearchKit/Common/ORKScaleSlider.m
+++ b/ResearchKit/Common/ORKScaleSlider.m
@@ -1,6 +1,7 @@
 /*
  Copyright (c) 2015, Apple Inc. All rights reserved.
- 
+ Copyright (c) 2015, Ricardo Sánchez-Sáez.
+
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
  

--- a/ResearchKit/Common/ORKScaleSlider.m
+++ b/ResearchKit/Common/ORKScaleSlider.m
@@ -80,6 +80,9 @@
     }
 }
 
+// Error prone: needs to be replaced by a custom thumb asset
+// Details here: https://github.com/ResearchKit/ResearchKit/pull/33#discussion_r28804792
+// Tracked here: https://github.com/ResearchKit/ResearchKit/issues/67
 - (UIView *)thumbImageSubview {
     UIView *thumbImageSubview = nil;
     CGRect bounds = [self bounds];

--- a/ResearchKit/Common/ORKScaleSlider.m
+++ b/ResearchKit/Common/ORKScaleSlider.m
@@ -69,6 +69,52 @@
     _showThumb = showThumb;
 }
 
+- (void)setIsVertical:(BOOL)isVertical
+{
+    if (isVertical != _isVertical)
+    {
+        _isVertical = isVertical;
+        self.transform = isVertical ? CGAffineTransformMakeRotation(-M_PI_2) : CGAffineTransformIdentity;
+    }
+}
+
+- (void)addConstraint:(NSLayoutConstraint *)constraint
+{
+    [super addConstraint:constraint];
+    if (_isVertical && constraint.firstItem == self && constraint.firstAttribute == NSLayoutAttributeHeight)
+    {
+        // In vertical mode, the slider needs to be of square size for the drawn area to have the appropriate height (due to using self.transform)
+        [self addConstraint:[NSLayoutConstraint constraintWithItem:self
+                                                         attribute:NSLayoutAttributeWidth
+                                                         relatedBy:NSLayoutRelationEqual
+                                                            toItem:self
+                                                         attribute:NSLayoutAttributeHeight
+                                                        multiplier:1.0
+                                                          constant:0.0]];
+    }
+}
+
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+    UIView *view = nil;
+    if (_isVertical)
+    {
+        // In vertical mode, we need to ignore the touch are for the needed extra width
+        const CGFloat desiredSliderWidth = 36.0;
+        const CGFloat actualWidth = self.bounds.size.width;
+        const CGFloat centerX = actualWidth / 2;
+        if (fabs(point.y - centerX) < desiredSliderWidth / 2)
+        {
+            view = [super hitTest:point withEvent:event];
+        }
+    }
+    else
+    {
+        view = [super hitTest:point withEvent:event];
+    }
+    return view;
+}
+
 - (void)sliderTouched:(UIGestureRecognizer *)gesture
 {
     self.showThumb = YES;

--- a/ResearchKit/Common/ORKScaleSlider.m
+++ b/ResearchKit/Common/ORKScaleSlider.m
@@ -81,6 +81,10 @@
 }
 
 - (void)updateValueForTouchAtPoint:(CGPoint)touchPoint {
+    // Ignore negative (out of bounds) positions
+    if (touchPoint.x < 0) {
+        touchPoint.x = 0;
+    }
     CGRect trackRect = [self trackRectForBounds:[self bounds]];
     CGFloat position = (touchPoint.x - CGRectGetMinX(trackRect)) / CGRectGetWidth(trackRect);
     

--- a/ResearchKit/Common/ORKScaleSlider.m
+++ b/ResearchKit/Common/ORKScaleSlider.m
@@ -40,6 +40,7 @@
 
 @implementation ORKScaleSlider {
     CFAbsoluteTime _axLastOutputTime;
+    BOOL _thumbImageNeedsTransformUpdate;
 }
 
 - (id)initWithFrame:(CGRect)frame
@@ -60,6 +61,7 @@
         self.showThumb = NO;
         
         _axLastOutputTime = 0;
+        _thumbImageNeedsTransformUpdate = NO;
     }
     return self;
 }
@@ -74,12 +76,32 @@
     if (vertical != _vertical)
     {
         _vertical = vertical;
-        self.transform = vertical ? CGAffineTransformMakeRotation(-M_PI_2) : CGAffineTransformIdentity;
+        self.transform = _vertical ? CGAffineTransformMakeRotation(-M_PI_2) : CGAffineTransformIdentity;
+        _thumbImageNeedsTransformUpdate = YES;
     }
 }
 
-- (void)addConstraint:(NSLayoutConstraint *)constraint
-{
+- (UIView *)_thumbImageSubview {
+    UIView *thumbImageSubview = nil;
+    CGRect trackRect = [self trackRectForBounds:self.bounds];
+    CGRect thumbRect = [self thumbRectForBounds:self.bounds trackRect:trackRect value:self.value];
+    for (UIView *subview in self.subviews) {
+        if (CGRectEqualToRect(thumbRect, subview.frame)) {
+            thumbImageSubview = subview;
+        }
+    }
+    return thumbImageSubview;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    if (_thumbImageNeedsTransformUpdate)
+    {
+        [self _thumbImageSubview].transform = _vertical ? CGAffineTransformMakeRotation(M_PI_2) : CGAffineTransformIdentity;
+    }
+}
+
+- (void)addConstraint:(NSLayoutConstraint *)constraint {
     [super addConstraint:constraint];
     if (_vertical && constraint.firstItem == self && constraint.firstAttribute == NSLayoutAttributeHeight)
     {

--- a/ResearchKit/Common/ORKScaleSlider.m
+++ b/ResearchKit/Common/ORKScaleSlider.m
@@ -82,8 +82,9 @@
 
 - (UIView *)thumbImageSubview {
     UIView *thumbImageSubview = nil;
-    CGRect trackRect = [self trackRectForBounds:self.bounds];
-    CGRect thumbRect = [self thumbRectForBounds:self.bounds trackRect:trackRect value:self.value];
+    CGRect bounds = [self bounds];
+    CGRect trackRect = [self trackRectForBounds:bounds];
+    CGRect thumbRect = [self thumbRectForBounds:bounds trackRect:trackRect value:self.value];
     for (UIView *subview in self.subviews) {
         if (CGRectEqualToRect(thumbRect, subview.frame)) {
             thumbImageSubview = subview;
@@ -122,7 +123,7 @@
     if (_vertical) {
         // In vertical mode, we need to ignore the touch area for the needed extra width
         const CGFloat desiredSliderWidth = 36.0;
-        const CGFloat actualWidth = self.bounds.size.width;
+        const CGFloat actualWidth = [self bounds].size.width;
         const CGFloat centerX = actualWidth / 2;
         if (fabs(point.y - centerX) < desiredSliderWidth / 2) {
             view = [super hitTest:point withEvent:event];
@@ -149,7 +150,7 @@
     if (touchPoint.x < 0) {
         touchPoint.x = 0;
     }
-    CGRect trackRect = [self trackRectForBounds:self.bounds];
+    CGRect trackRect = [self trackRectForBounds:[self bounds]];
     CGFloat position = (touchPoint.x - CGRectGetMinX(trackRect)) / CGRectGetWidth(trackRect);
     
     CGFloat newValue = position * ([self maximumValue] - [self minimumValue]) + [self minimumValue];
@@ -165,8 +166,9 @@
 
 static CGFloat kLineWidth = 1.0;
 - (void)drawRect:(CGRect)rect {
-    CGRect trackRect = [self trackRectForBounds:self.bounds];
-    CGFloat centerY = self.bounds.size.height / 2.0;
+    CGRect bounds = [self bounds];
+    CGRect trackRect = [self trackRectForBounds:bounds];
+    CGFloat centerY = bounds.size.height / 2.0;
     
     [[UIColor blackColor] set];
     

--- a/ResearchKit/Common/ORKScaleSliderView.m
+++ b/ResearchKit/Common/ORKScaleSliderView.m
@@ -130,26 +130,55 @@
     
     if ([_formatProvider isVertical])
     {
-        // Horizontal slider constraints
-        const CGFloat kSmallMargin = 11.0;
+        // Vertical slider constraints
         const CGFloat kMargin = 15.0;
-        const CGFloat kSliderHeight = 120.0;
+        const CGFloat kBigMargin = 24;
         [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-[_slider]-|"
                                                                      options:0
-                                                                     metrics:@{@"kSliderHeight": @(kSliderHeight)}
+                                                                     metrics:nil
                                                                        views:views]];
 
-        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_valueLabel(==40)]-kSmallMargin-[_rightRangeLabel]-kMargin-[_slider(==kSliderHeight)]-kMargin-[_leftRangeLabel]"
+        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_valueLabel(==40)]-kBigMargin-[_slider]-kMargin-|"
                                                                      options:NSLayoutFormatAlignAllCenterX|NSLayoutFormatDirectionLeadingToTrailing
-                                                                     metrics:@{@"kSliderHeight": @(kSliderHeight),
-                                                                               @"kMargin": @(kMargin),
-                                                                               @"kSmallMargin": @(kSmallMargin)}
+                                                                     metrics:@{@"kMargin": @(kMargin), @"kBigMargin": @(kBigMargin)}
                                                                        views:views]];
         
         [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:[_rightRangeLabel(==_leftRangeLabel)]"
                                                                      options:0
                                                                      metrics:nil
                                                                        views:views]];
+
+        [self addConstraint:[NSLayoutConstraint constraintWithItem:self.slider
+                                                         attribute:NSLayoutAttributeTop
+                                                         relatedBy:NSLayoutRelationEqual
+                                                            toItem:self.rightRangeLabel
+                                                         attribute:NSLayoutAttributeCenterY
+                                                        multiplier:1.0
+                                                          constant:-4.0]];
+         [self addConstraint:[NSLayoutConstraint constraintWithItem:self.slider
+                                                          attribute:NSLayoutAttributeBottom
+                                                          relatedBy:NSLayoutRelationEqual
+                                                             toItem:self.leftRangeLabel
+                                                          attribute:NSLayoutAttributeCenterY
+                                                         multiplier:1.0
+                                                           constant:4.0]];
+        
+        NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self.rightRangeLabel
+                                                                      attribute:NSLayoutAttributeRight
+                                                                      relatedBy:NSLayoutRelationEqual
+                                                                         toItem:self.slider
+                                                                      attribute:NSLayoutAttributeCenterX
+                                                                     multiplier:1.0
+                                                                       constant:-kBigMargin];
+        [self addConstraint:constraint];
+        constraint = [NSLayoutConstraint constraintWithItem:self.leftRangeLabel
+                                                  attribute:NSLayoutAttributeRight
+                                                  relatedBy:NSLayoutRelationEqual
+                                                     toItem:self.slider
+                                                  attribute:NSLayoutAttributeCenterX
+                                                 multiplier:1.0
+                                                   constant:-kBigMargin];
+        [self addConstraint:constraint];
     }
     else
     {

--- a/ResearchKit/Common/ORKScaleSliderView.m
+++ b/ResearchKit/Common/ORKScaleSliderView.m
@@ -57,6 +57,8 @@
         self.leftRangeLabel.text = [formatProvider localizedStringForNumber:[formatProvider minimumNumber]];
         self.rightRangeLabel.text = [formatProvider localizedStringForNumber:[formatProvider maximumNumber]];
         
+        self.slider.isVertical = [formatProvider isVertical];
+        
         self.slider.maximumValue = [[formatProvider maximumNumber] floatValue];
         self.slider.minimumValue = [[formatProvider minimumNumber] floatValue];
         
@@ -126,19 +128,51 @@
     
     NSDictionary *views = NSDictionaryOfVariableBindings(_slider,_leftRangeLabel,_rightRangeLabel, _valueLabel);
     
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_valueLabel(==40)]-[_slider]"
-                                                                 options:NSLayoutFormatAlignAllCenterX
-                                                                 metrics:nil views:views]];
-    
-    const CGFloat kMargin = 17.0;
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-kMargin-[_leftRangeLabel]-kMargin-[_slider]-kMargin-[_rightRangeLabel(==_leftRangeLabel)]-kMargin-|" options:NSLayoutFormatAlignAllCenterY|NSLayoutFormatDirectionLeadingToTrailing
-                                                                 metrics:@{@"kMargin": @(kMargin)} views:views]];
-    
-    [self addConstraint:[NSLayoutConstraint constraintWithItem:_valueLabel
-                                                     attribute:NSLayoutAttributeLastBaseline
-                                                     relatedBy:NSLayoutRelationEqual
-                                                        toItem:_slider
-                                                     attribute:NSLayoutAttributeCenterY multiplier:1.0 constant:-34.0]];
+    if ([_formatProvider isVertical])
+    {
+        // Horizontal slider constraints
+        const CGFloat kSmallMargin = 11.0;
+        const CGFloat kMargin = 15.0;
+        const CGFloat kSliderHeight = 120.0;
+        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-[_slider]-|"
+                                                                     options:0
+                                                                     metrics:@{@"kSliderHeight": @(kSliderHeight)}
+                                                                       views:views]];
+
+        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_valueLabel(==40)]-kSmallMargin-[_rightRangeLabel]-kMargin-[_slider(==kSliderHeight)]-kMargin-[_leftRangeLabel]"
+                                                                     options:NSLayoutFormatAlignAllCenterX|NSLayoutFormatDirectionLeadingToTrailing
+                                                                     metrics:@{@"kSliderHeight": @(kSliderHeight),
+                                                                               @"kMargin": @(kMargin),
+                                                                               @"kSmallMargin": @(kSmallMargin)}
+                                                                       views:views]];
+        
+        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:[_rightRangeLabel(==_leftRangeLabel)]"
+                                                                     options:0
+                                                                     metrics:nil
+                                                                       views:views]];
+    }
+    else
+    {
+        // Horizontal slider constraints
+        const CGFloat kMargin = 17.0;
+        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_valueLabel(==40)]-[_slider]"
+                                                                     options:NSLayoutFormatAlignAllCenterX
+                                                                     metrics:nil
+                                                                       views:views]];
+        
+        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-kMargin-[_leftRangeLabel]-kMargin-[_slider]-kMargin-[_rightRangeLabel(==_leftRangeLabel)]-kMargin-|"
+                                                                     options:NSLayoutFormatAlignAllCenterY|NSLayoutFormatDirectionLeadingToTrailing
+                                                                     metrics:@{@"kMargin": @(kMargin)}
+                                                                       views:views]];
+        
+        [self addConstraint:[NSLayoutConstraint constraintWithItem:_valueLabel
+                                                         attribute:NSLayoutAttributeLastBaseline
+                                                         relatedBy:NSLayoutRelationEqual
+                                                            toItem:_slider
+                                                         attribute:NSLayoutAttributeCenterY
+                                                        multiplier:1.0
+                                                          constant:-34.0]];
+    }
 }
 
 

--- a/ResearchKit/Common/ORKScaleSliderView.m
+++ b/ResearchKit/Common/ORKScaleSliderView.m
@@ -1,6 +1,7 @@
 /*
  Copyright (c) 2015, Apple Inc. All rights reserved.
- 
+ Copyright (c) 2015, Ricardo Sánchez-Sáez.
+
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
  

--- a/ResearchKit/Common/ORKScaleSliderView.m
+++ b/ResearchKit/Common/ORKScaleSliderView.m
@@ -57,7 +57,7 @@
         self.leftRangeLabel.text = [formatProvider localizedStringForNumber:[formatProvider minimumNumber]];
         self.rightRangeLabel.text = [formatProvider localizedStringForNumber:[formatProvider maximumNumber]];
         
-        self.slider.isVertical = [formatProvider isVertical];
+        self.slider.vertical = [formatProvider isVertical];
         
         self.slider.maximumValue = [[formatProvider maximumNumber] floatValue];
         self.slider.minimumValue = [[formatProvider minimumNumber] floatValue];

--- a/ResearchKit/Common/ORKSurveyAnswerCellForScale.h
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForScale.h
@@ -36,4 +36,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface ORKSurveyAnswerCellForVerticalScale : ORKSurveyAnswerCellForScale
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKSurveyAnswerCellForScale.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForScale.m
@@ -119,6 +119,15 @@
 }
 
 + (CGFloat)suggestedCellHeightForView:(UIView *)view {
+    return 140.0;
+}
+
+@end
+
+
+@implementation ORKSurveyAnswerCellForVerticalScale
+
++ (CGFloat)suggestedCellHeightForView:(UIView *)view {
     return 244.0;
 }
 

--- a/ResearchKit/Common/ORKSurveyAnswerCellForScale.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForScale.m
@@ -119,9 +119,7 @@
 }
 
 + (CGFloat)suggestedCellHeightForView:(UIView *)view {
-    return 140.0;
+    return 244.0;
 }
-
-
 
 @end

--- a/ResearchKit/Common/ORKSurveyAnswerCellForScale.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForScale.m
@@ -128,7 +128,7 @@
 @implementation ORKSurveyAnswerCellForVerticalScale
 
 + (CGFloat)suggestedCellHeightForView:(UIView *)view {
-    return 244.0;
+    return 358.0;
 }
 
 @end

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -693,7 +693,11 @@ static NSString * const TwoFingerTapTaskIdentifier = @"tap";
          */
         ORKQuestionStep *step = [ORKQuestionStep questionStepWithIdentifier:@"qid_010a"
                                                                       title:@"On a scale of 1 to 10, how much pain do you feel?"
-                                                                     answer:[ORKAnswerFormat scaleAnswerFormatWithMaxValue:10 minValue:1 step:1 defaultValue:NSIntegerMax]];
+                                                                     answer:[ORKAnswerFormat scaleAnswerFormatWithMaximumValue:10
+                                                                                                                  minimumValue:1
+                                                                                                                  defaultValue:NSIntegerMax
+                                                                                                                          step:1
+                                                                                                                      vertical:NO]];
         [steps addObject:step];
     }
     {
@@ -1316,7 +1320,11 @@ static NSString * const TwoFingerTapTaskIdentifier = @"tap";
         /*
          Continuous scale with two decimal places.
          */
-        ORKContinuousScaleAnswerFormat *scaleAnswerFormat =  [ORKAnswerFormat continuousScaleAnswerFormatWithMaxValue:10 minValue:1 defaultValue:NSIntegerMax maximumFractionDigits:2];
+        ORKContinuousScaleAnswerFormat *scaleAnswerFormat =  [ORKAnswerFormat continuousScaleAnswerFormatWithMaximumValue:10
+                                                                                                             minimumValue:1
+                                                                                                             defaultValue:NSIntegerMax
+                                                                                                    maximumFractionDigits:2
+                                                                                                                 vertical:NO];
         
         ORKQuestionStep *step = [ORKQuestionStep questionStepWithIdentifier:@"scale_01"
                                                                     title:@"On a scale of 1 to 10, how much pain do you feel?"
@@ -1328,7 +1336,11 @@ static NSString * const TwoFingerTapTaskIdentifier = @"tap";
         /*
          Discrete scale, no default.
          */
-        ORKScaleAnswerFormat *scaleAnswerFormat =  [ORKAnswerFormat scaleAnswerFormatWithMaxValue:300 minValue:100 step:50 defaultValue:NSIntegerMax];
+        ORKScaleAnswerFormat *scaleAnswerFormat =  [ORKAnswerFormat scaleAnswerFormatWithMaximumValue:300
+                                                                                         minimumValue:100
+                                                                                         defaultValue:NSIntegerMax
+                                                                                                 step:50
+                                                                                             vertical:NO];
         
         ORKQuestionStep *step = [ORKQuestionStep questionStepWithIdentifier:@"scale_02"
                                                                     title:@"How much money do you need?"
@@ -1340,7 +1352,11 @@ static NSString * const TwoFingerTapTaskIdentifier = @"tap";
         /*
          Discrete scale, with a default.
          */
-        ORKScaleAnswerFormat *scaleAnswerFormat =  [ORKAnswerFormat scaleAnswerFormatWithMaxValue:10 minValue:1 step:1 defaultValue:5];
+        ORKScaleAnswerFormat *scaleAnswerFormat =  [ORKAnswerFormat scaleAnswerFormatWithMaximumValue:10
+                                                                                         minimumValue:1
+                                                                                         defaultValue:5
+                                                                                                 step:1
+                                                                                             vertical:NO];
         
         ORKQuestionStep *step = [ORKQuestionStep questionStepWithIdentifier:@"scale_05"
                                                                     title:@"On a scale of 1 to 10, how much pain do you feel?"
@@ -1352,7 +1368,11 @@ static NSString * const TwoFingerTapTaskIdentifier = @"tap";
         /*
          Discrete scale, with a default that is not on a step boundary.
          */
-        ORKScaleAnswerFormat *scaleAnswerFormat =  [ORKAnswerFormat scaleAnswerFormatWithMaxValue:300 minValue:100 step:50 defaultValue:174];
+        ORKScaleAnswerFormat *scaleAnswerFormat =  [ORKAnswerFormat scaleAnswerFormatWithMaximumValue:300
+                                                                                         minimumValue:100
+                                                                                         defaultValue:174
+                                                                                                 step:50
+                                                                                             vertical:NO];
         
         ORKQuestionStep *step = [ORKQuestionStep questionStepWithIdentifier:@"scale_06"
                                                                     title:@"How much money do you need?"

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -1310,7 +1310,7 @@ static NSString * const TwoFingerTapTaskIdentifier = @"tap";
 #pragma mark Scales task
 
 /*
- This task is used to test various uses of discrete and continuous valued sliders.
+ This task is used to test various uses of discrete and continuous, horizontal and vertical valued sliders.
  */
 - (id<ORKTask>)makeScalesTask {
 
@@ -1358,7 +1358,7 @@ static NSString * const TwoFingerTapTaskIdentifier = @"tap";
                                                                                                  step:1
                                                                                              vertical:NO];
         
-        ORKQuestionStep *step = [ORKQuestionStep questionStepWithIdentifier:@"scale_05"
+        ORKQuestionStep *step = [ORKQuestionStep questionStepWithIdentifier:@"scale_03"
                                                                     title:@"On a scale of 1 to 10, how much pain do you feel?"
                                                                    answer:scaleAnswerFormat];
         [steps addObject:step];
@@ -1374,9 +1374,41 @@ static NSString * const TwoFingerTapTaskIdentifier = @"tap";
                                                                                                  step:50
                                                                                              vertical:NO];
         
-        ORKQuestionStep *step = [ORKQuestionStep questionStepWithIdentifier:@"scale_06"
+        ORKQuestionStep *step = [ORKQuestionStep questionStepWithIdentifier:@"scale_04"
                                                                     title:@"How much money do you need?"
                                                                    answer:scaleAnswerFormat];
+        [steps addObject:step];
+    }
+
+    {
+        /*
+         Vertical continuous scale with three decimal places and a default.
+         */
+        ORKContinuousScaleAnswerFormat *scaleAnswerFormat =  [ORKAnswerFormat continuousScaleAnswerFormatWithMaximumValue:10
+                                                                                                             minimumValue:1
+                                                                                                             defaultValue:8.725
+                                                                                                    maximumFractionDigits:3
+                                                                                                                 vertical:YES];
+        
+        ORKQuestionStep *step = [ORKQuestionStep questionStepWithIdentifier:@"scale_05"
+                                                                      title:@"On a scale of 1 to 10, what is your mood?"
+                                                                     answer:scaleAnswerFormat];
+        [steps addObject:step];
+    }
+
+    {
+        /*
+         Vertical discrete scale, with a default on a step boundary.
+         */
+        ORKScaleAnswerFormat *scaleAnswerFormat =  [ORKAnswerFormat scaleAnswerFormatWithMaximumValue:10
+                                                                                         minimumValue:1
+                                                                                         defaultValue:5
+                                                                                                 step:1
+                                                                                             vertical:YES];
+        
+        ORKQuestionStep *step = [ORKQuestionStep questionStepWithIdentifier:@"scale_06"
+                                                                      title:@"How would you measure your mood improvement?"
+                                                                     answer:scaleAnswerFormat];
         [steps addObject:step];
     }
 

--- a/Testing/ORKTest/ORKTest/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTest/ORKESerialization.m
@@ -618,23 +618,25 @@ ret =
           })),
   ENTRY(ORKScaleAnswerFormat,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
-            return [[ORKScaleAnswerFormat alloc] initWithMaximumValue:[GETPROP(dict, maximum) integerValue] minimumValue:[GETPROP(dict, minimum) integerValue] step:[GETPROP(dict, step) integerValue] defaultValue:[GETPROP(dict, defaultValue) integerValue]];
+            return [[ORKScaleAnswerFormat alloc] initWithMaximumValue:[GETPROP(dict, maximum) integerValue] minimumValue:[GETPROP(dict, minimum) integerValue] defaultValue:[GETPROP(dict, defaultValue) integerValue] step:[GETPROP(dict, step) integerValue] vertical:[GETPROP(dict, vertical) boolValue]];
         },
         (@{
           PROPERTY(minimum, NSNumber, NSObject, NO, nil, nil),
           PROPERTY(maximum, NSNumber, NSObject, NO, nil, nil),
-          PROPERTY(step, NSNumber, NSObject, NO, nil, nil),
           PROPERTY(defaultValue, NSNumber, NSObject, NO, nil, nil),
+          PROPERTY(step, NSNumber, NSObject, NO, nil, nil),
+          PROPERTY(vertical, NSNumber, NSObject, NO, nil, nil)
           })),
   ENTRY(ORKContinuousScaleAnswerFormat,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
-            return [[ORKContinuousScaleAnswerFormat alloc] initWithMaximumValue:[GETPROP(dict, maximum) doubleValue] minimumValue:[GETPROP(dict, minimum) doubleValue] defaultValue:[GETPROP(dict, defaultValue) doubleValue] maximumFractionDigits:[GETPROP(dict, maximumFractionDigits) integerValue]];
+            return [[ORKContinuousScaleAnswerFormat alloc] initWithMaximumValue:[GETPROP(dict, maximum) doubleValue] minimumValue:[GETPROP(dict, minimum) doubleValue] defaultValue:[GETPROP(dict, defaultValue) doubleValue] maximumFractionDigits:[GETPROP(dict, maximumFractionDigits) integerValue] vertical:[GETPROP(dict, vertical) boolValue]];
         },
         (@{
           PROPERTY(minimum, NSNumber, NSObject, NO, nil, nil),
           PROPERTY(maximum, NSNumber, NSObject, NO, nil, nil),
-          PROPERTY(maximumFractionDigits, NSNumber, NSObject, NO, nil, nil),
           PROPERTY(defaultValue, NSNumber, NSObject, NO, nil, nil),
+          PROPERTY(maximumFractionDigits, NSNumber, NSObject, NO, nil, nil),
+          PROPERTY(vertical, NSNumber, NSObject, NO, nil, nil)
           })),
   ENTRY(ORKTextAnswerFormat,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -226,8 +226,11 @@
     
     ORKQuestionStep *questionStep2 = [ORKQuestionStep questionStepWithIdentifier:@"id"
                                                                      title:@"question" answer:[ORKNumericAnswerFormat decimalAnswerFormatWithUnit:@"kg"]];
-    
-    ORKOrderedTask *task = [[ORKOrderedTask alloc] initWithIdentifier:@"id" steps:@[activeStep, questionStep, questionStep2]];
+
+    ORKQuestionStep *questionStep3 = [ORKQuestionStep questionStepWithIdentifier:@"id"
+                                                                           title:@"question" answer:[ORKScaleAnswerFormat scaleAnswerFormatWithMaximumValue:10.0 minimumValue:1.0 defaultValue:5.0 step:1.0 vertical:YES]];
+
+    ORKOrderedTask *task = [[ORKOrderedTask alloc] initWithIdentifier:@"id" steps:@[activeStep, questionStep, questionStep2, questionStep3]];
     
     NSDictionary *dict1 = [ORKESerializer JSONObjectForObject:task error:nil];
     

--- a/samples/ORKCatalog/ORKCatalog/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/TaskListRow.swift
@@ -156,6 +156,8 @@ enum TaskListRow: Int, Printable {
         case ScaleQuestionTask =                    "ScaleQuestionTask"
         case DiscreteScaleQuestionStep =            "DiscreteScaleQuestionStep"
         case ContinuousScaleQuestionStep =          "ContinuousScaleQuestionStep"
+        case DiscreteVerticalScaleQuestionStep =    "DiscreteVerticalScaleQuestionStep"
+        case ContinuousVerticalScaleQuestionStep =  "ContinuousVerticalScaleQuestionStep"
 
         // Task with examples of numeric questions.
         case NumericQuestionTask =                  "NumericQuestionTask"
@@ -313,7 +315,25 @@ enum TaskListRow: Int, Printable {
         questionStep2.text = exampleDetailText
         
         steps += [questionStep2]
+
+        // The third step is a vertical scale control with 10 discrete ticks.
+        let step3AnswerFormat = ORKAnswerFormat.verticalScaleAnswerFormatWithMaxValue(10, minValue: 1, step: 1, defaultValue: NSIntegerMax)
         
+        let questionStep3 = ORKQuestionStep(identifier: Identifier.DiscreteVerticalScaleQuestionStep.rawValue, title: exampleQuestionText, answer: step3AnswerFormat)
+        
+        questionStep3.text = exampleDetailText
+        
+        steps += [questionStep3]
+
+        // The fourth step is a vertical scale control that allows continuous movement.
+        let step4AnswerFormat = ORKAnswerFormat.continuousVerticalScaleAnswerFormatWithMaxValue(5.0, minValue: 1.0, defaultValue: 99.0, maximumFractionDigits: 2)
+        
+        let questionStep4 = ORKQuestionStep(identifier: Identifier.ContinuousVerticalScaleQuestionStep.rawValue, title: exampleQuestionText, answer: step4AnswerFormat)
+        
+        questionStep4.text = exampleDetailText
+        
+        steps += [questionStep4]
+
         return ORKOrderedTask(identifier: Identifier.ScaleQuestionTask.rawValue, steps: steps)
     }
     

--- a/samples/ORKCatalog/ORKCatalog/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/TaskListRow.swift
@@ -299,7 +299,7 @@ enum TaskListRow: Int, Printable {
         var steps = [ORKStep]()
         
         // The first step is a scale control with 10 discrete ticks.
-        let step1AnswerFormat = ORKAnswerFormat.scaleAnswerFormatWithMaxValue(10, minValue: 1, step: 1, defaultValue: NSIntegerMax)
+        let step1AnswerFormat = ORKAnswerFormat.scaleAnswerFormatWithMaximumValue(10, minimumValue: 1, defaultValue: NSIntegerMax, step: 1, vertical: false)
         
         let questionStep1 = ORKQuestionStep(identifier: Identifier.DiscreteScaleQuestionStep.rawValue, title: exampleQuestionText, answer: step1AnswerFormat)
         
@@ -308,7 +308,7 @@ enum TaskListRow: Int, Printable {
         steps += [questionStep1]
         
         // The second step is a scale control that allows continuous movement.
-        let step2AnswerFormat = ORKAnswerFormat.continuousScaleAnswerFormatWithMaxValue(5.0, minValue: 1.0, defaultValue: 99.0, maximumFractionDigits: 2)
+        let step2AnswerFormat = ORKAnswerFormat.continuousScaleAnswerFormatWithMaximumValue(5.0, minimumValue: 1.0, defaultValue: 99.0, maximumFractionDigits: 2, vertical: false)
         
         let questionStep2 = ORKQuestionStep(identifier: Identifier.ContinuousScaleQuestionStep.rawValue, title: exampleQuestionText, answer: step2AnswerFormat)
         
@@ -317,7 +317,7 @@ enum TaskListRow: Int, Printable {
         steps += [questionStep2]
 
         // The third step is a vertical scale control with 10 discrete ticks.
-        let step3AnswerFormat = ORKAnswerFormat.verticalScaleAnswerFormatWithMaxValue(10, minValue: 1, step: 1, defaultValue: NSIntegerMax)
+        let step3AnswerFormat = ORKAnswerFormat.scaleAnswerFormatWithMaximumValue(10, minimumValue: 1, defaultValue: NSIntegerMax, step: 1, vertical: true)
         
         let questionStep3 = ORKQuestionStep(identifier: Identifier.DiscreteVerticalScaleQuestionStep.rawValue, title: exampleQuestionText, answer: step3AnswerFormat)
         
@@ -326,7 +326,7 @@ enum TaskListRow: Int, Printable {
         steps += [questionStep3]
 
         // The fourth step is a vertical scale control that allows continuous movement.
-        let step4AnswerFormat = ORKAnswerFormat.continuousVerticalScaleAnswerFormatWithMaxValue(5.0, minValue: 1.0, defaultValue: 99.0, maximumFractionDigits: 2)
+        let step4AnswerFormat = ORKAnswerFormat.continuousScaleAnswerFormatWithMaximumValue(5.0, minimumValue: 1.0, defaultValue: 99.0, maximumFractionDigits: 2, vertical: true)
         
         let questionStep4 = ORKQuestionStep(identifier: Identifier.ContinuousVerticalScaleQuestionStep.rawValue, title: exampleQuestionText, answer: step4AnswerFormat)
         


### PR DESCRIPTION
I have implemented vertical scale support ([issue #3](https://github.com/ResearchKit/ResearchKit/issues/3)).

`ORKScaleSlider` now has the `isVertical` property. When set to `YES`, it internally uses the `UIView`'s`transform` property and some minor *bounds* and *touch* trickery to draw and work in vertical.

`ORKScaleSliderView` now has vertical support through the use of the new `isVertical` method from the `ORKScaleAnswerFormatProvider`.

New classes: `ORKVerticalScaleAnswerFormat` and `ORKContinuousVerticalScaleAnswerFormat`. The corresponding example steps have been added to `ORKCatalog`'s *Scale Question*.