### PR TITLE
Issue #122: `shouldPresentStep:` method should correctly handle nil step

### DIFF
--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1097,7 +1097,6 @@ static NSString * const _ChildNavigationControllerRestorationKey = @"childNaviga
         }
         [self finishAudioPromptSession];
         [self finishWithReason:ORKTaskViewControllerFinishReasonCompleted error:nil];
-        
     } else if ([self shouldPresentStep:step]) {
         ORKStepViewController *stepViewController = [self viewControllerForStep:step];
         NSAssert(stepViewController != nil, @"A non-nil step should always generate a step view controller");

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -909,9 +909,9 @@ static NSString * const _ChildNavigationControllerRestorationKey = @"childNaviga
 }
 
 - (BOOL)shouldPresentStep:(ORKStep *)step {
-    BOOL shouldPresent = YES;
+    BOOL shouldPresent = (step != nil);
     
-    if ([self.delegate respondsToSelector:@selector(taskViewController:shouldPresentStep:)]) {
+    if (shouldPresent && [self.delegate respondsToSelector:@selector(taskViewController:shouldPresentStep:)]) {
         shouldPresent = [self.delegate taskViewController:self shouldPresentStep:step];
     }
     
@@ -1090,25 +1090,20 @@ static NSString * const _ChildNavigationControllerRestorationKey = @"childNaviga
     }
     
     ORKStep *step = [self nextStep];
-    ORKStepViewController *stepViewController = nil;
     
-    if ([self shouldPresentStep:step]) {
-        stepViewController = [self viewControllerForStep:step];
-        
-        if (stepViewController == nil) {
-            
-            if ([self.delegate respondsToSelector:@selector(taskViewController:didChangeResult:)]) {
-                [self.delegate taskViewController:self didChangeResult:[self result]];
-            }
-            
-            [self finishAudioPromptSession];
-            
-            [self finishWithReason:ORKTaskViewControllerFinishReasonCompleted error:nil];
-            
-        } else {
-            [self showViewController:stepViewController goForward:YES animated:YES];
+    if (step == nil) {
+        if ([self.delegate respondsToSelector:@selector(taskViewController:didChangeResult:)]) {
+            [self.delegate taskViewController:self didChangeResult:[self result]];
         }
+        [self finishAudioPromptSession];
+        [self finishWithReason:ORKTaskViewControllerFinishReasonCompleted error:nil];
+        
+    } else if ([self shouldPresentStep:step]) {
+        ORKStepViewController *stepViewController = [self viewControllerForStep:step];
+        NSAssert(stepViewController != nil, @"A non-nil step should always generate a step view controller");
+        [self showViewController:stepViewController goForward:YES animated:YES];
     }
+    
 }
 
 - (IBAction)flipToPreviousPageFrom:(ORKStepViewController *)fromController {


### PR DESCRIPTION
Adjust internal `shouldPresentStep:` method not to call the delegate
on a nil step, and to return NO if the step is nil. When the task has
completed, a nil step indicates this, so handle that case explicitly
rather than depending on a semantically odd `YES` from `shouldPresentStep:`.

Testing: verified correct behavior for forward and backward navigation at beginning and end of tasks in `ORKTest` in simulator.