### PR TITLE
Remove unnecessary casts

### DIFF
--- a/ResearchKit/ActiveTasks/HKSample+ORKJSONDictionary.m
+++ b/ResearchKit/ActiveTasks/HKSample+ORKJSONDictionary.m
@@ -44,16 +44,9 @@ static NSString *const kHKCorrelatedObjectsKey = @"objects";
 // static NSString *const kHKSourceIdentifierKey = @"sourceBundleIdentifier";
 
 
-@interface HKSample ()
-
-- (NSMutableDictionary *)ork_JSONMutableDictionaryWithOptions:(ORKSampleJSONOptions)options unit:(HKUnit *)unit;
-
-@end
-
-
 @implementation HKSample (ORKJSONDictionary)
 
-- (NSDictionary *)ork_JSONMutableDictionaryWithOptions:(ORKSampleJSONOptions)options unit:(HKUnit *)unit {
+- (NSMutableDictionary *)ork_JSONMutableDictionaryWithOptions:(ORKSampleJSONOptions)options unit:(HKUnit *)unit {
     NSMutableDictionary *mutableDictionary = [NSMutableDictionary dictionaryWithCapacity:12];
     
     // Type identification

--- a/ResearchKit/ActiveTasks/HKSample+ORKJSONDictionary.m
+++ b/ResearchKit/ActiveTasks/HKSample+ORKJSONDictionary.m
@@ -142,6 +142,7 @@ static NSString *const kHKCorrelatedObjectsKey = @"objects";
 
 - (NSDictionary *)ork_JSONDictionaryWithOptions:(ORKSampleJSONOptions)options sampleTypes:(NSArray *)sampleTypes units:(NSArray *)units {
     NSMutableDictionary *mdict = (NSMutableDictionary *)[self ork_JSONDictionaryWithOptions:options unit:nil];
+    NSAssert([mdict isKindOfClass:[NSMutableDictionary class]], @"");
     
     // The correlated objects
     NSMutableArray *correlatedObjects = [NSMutableArray arrayWithCapacity:[sampleTypes count]];

--- a/ResearchKit/ActiveTasks/ORKActiveStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKActiveStepViewController.m
@@ -324,7 +324,7 @@
         // Let VO speak "Step x of y" before the instruction.
         // If VO is not running, the text is spoken immediately.
         ORKAccessibilityPerformBlockAfterDelay(1.5, ^{
-            [[ORKVoiceEngine sharedVoiceEngine] speakText:(NSString *__nonnull)self.activeStep.spokenInstruction];
+            [[ORKVoiceEngine sharedVoiceEngine] speakText:self.activeStep.spokenInstruction];
         });
     }
 }

--- a/ResearchKit/ActiveTasks/ORKSpatialSpanMemoryStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKSpatialSpanMemoryStepViewController.m
@@ -207,7 +207,7 @@ typedef void (^_ORKStateHandler)(ORKState *fromState, ORKState *_toState, id con
     
     NSMutableArray *results = [NSMutableArray arrayWithArray:sResult.results];
     
-    ORKSpatialSpanMemoryResult *memoryResult = [[ORKSpatialSpanMemoryResult alloc] initWithIdentifier:(NSString *__nonnull)self.step.identifier];
+    ORKSpatialSpanMemoryResult *memoryResult = [[ORKSpatialSpanMemoryResult alloc] initWithIdentifier:self.step.identifier];
     memoryResult.startDate = sResult.startDate;
     memoryResult.endDate = now;
     

--- a/ResearchKit/ActiveTasks/ORKTappingIntervalStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKTappingIntervalStepViewController.m
@@ -119,7 +119,7 @@
     
     NSMutableArray *results = [NSMutableArray arrayWithArray:sResult.results];
     
-    ORKTappingIntervalResult *tappingResult = [[ORKTappingIntervalResult alloc] initWithIdentifier:(NSString *__nonnull)self.step.identifier];
+    ORKTappingIntervalResult *tappingResult = [[ORKTappingIntervalResult alloc] initWithIdentifier:self.step.identifier];
     tappingResult.startDate = sResult.startDate;
     tappingResult.endDate = now;
     tappingResult.buttonRect1 = _buttonRect1;

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -963,7 +963,7 @@ static NSArray *ork_processTextChoices(NSArray *textChoices) {
 }
 
 - (NSCalendar *)currentCalendar {
-    return (NSCalendar *__nonnull)(_calendar ? : [NSCalendar currentCalendar]);
+    return (_calendar ? : [NSCalendar currentCalendar]);
 }
 
 - (NSDateFormatter *)resultDateFormatter {
@@ -1001,7 +1001,7 @@ static NSArray *ork_processTextChoices(NSArray *textChoices) {
 }
 
 - (NSDate *)pickerDefaultDate {
-    return (NSDate *__nonnull)(self.defaultDate ? : [NSDate date]);
+    return (self.defaultDate ? : [NSDate date]);
    
 }
 

--- a/ResearchKit/Common/ORKCompletionStepViewController.m
+++ b/ResearchKit/Common/ORKCompletionStepViewController.m
@@ -106,7 +106,7 @@ static const CGFloat TickViewSize = 122;
     CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"strokeEnd"];
     [animation setTimingFunction:timing];
     [animation setFillMode:kCAFillModeBoth];
-    animation.fromValue = @( [(CAShapeLayer *)[_shapeLayer presentationLayer] strokeEnd]);
+    animation.fromValue = @([(CAShapeLayer *)[_shapeLayer presentationLayer] strokeEnd]);
     animation.toValue = @(animationPoint);
     
     animation.duration = 0.3;

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -641,7 +641,7 @@
         }
         else if ([impliedAnswerFormat isKindOfClass:[ORKNumericAnswerFormat class]]) {
             ORKNumericQuestionResult *nqr = (ORKNumericQuestionResult *)result;
-            nqr.unit = (NSString *__nonnull)[(ORKNumericAnswerFormat *)impliedAnswerFormat unit];
+            nqr.unit = [(ORKNumericAnswerFormat *)impliedAnswerFormat unit];
         }
         
         result.startDate = answerDate;

--- a/ResearchKit/Common/ORKQuestionStepViewController.m
+++ b/ResearchKit/Common/ORKQuestionStepViewController.m
@@ -392,7 +392,7 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
     ORKStepResult *sResult = [super result];
     ORKQuestionStep *questionStep = self.questionStep;
     
-    ORKQuestionResult *result = [questionStep.answerFormat resultWithIdentifier:(NSString *__nonnull)questionStep.identifier answer:self.answer];
+    ORKQuestionResult *result = [questionStep.answerFormat resultWithIdentifier:questionStep.identifier answer:self.answer];
     ORKAnswerFormat *impliedAnswerFormat = [questionStep impliedAnswerFormat];
     
     if ([impliedAnswerFormat isKindOfClass:[ORKDateAnswerFormat class]]) {
@@ -404,7 +404,7 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
         }
     } else if ([impliedAnswerFormat isKindOfClass:[ORKNumericAnswerFormat class]]) {
         ORKNumericQuestionResult *nqr = (ORKNumericQuestionResult *)result;
-        nqr.unit = (NSString *__nonnull)[(ORKNumericAnswerFormat *)impliedAnswerFormat unit];
+        nqr.unit = [(ORKNumericAnswerFormat *)impliedAnswerFormat unit];
     }
     
     result.startDate = sResult.startDate;

--- a/ResearchKit/Common/ORKStepViewController.m
+++ b/ResearchKit/Common/ORKStepViewController.m
@@ -258,7 +258,7 @@
 
 - (ORKStepResult *)result {
     
-    ORKStepResult *sResult = [[ORKStepResult alloc] initWithStepIdentifier:(NSString *__nonnull)self.step.identifier results:@[]];
+    ORKStepResult *sResult = [[ORKStepResult alloc] initWithStepIdentifier:self.step.identifier results:@[]];
     sResult.startDate = self.presentedDate;
     sResult.endDate = self.dismissedDate? :[NSDate date];
     

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -708,7 +708,7 @@ static NSString * const _ChildNavigationControllerRestorationKey = @"childNaviga
 
 - (ORKTaskResult *)result {
     
-    ORKTaskResult *result = [[ORKTaskResult alloc] initWithTaskIdentifier:(NSString *__nonnull)[self.task identifier] taskRunUUID:self.taskRunUUID outputDirectory:self.outputDirectory];
+    ORKTaskResult *result = [[ORKTaskResult alloc] initWithTaskIdentifier:[self.task identifier] taskRunUUID:self.taskRunUUID outputDirectory:self.outputDirectory];
     result.startDate = _presentedDate;
     result.endDate = _dismissedDate ? :[NSDate date];
     
@@ -889,7 +889,7 @@ static NSString * const _ChildNavigationControllerRestorationKey = @"childNaviga
     
     NSString *progressLabel = nil;
     if (self.showsProgressInNavigationBar && [_task respondsToSelector:@selector(progressOfCurrentStep:withResult:)]) {
-        ORKTaskProgress progress = [_task progressOfCurrentStep:(ORKStep *__nonnull)viewController.step withResult:[self result]];
+        ORKTaskProgress progress = [_task progressOfCurrentStep:viewController.step withResult:[self result]];
 
         if (progress.total > 0) {
             progressLabel = [NSString stringWithFormat:ORKLocalizedString(@"STEP_PROGRESS_FORMAT", nil) ,(unsigned long)progress.current+1, (unsigned long)progress.total];
@@ -1106,7 +1106,7 @@ static NSString * const _ChildNavigationControllerRestorationKey = @"childNaviga
 
 - (IBAction)learnMoreAction:(id)sender {
     if (self.delegate && [self.delegate respondsToSelector:@selector(taskViewController:learnMoreForStep:)]) {
-        [self.delegate taskViewController:self learnMoreForStep:(ORKStepViewController *__nonnull)self.currentStepViewController];
+        [self.delegate taskViewController:self learnMoreForStep:self.currentStepViewController];
     }
 }
 
@@ -1345,7 +1345,7 @@ static NSString * const _ORKPresentedDate = @"presentedDate";
             }
             
             if ([self.delegate respondsToSelector:@selector(taskViewController:hasLearnMoreForStep:)] &&
-                [self.delegate taskViewController:self hasLearnMoreForStep:(ORKStep *__nonnull)stepViewController.step]) {
+                [self.delegate taskViewController:self hasLearnMoreForStep:stepViewController.step]) {
                 
                 stepViewController.learnMoreButtonItem = [self defaultLearnMoreButtonItem];
             }

--- a/ResearchKit/Consent/ORKConsentSceneViewController.m
+++ b/ResearchKit/Consent/ORKConsentSceneViewController.m
@@ -195,7 +195,7 @@ static NSString *localizedLearnMoreForType(ORKConsentSectionType sectionType) {
 
 - (IBAction)showContent:(id)sender {
 
-    ORKConsentLearnMoreViewController *vc = [[ORKConsentLearnMoreViewController alloc] initWithHTMLContent:(NSString *__nonnull)((_section.htmlContent.length > 0)?_section.htmlContent : _section.escapedContent)];
+    ORKConsentLearnMoreViewController *vc = [[ORKConsentLearnMoreViewController alloc] initWithHTMLContent:((_section.htmlContent.length > 0) ? _section.htmlContent : _section.escapedContent)];
     vc.title = ORKLocalizedString(@"CONSENT_LEARN_MORE_TITLE", nil);
     UINavigationController *navc = [[UINavigationController alloc] initWithRootViewController:vc];
     [self presentViewController:navc animated:YES completion:nil];

--- a/Testing/ORKTest/ORKTest/DynamicTask.m
+++ b/Testing/ORKTest/ORKTest/DynamicTask.m
@@ -107,7 +107,7 @@
     } else if ([ident isEqualToString:self.step3a.identifier] || [ident isEqualToString:self.step3b.identifier]) {
         return self.step2;
     } else if ([ident isEqualToString:self.step4.identifier] ) {
-        ORKQuestionResult *questionResult = (ORKQuestionResult *)[(ORKStepResult *)[result stepResultForStepIdentifier:self.step3a.identifier] firstResult];
+        ORKQuestionResult *questionResult = (ORKQuestionResult *)[[result stepResultForStepIdentifier:self.step3a.identifier] firstResult];
         
         if (questionResult != nil) {
              return self.step3a;


### PR DESCRIPTION
I have removed some seemingly unnecessary casts (and added an assert for an indirect assumption-based `NSDictionary` -> `NSMutableDictionary` cast). Removing these produces no warnings (nor static analyzer warnings), and all tests continue to pass.

If these were intentional, feel free to just close this pull request instead.