### PR TITLE
Added Signature Section to htmlForMobile even if htmlReviewContent is used

### DIFF
--- a/ResearchKit/Consent/ORKConsentDocument.m
+++ b/ResearchKit/Consent/ORKConsentDocument.m
@@ -41,7 +41,8 @@
 #import "ORKDefines_Private.h"
 
 
-@implementation ORKConsentDocument {
+@implementation ORKConsentDocument
+{
     NSMutableArray *_signatures;
 }
 
@@ -50,7 +51,8 @@
 }
 
 - (void)addSignature:(ORKConsentSignature *)signature {
-    if (! _signatures) {
+    if (! _signatures)
+    {
         _signatures = [NSMutableArray array];
     }
     [_signatures addObject:signature];
@@ -154,6 +156,70 @@
     
     if (_htmlReviewContent) {
         [body appendString:_htmlReviewContent];
+        [body appendFormat:@"<p>%@</p>", _signaturePageContent?:@""];
+        
+        NSString *hr = @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />";
+        
+        NSString *signatureElementWrapper = @"<p><br/><div class='sigbox'><div class='inbox'>%@</div></div>%@%@</p>";
+        for (ORKConsentSignature *signature in self.signatures)
+        {
+            BOOL addedSig = NO;
+            
+            NSMutableArray *signatureElements = [NSMutableArray array];
+            
+            // Signature
+            if (signature.requiresName || signature.familyName || signature.givenName)
+            {
+                addedSig = YES;
+                NSString *nameStr = @"&nbsp;";
+                if (signature.familyName || signature.givenName) {
+                    NSMutableArray *names = [NSMutableArray array];
+                    if (signature.givenName) {
+                        [names addObject:signature.givenName];
+                    }
+                    if (signature.familyName) {
+                        [names addObject:signature.familyName];
+                    }
+                    nameStr = [names componentsJoinedByString:@"&nbsp;"];
+                }
+                
+                NSString *titleFormat = ORKLocalizedString(@"CONSENT_DOC_LINE_PRINTED_NAME", nil);
+                [signatureElements addObject:[NSString stringWithFormat:signatureElementWrapper, nameStr, hr, [NSString stringWithFormat:titleFormat,signature.title]]];
+            }
+            
+            if (signature.requiresSignatureImage || signature.signatureImage)
+            {
+                addedSig = YES;
+                NSString *imageTag = nil;
+                
+                if (signature.signatureImage) {
+                    NSString *base64 = [UIImagePNGRepresentation(signature.signatureImage) base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+                    imageTag = [NSString stringWithFormat:@"<img width='100%%' alt='star' src='data:image/png;base64,%@' />", base64];
+                } else {
+                    [body appendString:@"<br/>"];
+                }
+                NSString *titleFormat = ORKLocalizedString(@"CONSENT_DOC_LINE_SIGNATURE", nil);
+                [signatureElements addObject:[NSString stringWithFormat:signatureElementWrapper, imageTag?:@"&nbsp;", hr, [NSString stringWithFormat:titleFormat, signature.title]]];
+            }
+            
+            
+            if (addedSig)
+            {
+                [signatureElements addObject:[NSString stringWithFormat:signatureElementWrapper, signature.signatureDate?:@"&nbsp;", hr, ORKLocalizedString(@"CONSENT_DOC_LINE_DATE", nil)]];
+            }
+            
+            NSInteger numElements = [signatureElements count];
+            if (numElements > 1) {
+                [body appendString:[NSString stringWithFormat:@"<div class='grid border'>"]];
+                for (NSString *element in signatureElements) {
+                    [body appendString:[NSString stringWithFormat:@"<div class='col-1-3 border'>%@</div>",element]];
+                }
+                
+                [body appendString:@"</div>"];
+            } else if (numElements == 1) {
+                [body appendString:[NSString stringWithFormat:@"<div width='200'>%@</div>",[signatureElements lastObject]]];
+            }
+        }
     } else {
         
         // title
@@ -173,13 +239,15 @@
             NSString *hr = @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />";
             
             NSString *signatureElementWrapper = @"<p><br/><div class='sigbox'><div class='inbox'>%@</div></div>%@%@</p>";
-            for (ORKConsentSignature *signature in self.signatures) {
+            for (ORKConsentSignature *signature in self.signatures)
+            {
                 BOOL addedSig = NO;
                 
                 NSMutableArray *signatureElements = [NSMutableArray array];
                 
                 // Signature
-                if (signature.requiresName || signature.familyName || signature.givenName) {
+                if (signature.requiresName || signature.familyName || signature.givenName)
+                {
                     addedSig = YES;
                     NSString *nameStr = @"&nbsp;";
                     if (signature.familyName || signature.givenName) {
@@ -197,7 +265,8 @@
                     [signatureElements addObject:[NSString stringWithFormat:signatureElementWrapper, nameStr, hr, [NSString stringWithFormat:titleFormat,signature.title]]];
                 }
                 
-                if (signature.requiresSignatureImage || signature.signatureImage) {
+                if (signature.requiresSignatureImage || signature.signatureImage)
+                {
                     addedSig = YES;
                     NSString *imageTag = nil;
                     
@@ -212,7 +281,8 @@
                 }
                 
                 
-                if (addedSig) {
+                if (addedSig)
+                {
                     [signatureElements addObject:[NSString stringWithFormat:signatureElementWrapper, signature.signatureDate?:@"&nbsp;", hr, ORKLocalizedString(@"CONSENT_DOC_LINE_DATE", nil)]];
                 }
                 
@@ -238,13 +308,16 @@
 
 
 
-+ (BOOL)supportsSecureCoding {
++ (BOOL)supportsSecureCoding
+{
     return YES;
 }
 
-- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
+{
     self = [super init];
-    if (self) {
+    if (self)
+    {
         ORK_DECODE_OBJ_CLASS(aDecoder, title, NSString);
         ORK_DECODE_OBJ_CLASS(aDecoder, signaturePageTitle, NSString);
         ORK_DECODE_OBJ_CLASS(aDecoder, signaturePageContent, NSString);
@@ -256,7 +329,8 @@
     return self;
 }
 
-- (void)encodeWithCoder:(NSCoder *)aCoder {
+- (void)encodeWithCoder:(NSCoder *)aCoder
+{
     ORK_ENCODE_OBJ(aCoder, title);
     ORK_ENCODE_OBJ(aCoder, signaturePageTitle);
     ORK_ENCODE_OBJ(aCoder, signaturePageContent);
@@ -284,7 +358,8 @@
 }
 
 
-- (instancetype)copyWithZone:(NSZone *)zone {
+- (instancetype)copyWithZone:(NSZone *)zone
+{
     ORKConsentDocument *doc = [[[self class] allocWithZone:zone] init];
     doc.title = _title;
     doc.signaturePageTitle = _signaturePageTitle;
@@ -306,4 +381,5 @@
 
 
 @end
+
 


### PR DESCRIPTION
When creating the PDF in the Consent Section, the signature fields are not appended if htmlReviewContent is used. This appends the signature fields to the htmlReviewContent prior to PDF creation.