### PR TITLE
Use ORKStrongify() and ORKWeakify() macros to avoid retain cycles in blocks

### DIFF
--- a/ResearchKit/ActiveTasks/ORKActiveStepTimer.m
+++ b/ResearchKit/ActiveTasks/ORKActiveStepTimer.m
@@ -29,6 +29,7 @@
  */
 
 #import "ORKActiveStepTimer.h"
+#import "ORKHelpers.h"
 #include <mach/mach.h>
 #include <mach/mach_time.h>
 #import <UIKit/UIKit.h>
@@ -199,10 +200,10 @@ static NSTimeInterval timeIntervalFromMachTime(uint64_t delta) {
         assert(0);
         return;
     }
-    __weak typeof(self) weakSelf = self;
+    ORKWeakify(self);
     dispatch_source_set_event_handler(_timer, ^{
-        typeof(self) strongSelf = weakSelf;
-        [strongSelf hiqueue_event];
+        ORKStrongify(self);
+        [selfStrong hiqueue_event];
     });
     
     NSTimeInterval timeUntilNextFire = (floor(_preExistingRuntime / _interval) + 1)*_interval -  _preExistingRuntime;

--- a/ResearchKit/ActiveTasks/ORKActiveStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKActiveStepViewController.m
@@ -399,13 +399,13 @@
     
     if (stepDuration > 0) {
         
-        __weak typeof(self) weakSelf = self;
+        ORKWeakify(self);
         _activeStepTimer = [[ORKActiveStepTimer alloc] initWithDuration:stepDuration
                                                         interval:_timerUpdateInterval
                                                          runtime:0
                                                          handler:^(ORKActiveStepTimer *timer, BOOL finished) {
-                                                             typeof(self) strongSelf = weakSelf;
-                                                             [strongSelf countDownTimerFired:timer finished:finished];
+                                                             ORKStrongify(self);
+                                                             [selfStrong countDownTimerFired:timer finished:finished];
                                                          }];
         [_activeStepTimer resume];
     }

--- a/ResearchKit/ActiveTasks/ORKAudioStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKAudioStepViewController.m
@@ -116,12 +116,12 @@
     if (! _timer) {
         
         NSTimeInterval duration = self.audioStep.duration;
-        __weak typeof(self) weakSelf = self;
+        ORKWeakify(self);
         _timer = [[ORKActiveStepTimer alloc] initWithDuration:duration interval:duration/100 runtime:0 handler:^(ORKActiveStepTimer *timer, BOOL finished) {
-            typeof(self) strongSelf = weakSelf;
-            [strongSelf doSample];
+            ORKStrongify(self);
+            [selfStrong doSample];
             if (finished) {
-                [strongSelf finish];
+                [selfStrong finish];
             }
         }];
         [_timer resume];

--- a/ResearchKit/ActiveTasks/ORKDataLogger.m
+++ b/ResearchKit/ActiveTasks/ORKDataLogger.m
@@ -536,10 +536,10 @@ static NSInteger _ORKJSON_terminatorLength = 0;
     
     if (_directorySource) {
         dispatch_source_set_cancel_handler(_directorySource, ^{ close(dirFD); });
-        __weak __typeof(self) weakSelf = self;
+        ORKWeakify(self);
         dispatch_source_set_event_handler(_directorySource, ^{
-            __strong __typeof(self) strongSelf = weakSelf;
-            [strongSelf directoryUpdated];
+            ORKStrongify(self);
+            [selfStrong directoryUpdated];
         });
         dispatch_resume(_directorySource);
     }

--- a/ResearchKit/ActiveTasks/ORKHealthQuantityTypeRecorder.m
+++ b/ResearchKit/ActiveTasks/ORKHealthQuantityTypeRecorder.m
@@ -132,7 +132,7 @@ static const NSInteger _HealthAnchoredQueryLimit = 100;
     NSAssert(_samplePredicate != nil, @"Sample predicate should be non-nil if recording");
     
     
-    __weak typeof(self) weakSelf = self;
+    ORKWeakify(self);
     HKAnchoredObjectQuery *anchoredQuery = [[HKAnchoredObjectQuery alloc]
                                             initWithType:_quantityType
                                             predicate:_samplePredicate
@@ -146,8 +146,8 @@ static const NSInteger _HealthAnchoredQueryLimit = 100;
                                                     return;
                                                 }
                                                 
-                                                __typeof(self) strongSelf = weakSelf;
-                                                [strongSelf query_logResults:results withAnchor:newAnchor];
+                                                ORKStrongify(self);
+                                                [selfStrong query_logResults:results withAnchor:newAnchor];
                                                 
                                             }];
     [_healthStore executeQuery:anchoredQuery];
@@ -201,18 +201,17 @@ static const NSInteger _HealthAnchoredQueryLimit = 100;
     
     NSAssert(!_observerQuery, @"observer query should not exist if not recording");
     
-    __weak __typeof(self) weakSelf = self;
+    ORKWeakify(self);
     _observerQuery = [[HKObserverQuery alloc]
                       initWithSampleType:_quantityType
                       predicate:_samplePredicate
                       updateHandler:^(HKObserverQuery *query, HKObserverQueryCompletionHandler completionHandler, NSError *error) {
-                          __typeof(self) strongSelf = weakSelf;
-                          
+                          ORKStrongify(self);
                           dispatch_async(dispatch_get_main_queue(), ^{
                               if (error) {
-                                  [strongSelf finishRecordingWithError:error];
+                                  [selfStrong finishRecordingWithError:error];
                               } else {
-                                  [strongSelf doFetchNewData];
+                                  [selfStrong doFetchNewData];
                               }
                           });
                           

--- a/ResearchKit/ActiveTasks/ORKPedometerRecorder.m
+++ b/ResearchKit/ActiveTasks/ORKPedometerRecorder.m
@@ -33,6 +33,7 @@
 #import "CMPedometerData+ORKJSONDictionary.h"
 #import "ORKRecorder_Internal.h"
 #import "ORKRecorder_Private.h"
+#import "ORKHelpers.h"
 
 @interface ORKPedometerRecorder() {
     ORKDataLogger *_logger;
@@ -113,21 +114,21 @@
     }
 
     _isRecording = YES;
-    __weak __typeof(self) weakSelf = self;
+    ORKWeakify(self);
     [self.pedometer startPedometerUpdatesFromDate:[NSDate date] withHandler:^(CMPedometerData *pedometerData, NSError *error) {
         
         BOOL success = NO;
         if (pedometerData) {
             success = [_logger append:[pedometerData ork_JSONDictionary] error:&error];
             dispatch_async(dispatch_get_main_queue(), ^{
-                __typeof(self) strongSelf = weakSelf;
-                [strongSelf updateStatisticsWithData:pedometerData];
+                ORKStrongify(self);
+                [selfStrong updateStatisticsWithData:pedometerData];
             });
         }
         if (!success || error) {
             dispatch_async(dispatch_get_main_queue(), ^{
-                __typeof(self) strongSelf = weakSelf;
-                [strongSelf finishRecordingWithError:error];
+                ORKStrongify(self);
+                [selfStrong finishRecordingWithError:error];
             });
         }
     }];

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -339,7 +339,7 @@
 - (void)refreshDefaults {
     NSArray *formItems = [self formItems];
     ORKAnswerDefaultSource *source = _defaultSource;
-    __weak typeof(self) weakSelf = self;
+    ORKWeakify(self);
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
         dispatch_semaphore_t sem = dispatch_semaphore_create(0);
         __block NSMutableDictionary *defaults = [NSMutableDictionary dictionary];
@@ -360,8 +360,8 @@
         
         // All fetches have completed.
         dispatch_async(dispatch_get_main_queue(), ^{
-            __strong typeof(weakSelf) strongSelf = weakSelf;
-            [strongSelf updateDefaults:defaults];
+            ORKStrongify(self);
+            [selfStrong updateDefaults:defaults];
         });
         
     });

--- a/ResearchKit/Common/ORKHelpers.h
+++ b/ResearchKit/Common/ORKHelpers.h
@@ -202,3 +202,6 @@ id ORKDynamicCast_(id x, Class objClass);
 #define ORKDynamicCast(x, c) ((c *) ORKDynamicCast_(x, [c class]))
 
 const CGFloat ORKScrollToTopAnimationDuration;
+
+#define ORKWeakify(VARIABLE)    __weak typeof(VARIABLE) VARIABLE##Weak = VARIABLE
+#define ORKStrongify(VARIABLE)  __strong typeof(VARIABLE##Weak) VARIABLE##Strong = VARIABLE##Weak

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -881,8 +881,6 @@ static NSString * const _ChildNavigationControllerRestorationKey = @"childNaviga
         _lastRestorableStepIdentifier = step.identifier;
     }
     
-    __weak typeof(self) weakSelf = self;
-    
     UIPageViewControllerNavigationDirection direction = goForward?UIPageViewControllerNavigationDirectionForward:UIPageViewControllerNavigationDirectionReverse;
     
     ORKStepViewControllerNavigationDirection stepDirection = goForward?ORKStepViewControllerNavigationDirectionForward : ORKStepViewControllerNavigationDirectionReverse;
@@ -911,21 +909,21 @@ static NSString * const _ChildNavigationControllerRestorationKey = @"childNaviga
     // from the same VC.
     _currentStepViewController = viewController;
     
+    ORKWeakify(self);
     [self.pageViewController setViewControllers:@[viewController] direction:direction animated:animated completion:^(BOOL finished) {
+        ORKStrongify(self);
         
-        __strong typeof(weakSelf) strongSelf = weakSelf;
-        
-        ORK_Log_Debug(@"%@ %@", strongSelf, viewController);
+        ORK_Log_Debug(@"%@ %@", selfStrong, viewController);
         
         // Set the progress label only if non-nil or if it is nil having previously set a progress label.
-        if (progressLabel || strongSelf->_haveSetProgressLabel) {
-            strongSelf.pageViewController.navigationItem.title = progressLabel;
+        if (progressLabel || selfStrong->_haveSetProgressLabel) {
+            selfStrong.pageViewController.navigationItem.title = progressLabel;
         }
         
-        strongSelf->_haveSetProgressLabel = (progressLabel != nil);
+        selfStrong->_haveSetProgressLabel = (progressLabel != nil);
         
         // Collect toolbarItems
-        [strongSelf collectToolbarItemsFromViewController:viewController];
+        [selfStrong collectToolbarItemsFromViewController:viewController];
     }];
     
 }

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -383,23 +383,23 @@ static NSString * const _FamilyNameIdentifier = @"family";
     
     UIPageViewControllerNavigationDirection direction = (!animated || page > currentIndex)?UIPageViewControllerNavigationDirectionForward:UIPageViewControllerNavigationDirectionReverse;
     _currentPageIndex = page;
-    __weak typeof(self) weakSelf = self;
     
     //unregister ScrollView to clear hairline
     [self.taskViewController setRegisteredScrollView:nil];
     
+    ORKWeakify(self);
     [_pageViewController setViewControllers:@[viewController] direction:direction animated:animated completion:^(BOOL finished) {
         if (finished){
-            STRONGTYPE(weakSelf) strongSelf = weakSelf;
-            [strongSelf updateBackButton];
+            ORKStrongify(self);
+            [selfStrong updateBackButton];
             
             //register ScrollView to update hairline
             if ([viewController isKindOfClass:[ORKConsentReviewController class]]) {
                 ORKConsentReviewController *reviewVc =  (ORKConsentReviewController *)viewController;
-                [strongSelf.taskViewController setRegisteredScrollView:reviewVc.webView.scrollView];
+                [selfStrong.taskViewController setRegisteredScrollView:reviewVc.webView.scrollView];
             }
             
-            UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, strongSelf.navigationItem.leftBarButtonItem);
+            UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, selfStrong.navigationItem.leftBarButtonItem);
         }
     }];
 }

--- a/ResearchKit/Consent/ORKVisualConsentStepViewController.m
+++ b/ResearchKit/Consent/ORKVisualConsentStepViewController.m
@@ -366,9 +366,9 @@
 
 - (ORKVisualConsentTransitionAnimator *)doAnimateFromViewController:(ORKConsentSceneViewController *)fromController toController:(ORKConsentSceneViewController *)viewController direction:(UIPageViewControllerNavigationDirection)direction semaphore:(dispatch_semaphore_t)sem url:(NSURL *)url animateBeforeTransition:(BOOL)animateBeforeTransition transitionBeforeAnimate:(BOOL)transitionBeforeAnimate {
     
-    __weak typeof(self) weakSelf = self;
     _animator = [[ORKVisualConsentTransitionAnimator alloc] initWithVisualConsentStepViewController:self movieURL:url];
-    
+
+    ORKWeakify(self);
     [_animator animateTransitionWithDirection:direction
                                           withLoadHandler:^(ORKVisualConsentTransitionAnimator *animator, UIPageViewControllerNavigationDirection direction) {
                                               fromController.imageHidden = YES;
@@ -376,23 +376,23 @@
                                               
                                               if (!animateBeforeTransition && !transitionBeforeAnimate) {
                                                   dispatch_async(dispatch_get_main_queue(), ^{
-                                                      __strong typeof(self) strongSelf = weakSelf;
-                                                      [strongSelf doShowViewController:viewController direction:direction animated:YES semaphore:sem];                                         });
+                                                      ORKStrongify(self);
+                                                      [selfStrong doShowViewController:viewController direction:direction animated:YES semaphore:sem];                                         });
                                               }
                                           }
                                         completionHandler:^(ORKVisualConsentTransitionAnimator *animator, UIPageViewControllerNavigationDirection direction) {
                                             
                                             if (animateBeforeTransition && !transitionBeforeAnimate) {
                                                 dispatch_async(dispatch_get_main_queue(), ^{
-                                                    __strong typeof(self) strongSelf = weakSelf;
-                                                    [strongSelf doShowViewController:viewController direction:direction animated:YES semaphore:sem];                                         });
+                                                    ORKStrongify(self);
+                                                    [selfStrong doShowViewController:viewController direction:direction animated:YES semaphore:sem];                                         });
                                             } else {
                                                 viewController.imageHidden = NO;
                                                 fromController.imageHidden = NO;
                                             }
                                             
-                                            __strong typeof(self) strongSelf = weakSelf;
-                                            [strongSelf finishTransitioningAnimator:animator];
+                                            ORKStrongify(self);
+                                            [selfStrong finishTransitioningAnimator:animator];
 
                                             dispatch_semaphore_signal(sem);
                                         }];
@@ -499,10 +499,10 @@
         _transitioning = YES;
         
         
-        __weak typeof(self) weakSelf = self;
+        ORKWeakify(self);
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
             // Defensive timeouts
-            typeof(self) strongSelf = weakSelf;
+            ORKStrongify(self);
             
             dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 5));
             
@@ -510,7 +510,7 @@
             
             if (url && transitionBeforeAnimate) {
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    animator = [strongSelf doAnimateFromViewController:fromController
+                    animator = [selfStrong doAnimateFromViewController:fromController
                                                            toController:viewController
                                                               direction:direction
                                                               semaphore:sem
@@ -523,16 +523,16 @@
             dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 5));
             
             dispatch_async(dispatch_get_main_queue(), ^{
-                __strong typeof(self) strongSelf = weakSelf;
+                ORKStrongify(self);
                 
                 viewController.imageHidden = NO;
                 fromController.imageHidden = NO;
                 
                 if (animator) {
-                    [strongSelf finishTransitioningAnimator:animator];
+                    [selfStrong finishTransitioningAnimator:animator];
                 }
                 
-                [strongSelf updatePageIndex];
+                [selfStrong updatePageIndex];
             });
         });
         

--- a/ResearchKit/Consent/ORKVisualConsentTransitionAnimator.m
+++ b/ResearchKit/Consent/ORKVisualConsentTransitionAnimator.m
@@ -197,8 +197,6 @@
 
 - (void)performAnimationWithContext:(ORKVisualConsentAnimationContext *)context {
     AVPlayer *moviePlayer = _moviePlayer;
-
-    __weak AVPlayer *weakPlayer = moviePlayer;
     
     _pendingContext = context;
     
@@ -208,10 +206,11 @@
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(playbackDidFinish:) name:AVPlayerItemFailedToPlayToEndTimeNotification object:[moviePlayer currentItem]];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(playbackDidFinish:) name:AVPlayerItemPlaybackStalledNotification object:[moviePlayer currentItem]];
     
+    ORKWeakify(moviePlayer);
     [moviePlayer seekToTime:[context.startTime CMTimeValue]
             toleranceBefore:CMTimeMake(NSEC_PER_SEC*1/60, NSEC_PER_SEC) toleranceAfter:CMTimeMake(NSEC_PER_SEC*1/60, NSEC_PER_SEC)  completionHandler:^(BOOL finished) {
-                AVPlayer *localPlayer = weakPlayer;
-                [localPlayer play];
+                ORKStrongify(moviePlayer);
+                [moviePlayerStrong play];
             }];
 }
 


### PR DESCRIPTION
I replaced all `__weak typeof(self) weakSelf = self`and `typeof(self) strongSelf = weakSelf` declarations for block use by the new `ORKStrongify()` and `ORKWeakify()` macros.

I feel this is less verbose and less error prone.