### PR TITLE
Add scroll to visual content screens

### DIFF
--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -727,6 +727,7 @@
 		B1C0F4E21A9BA65F0022C153 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B1C1DE4F196F541F00F75544 /* ResearchKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResearchKit.h; sourceTree = "<group>"; };
 		B1C7955D1A9FBF04007279BA /* HealthKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HealthKit.framework; path = System/Library/Frameworks/HealthKit.framework; sourceTree = SDKROOT; };
+		BCFB2EAF1AE70E4E0070B5D0 /* ORKConsentSceneViewController_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ORKConsentSceneViewController_Internal.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1261,6 +1262,7 @@
 				86C40C0E1A8D7C5C00081FAC /* ORKVisualConsentTransitionAnimator.h */,
 				86C40C0F1A8D7C5C00081FAC /* ORKVisualConsentTransitionAnimator.m */,
 				B12EFF441AB214B400A80147 /* Tinted Animations */,
+				BCFB2EAF1AE70E4E0070B5D0 /* ORKConsentSceneViewController_Internal.h */,
 			);
 			name = "Consent Views";
 			sourceTree = "<group>";

--- a/ResearchKit/Consent/ORKConsentSceneViewController.m
+++ b/ResearchKit/Consent/ORKConsentSceneViewController.m
@@ -1,6 +1,7 @@
 /*
  Copyright (c) 2015, Apple Inc. All rights reserved.
- 
+ Copyright (c) 2015, Ricardo Sánchez-Sáez.
+
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
  

--- a/ResearchKit/Consent/ORKConsentSceneViewController.m
+++ b/ResearchKit/Consent/ORKConsentSceneViewController.m
@@ -174,6 +174,26 @@ static NSString *localizedLearnMoreForType(ORKConsentSectionType sectionType) {
     }
 }
 
+- (void)setScrollEnabled:(BOOL)enabled {
+    ORKConsentSceneView *consentSceneView = (ORKConsentSceneView *)self.view;
+    consentSceneView.scrollEnabled = enabled;
+}
+
+- (void)scrollToTopAnimated:(BOOL)animated {
+    ORKConsentSceneView *consentSceneView = (ORKConsentSceneView *)self.view;
+    CGPoint targetContentOffset = CGPointMake(consentSceneView.contentOffset.x, 0);
+    [consentSceneView setContentOffset:targetContentOffset animated:animated];
+}
+
+- (BOOL)isScrolledToTop {
+    ORKConsentSceneView *consentSceneView = (ORKConsentSceneView *)self.view;
+    return consentSceneView.contentOffset.y == 0;
+}
+
+- (void)setScrollViewDelegate:(id<UIScrollViewDelegate>)delegate {
+    ORKConsentSceneView *consentSceneView = (ORKConsentSceneView *)self.view;
+    consentSceneView.delegate = delegate;
+}
 
 #pragma mark - Action
 

--- a/ResearchKit/Consent/ORKConsentSceneViewController.m
+++ b/ResearchKit/Consent/ORKConsentSceneViewController.m
@@ -174,25 +174,31 @@ static NSString *localizedLearnMoreForType(ORKConsentSectionType sectionType) {
     }
 }
 
+- (BOOL)scrollEnabled {
+    ORKConsentSceneView *consentSceneView = (ORKConsentSceneView *)self.view;
+    return consentSceneView.scrollEnabled;
+}
+
 - (void)setScrollEnabled:(BOOL)enabled {
     ORKConsentSceneView *consentSceneView = (ORKConsentSceneView *)self.view;
     consentSceneView.scrollEnabled = enabled;
 }
 
-- (void)scrollToTopAnimated:(BOOL)animated {
+- (void)scrollToTopAnimated:(BOOL)animated completion:(void (^)(BOOL finished))completion {
     ORKConsentSceneView *consentSceneView = (ORKConsentSceneView *)self.view;
-    CGPoint targetContentOffset = CGPointMake(consentSceneView.contentOffset.x, 0);
-    [consentSceneView setContentOffset:targetContentOffset animated:animated];
-}
-
-- (BOOL)isScrolledToTop {
-    ORKConsentSceneView *consentSceneView = (ORKConsentSceneView *)self.view;
-    return consentSceneView.contentOffset.y == 0;
-}
-
-- (void)setScrollViewDelegate:(id<UIScrollViewDelegate>)delegate {
-    ORKConsentSceneView *consentSceneView = (ORKConsentSceneView *)self.view;
-    consentSceneView.delegate = delegate;
+    CGRect targetBounds = consentSceneView.bounds;
+    targetBounds.origin.y = 0;
+    if (animated) {
+        [UIView animateWithDuration:0.2 animations:^{
+            consentSceneView.bounds = targetBounds;
+        } completion:completion];
+    } else {
+        consentSceneView.bounds = targetBounds;
+        if (completion) {
+            completion(YES);
+        }
+            
+    }
 }
 
 #pragma mark - Action

--- a/ResearchKit/Consent/ORKConsentSceneViewController_Internal.h
+++ b/ResearchKit/Consent/ORKConsentSceneViewController_Internal.h
@@ -32,15 +32,11 @@
 
 #import "ORKStepViewController.h"
 
-NS_ASSUME_NONNULL_BEGIN
-
 @interface ORKConsentSceneViewController ()
 
-- (void)setScrollEnabled:(BOOL)enabled;
-- (void)scrollToTopAnimated:(BOOL)animated;
-- (BOOL)isScrolledToTop;
-- (void)setScrollViewDelegate:(id<UIScrollViewDelegate>)delegate;
+@property (nonatomic, assign) BOOL scrollEnabled;
+
+- (void)scrollToTopAnimated:(BOOL)animated completion:(void (^)(BOOL finished))completion;
 
 @end
 
-NS_ASSUME_NONNULL_END

--- a/ResearchKit/Consent/ORKConsentSceneViewController_Internal.h
+++ b/ResearchKit/Consent/ORKConsentSceneViewController_Internal.h
@@ -1,0 +1,46 @@
+/*
+ Copyright (c) 2015, Ricardo Sánchez-Sáez.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+
+#import "ORKStepViewController.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ORKConsentSceneViewController ()
+
+- (void)setScrollEnabled:(BOOL)enabled;
+- (void)scrollToTopAnimated:(BOOL)animated;
+- (BOOL)isScrolledToTop;
+- (void)setScrollViewDelegate:(id<UIScrollViewDelegate>)delegate;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ResearchKit/Consent/ORKVisualConsentStepViewController.m
+++ b/ResearchKit/Consent/ORKVisualConsentStepViewController.m
@@ -254,27 +254,17 @@
 - (IBAction)next {
     ORKConsentSceneViewController *currentConsentSceneViewController = [self viewControllerForIndex:[self currentIndex]];
     [currentConsentSceneViewController setScrollEnabled:NO];
-    if ([currentConsentSceneViewController isScrolledToTop])
-    {
+    [currentConsentSceneViewController scrollToTopAnimated:YES completion:^(BOOL finished) {
         [self showNextViewController];
-    }
-    else
-    {
-        [currentConsentSceneViewController setScrollViewDelegate:self];
-        [currentConsentSceneViewController scrollToTopAnimated:YES];
-    }
-}
-
-- (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView {
-    self.delegate = nil;
-    [self showNextViewController];
+    }];
 }
 
 - (void)showNextViewController {
     ORKConsentSceneViewController *nextConsentSceneViewController = [self viewControllerForIndex:[self currentIndex]+1];
-    [nextConsentSceneViewController scrollToTopAnimated:NO];
-    [self showViewController:nextConsentSceneViewController forward:YES animated:YES];
-    ORKAccessibilityPostNotificationAfterDelay(UIAccessibilityScreenChangedNotification, nil, 0.5);
+    [nextConsentSceneViewController scrollToTopAnimated:NO completion:^(BOOL finished) {
+        [self showViewController:nextConsentSceneViewController forward:YES animated:YES];
+        ORKAccessibilityPostNotificationAfterDelay(UIAccessibilityScreenChangedNotification, nil, 0.5);
+    }];
 }
 
 #pragma mark - internal
@@ -304,8 +294,7 @@
     _currentPage = currentIndex;
     
     [self updateBackButton];
-    [self setScrollEnabled:NO];
-    
+
     [[self viewControllerForIndex:currentIndex] setScrollEnabled:YES];
     
     ORKConsentSection *currentSection = (ORKConsentSection *)_visualSections[currentIndex];

--- a/ResearchKit/Consent/ORKVisualConsentStepViewController.m
+++ b/ResearchKit/Consent/ORKVisualConsentStepViewController.m
@@ -48,7 +48,7 @@
 #import "ORKContinueButton.h"
 #import "ORKAccessibility.h"
 
-@interface ORKVisualConsentStepViewController () <UIPageViewControllerDelegate, UIScrollViewDelegate>
+@interface ORKVisualConsentStepViewController () <UIPageViewControllerDelegate>
 {
     BOOL _hasAppeared;
     ORKStepViewControllerNavigationDirection _navDirection;
@@ -246,7 +246,6 @@
 #pragma mark - actions
 
 - (IBAction)goToPreviousPage {
-    
     [self showViewController:[self viewControllerForIndex:[self currentIndex]-1] forward:NO animated:YES];
     UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
 }
@@ -255,13 +254,18 @@
     ORKConsentSceneViewController *currentConsentSceneViewController = [self viewControllerForIndex:[self currentIndex]];
     [currentConsentSceneViewController setScrollEnabled:NO];
     [currentConsentSceneViewController scrollToTopAnimated:YES completion:^(BOOL finished) {
-        [self showNextViewController];
+        if (finished) {
+            [self showNextViewController];
+        } else {
+            [currentConsentSceneViewController setScrollEnabled:YES];
+        }
     }];
 }
 
 - (void)showNextViewController {
     ORKConsentSceneViewController *nextConsentSceneViewController = [self viewControllerForIndex:[self currentIndex]+1];
     [nextConsentSceneViewController scrollToTopAnimated:NO completion:^(BOOL finished) {
+        // 'finished' is always YES when not animated
         [self showViewController:nextConsentSceneViewController forward:YES animated:YES];
         ORKAccessibilityPostNotificationAfterDelay(UIAccessibilityScreenChangedNotification, nil, 0.5);
     }];

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -1606,8 +1606,9 @@ static NSString * const TwoFingerTapTaskIdentifier = @"tap";
     
     NSMutableArray *sections = [NSMutableArray new];
     for (NSNumber *type in scenes) {
+        NSString *summary = @"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam adhuc, meo fortasse vitio, quid ego quaeram non perspicis. Plane idem, inquit, et maxima quidem, qua fieri nulla maior potest. Quonam, inquit, modo? An potest, inquit ille, quicquam esse suavius quam nihil dolere? Cave putes quicquam esse verius. Quonam, inquit, modo? Et doming eirmod delicata cum. Vel fabellas scribentur neglegentur cu, pro te iudicabit explicari. His alia idque scriptorem ei, quo no nominavi noluisse.";
         ORKConsentSection *c = [[ORKConsentSection alloc] initWithType:type.integerValue];
-        c.summary = @"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+        c.summary = summary;
         
         if (type.integerValue == ORKConsentSectionTypeOverview) {
             /*

--- a/samples/ORKCatalog/ORKCatalog/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/TaskListRow.swift
@@ -764,13 +764,13 @@ enum TaskListRow: Int, Printable {
         var consentSections: [ORKConsentSection] = consentSectionTypes.map { contentSectionType in
             let consentSection = ORKConsentSection(type: contentSectionType)
             
-            consentSection.summary = self.loremIpsumLongText
+            consentSection.summary = self.loremIpsumShortText
             
             if contentSectionType == .Overview {
                 consentSection.htmlContent = htmlContentString
             }
             else {
-                consentSection.content = self.loremIpsumVeryLongText
+                consentSection.content = self.loremIpsumLongText
             }
             
             return consentSection
@@ -825,10 +825,6 @@ enum TaskListRow: Int, Printable {
     
     private var loremIpsumLongText: String {
         return "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam adhuc, meo fortasse vitio, quid ego quaeram non perspicis. Plane idem, inquit, et maxima quidem, qua fieri nulla maior potest. Quonam, inquit, modo? An potest, inquit ille, quicquam esse suavius quam nihil dolere? Cave putes quicquam esse verius. Quonam, inquit, modo?"
-    }
-
-    private var loremIpsumVeryLongText: String {
-        return "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam adhuc, meo fortasse vitio, quid ego quaeram non perspicis. Plane idem, inquit, et maxima quidem, qua fieri nulla maior potest. Quonam, inquit, modo? An potest, inquit ille, quicquam esse suavius quam nihil dolere? Cave putes quicquam esse verius. Quonam, inquit, modo? Et doming eirmod delicata cum. Vel fabellas scribentur neglegentur cu, pro te iudicabit explicari. His alia idque scriptorem ei, quo no nominavi noluisse."
     }
 }
     

--- a/samples/ORKCatalog/ORKCatalog/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/TaskListRow.swift
@@ -764,13 +764,13 @@ enum TaskListRow: Int, Printable {
         var consentSections: [ORKConsentSection] = consentSectionTypes.map { contentSectionType in
             let consentSection = ORKConsentSection(type: contentSectionType)
             
-            consentSection.summary = self.loremIpsumShortText
+            consentSection.summary = self.loremIpsumLongText
             
             if contentSectionType == .Overview {
                 consentSection.htmlContent = htmlContentString
             }
             else {
-                consentSection.content = self.loremIpsumLongText
+                consentSection.content = self.loremIpsumVeryLongText
             }
             
             return consentSection
@@ -825,6 +825,10 @@ enum TaskListRow: Int, Printable {
     
     private var loremIpsumLongText: String {
         return "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam adhuc, meo fortasse vitio, quid ego quaeram non perspicis. Plane idem, inquit, et maxima quidem, qua fieri nulla maior potest. Quonam, inquit, modo? An potest, inquit ille, quicquam esse suavius quam nihil dolere? Cave putes quicquam esse verius. Quonam, inquit, modo?"
+    }
+
+    private var loremIpsumVeryLongText: String {
+        return "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam adhuc, meo fortasse vitio, quid ego quaeram non perspicis. Plane idem, inquit, et maxima quidem, qua fieri nulla maior potest. Quonam, inquit, modo? An potest, inquit ille, quicquam esse suavius quam nihil dolere? Cave putes quicquam esse verius. Quonam, inquit, modo? Et doming eirmod delicata cum. Vel fabellas scribentur neglegentur cu, pro te iudicabit explicari. His alia idque scriptorem ei, quo no nominavi noluisse."
     }
 }
     


### PR DESCRIPTION
Stab at doing [Issue #68](https://github.com/ResearchKit/ResearchKit/issues/68).

Adds `ORKConsentSceneViewController_Internal.h` file with convenience methods to enable/disable scrolling, scroll to top, and set the `scrollView` `delegate`.

Modifies `ORKVisualConsentStepViewController` so:
- `ORKConsentSceneViewController` scrolling is enabled only after overlay animation completes (`updatePageIndex` method)
- Current `ORKConsentSceneViewController` scrolls to top in animated fashion before transitioning to next page
- Makes sure next `ORKConsentSceneViewController` is always scrolled to top (guards against going forward, scrolling downward, going back, and going forward again)
- Disregards scrolling when going back

I made the sample *lorem ipsilum* text in `ORKCatalog`'s *Consent task* longer: scrolling can be tested on iPhone 4 and iPhone 5 screens. 