### PR TITLE
Use ORKTapCountLabel and dynamic text in ORKCountdownView

### DIFF
--- a/ResearchKit/ActiveTasks/ORKCountdownStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKCountdownStepViewController.m
@@ -37,24 +37,15 @@
 #import "ORKResult.h"
 #import "ORKLabel.h"
 #import "ORKSubheadlineLabel.h"
+#import "ORKTapCountLabel.h"
 #import "ORKHelpers.h"
 #import "ORKAccessibility.h"
 #import "ORKActiveStepView.h"
 
-@interface ORKCountDownViewLabel : ORKLabel
-
-@end
-
-@implementation ORKCountDownViewLabel
-+ (UIFont *)defaultFont {
-    return ORKThinFontWithSize(56);
-}
-@end
-
 @interface ORKCountdownView : ORKActiveStepCustomView
 
 @property (nonatomic, strong) ORKSubheadlineLabel *textLabel;
-@property (nonatomic, strong) ORKCountDownViewLabel *timeLabel;
+@property (nonatomic, strong) ORKTapCountLabel *timeLabel;
 @property (nonatomic, strong) UIView *progressView;
 
 - (void)startAnimateWithDuration:(NSTimeInterval)duration;
@@ -76,7 +67,7 @@
         _textLabel.text =  ORKLocalizedString(@"COUNTDOWN_LABEL", nil);
         [self addSubview:_textLabel];
         
-        _timeLabel = [ORKCountDownViewLabel new];
+        _timeLabel = [ORKTapCountLabel new];
         _timeLabel.translatesAutoresizingMaskIntoConstraints = NO;
         _timeLabel.textAlignment = NSTextAlignmentCenter;
         [self addSubview:_timeLabel];
@@ -87,8 +78,10 @@
         
         self.translatesAutoresizingMaskIntoConstraints = NO;
         
-        static const CGFloat ProgressIndicatorDiameter = 104;
+        const CGFloat ProgressIndicatorRadius = _timeLabel.font.pointSize-4.0;
+        const CGFloat ProgressIndicatorDiameter = 2*ProgressIndicatorRadius;        
         static const CGFloat ProgressIndicatorOuterMargin = 1;
+        
         NSDictionary *metrics = @{@"d":@(ProgressIndicatorDiameter+2*ProgressIndicatorOuterMargin)};
         
         NSDictionary *views = NSDictionaryOfVariableBindings(_textLabel, _timeLabel, _progressView);
@@ -124,7 +117,6 @@
                                                         multiplier:1 constant:16-ProgressIndicatorOuterMargin]];
         
         _circleLayer = [CAShapeLayer layer];
-        static const CGFloat ProgressIndicatorRadius = ProgressIndicatorDiameter/2;
         _circleLayer.path = [[UIBezierPath bezierPathWithArcCenter:CGPointMake(ProgressIndicatorRadius+ProgressIndicatorOuterMargin, ProgressIndicatorRadius+ProgressIndicatorOuterMargin)
                                                             radius:ProgressIndicatorRadius
                                                         startAngle:M_PI + M_PI_2


### PR DESCRIPTION
There are two similar label classes: `ORKTapCountLabel` and (private) `ORKCountDownViewLabel`.

The latter seems to be redundant: both create a thin label of size 56 for normal user-selected dynamic text size. This commit gets rid of `ORKCountDownViewLabel` and updates the calculation of progress indicator metrics. 

Although `ORKTapCountLabel` can change size dynamically, this would make no sense for `ORKCountdownView`, since the latter is only shown on the screens where user is actively engaged.

I tested the view via the *Fitness Check Active Task* screen; dynamic text sizes now seem to work.
 
Line-by-line version of the comments in the [source commit](https://github.com/ilyannn/ResearchKit/commit/b5d169fc41efef5373c6466d7faaa4acc060d8d7).