### PR TITLE
corrects typo in a comment

### DIFF
--- a/samples/ORKCatalog/ORKCatalog/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/TaskListRow.swift
@@ -205,7 +205,7 @@ enum TaskListRow: Int, Printable {
         case ShortWalkTask =                        "ShortWalkTask"
         case AudioTask =                            "AudioTask"
 
-        // Surevey task specific identifiers.
+        // Survey task specific identifiers.
         case SurveyTask =                           "SurveyTask"
         case IntroStep =                            "IntroStep"
         case QuestionStep =                         "QuestionStep"


### PR DESCRIPTION
fixes a typo in a comment in `samples/ORKCatalog/ORKCatalog/TaskListRow.swift` from `Surevey` to `Survey`