### PR TITLE
Improve dynamic cast macro

### DIFF
--- a/ResearchKit/Common/ORKDefines_Private.h
+++ b/ResearchKit/Common/ORKDefines_Private.h
@@ -37,7 +37,7 @@ ORK_EXTERN NSBundle *ORKBundle() ORK_AVAILABLE_DECL;
 #define ORKLocalizedString(key, comment) \
 [ORKBundle() localizedStringForKey:(key) value:@"" table:nil]
 
-#define ORKDynamicCast(x, c) ((c *) ([x isKindOfClass:[c class]] ? x : nil))
+#define ORKDynamicCast(x, c) ({id __x = (x); (c *) ([__x isKindOfClass:[c class]] ? __x : nil);})
 
 
 ORK_EXTERN NSString *ORKTimeOfDayStringFromComponents(NSDateComponents *dateComponents) ORK_AVAILABLE_DECL;


### PR DESCRIPTION
This is a tiny improvement which introduces a hidden temp variable to ensure x is not evaluated twice.
Since the macro isn't terribly often used, it's not of much help, but it does prevent double evaluation in this case:

`ORKDynamicCast(_visualSections[toIndex], ORKConsentSection) customAnimationURL]`

My change uses the lesser-known trick that the last statement in such a [statement expression](https://gcc.gnu.org/onlinedocs/gcc/Statement-Exprs.html) is returned. It's a GNU extension but works equally well with Clang. 

Since many people here will took at what Apple does and what the best practices are, this might be a worthy improvement.