### PR TITLE
Updating init methods that return id to return instancetype instead.

### DIFF
--- a/ResearchKit/ActiveTasks/ORKDataLogger.m
+++ b/ResearchKit/ActiveTasks/ORKDataLogger.m
@@ -60,7 +60,7 @@ static NSString * const kORKDataLoggerManagerConfigurationFilename = @".ORKDataL
 
 @interface ORKObjectObserver : NSObject
 
-- (id)initWithObject:(id)object keys:(NSArray *)keys selector:(SEL)selector;
+- (instancetype)initWithObject:(id)object keys:(NSArray *)keys selector:(SEL)selector;
 
 @property (unsafe_unretained) id object;
 
@@ -186,7 +186,7 @@ static NSString * const kORKDataLoggerManagerConfigurationFilename = @".ORKDataL
 
 static void *ORKObjectObserverContext = &ORKObjectObserverContext;
 
-- (id)initWithObject:(id)object keys:(NSArray *)keys selector:(SEL)selector
+- (instancetype)initWithObject:(id)object keys:(NSArray *)keys selector:(SEL)selector
 {
     self = [super init];
     if (self)
@@ -351,7 +351,7 @@ static NSInteger _ORKJSON_terminatorLength = 0;
 
 @implementation ORKJSONLogFormatter
 
-- (id)init
+- (instancetype)init
 {
     self = [super init];
     if (self)

--- a/ResearchKit/Common/ORKScaleSlider.m
+++ b/ResearchKit/Common/ORKScaleSlider.m
@@ -42,7 +42,7 @@
     CFAbsoluteTime _axLastOutputTime;
 }
 
-- (id)initWithFrame:(CGRect)frame
+- (instancetype)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];
     if (self) {

--- a/ResearchKit/Common/ORKSurveyAnswerCellForText.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForText.m
@@ -52,7 +52,7 @@
     NSArray *_constraints;
 }
 
-- (id)initWithFrame:(CGRect)frame
+- (instancetype)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];
     if (self) {

--- a/ResearchKit/Consent/ORKConsentSignature.m
+++ b/ResearchKit/Consent/ORKConsentSignature.m
@@ -61,7 +61,7 @@
     return sig;
 }
 
-- (id)init
+- (instancetype)init
 {
     self = [super init];
     if (self)

--- a/ResearchKit/Consent/ORKEAGLMoviePlayerView.m
+++ b/ResearchKit/Consent/ORKEAGLMoviePlayerView.m
@@ -116,7 +116,7 @@ static const GLfloat kColorConversion709[] = {
     return [CAEAGLLayer class];
 }
 
-- (id)initWithFrame:(CGRect)frame
+- (instancetype)initWithFrame:(CGRect)frame
 {
     if ((self = [super initWithFrame:frame]))
     {


### PR DESCRIPTION
Updating (id)init... methods to return instancetype instead of id.  initWithCoder: still returns (id) so those were left alone.