### PR TITLE
Use encodeInt32 instead of encoding 32-bit integers as objects, same for 64-bit

### DIFF
--- a/ResearchKit/Common/ORKHelpers.h
+++ b/ResearchKit/Common/ORKHelpers.h
@@ -72,10 +72,10 @@
 #define ORK_DECODE_INTEGER(d,x) _ ## x = [d decodeIntegerForKey:@STRINGIFY(x)]
 #define ORK_ENCODE_INTEGER(c,x) [c encodeInteger:_ ## x forKey:@STRINGIFY(x)]
 
-#define ORK_ENCODE_UINT32(c,x) [[c encodeInt32:_ ## x] forKey:@STRINGIFY(x)]
+#define ORK_ENCODE_UINT32(c,x) [c encodeInt32:_ ## x forKey:@STRINGIFY(x)]
 #define ORK_DECODE_UINT32(d,x) _ ## x = [d decodeInt32ForKey:@STRINGIFY(x)]
 
-#define ORK_ENCODE_UINT64(c,x) [[c encodeInt64:_ ## x] forKey:@STRINGIFY(x)]
+#define ORK_ENCODE_UINT64(c,x) [c encodeInt64:_ ## x forKey:@STRINGIFY(x)]
 #define ORK_DECODE_UINT64(d,x) _ ## x = [d decodeInt64ForKey:@STRINGIFY(x)]
 
 #define ORK_DECODE_ENUM(d,x)  _ ## x = (__typeof(_ ## x))[d decodeIntegerForKey:@STRINGIFY(x)]

--- a/ResearchKit/Common/ORKHelpers.h
+++ b/ResearchKit/Common/ORKHelpers.h
@@ -72,8 +72,11 @@
 #define ORK_DECODE_INTEGER(d,x) _ ## x = [d decodeIntegerForKey:@STRINGIFY(x)]
 #define ORK_ENCODE_INTEGER(c,x) [c encodeInteger:_ ## x forKey:@STRINGIFY(x)]
 
-#define ORK_ENCODE_UINT32(c,x) [c encodeObject:[NSNumber numberWithUnsignedLongLong:_ ## x] forKey:@STRINGIFY(x)]
-#define ORK_DECODE_UINT32(d,x) _ ## x = (uint32_t)[(NSNumber *)[d decodeObjectForKey:@STRINGIFY(x)] unsignedLongValue]
+#define ORK_ENCODE_UINT32(c,x) [[c encodeInt32:_ ## x] forKey:@STRINGIFY(x)]
+#define ORK_DECODE_UINT32(d,x) _ ## x = [d decodeInt32ForKey:@STRINGIFY(x)]
+
+#define ORK_ENCODE_UINT64(c,x) [[c encodeInt64:_ ## x] forKey:@STRINGIFY(x)]
+#define ORK_DECODE_UINT64(d,x) _ ## x = [d decodeInt64ForKey:@STRINGIFY(x)]
 
 #define ORK_DECODE_ENUM(d,x)  _ ## x = (__typeof(_ ## x))[d decodeIntegerForKey:@STRINGIFY(x)]
 #define ORK_ENCODE_ENUM(c,x)  [c encodeInteger:(NSInteger)_ ## x forKey:@STRINGIFY(x)]


### PR DESCRIPTION
Use encodeInt32 instead of encoding 32-bit integers as objects, same for 64-bit integers