### PR TITLE
Issue #118: Adjust fitness quantity pair layout

### DIFF
--- a/ResearchKit/ActiveTasks/ORKFitnessContentView.m
+++ b/ResearchKit/ActiveTasks/ORKFitnessContentView.m
@@ -106,11 +106,14 @@
         self.backgroundColor = [[UIColor redColor] colorWithAlphaComponent:0.2];
         _quantityPairView.backgroundColor = [[UIColor orangeColor] colorWithAlphaComponent:0.2];
 #endif
-        
+      
+        [self setDistanceInMeters:0];
+        [self heartRateView].title = ORKLocalizedString(@"FITNESS_HEARTRATE_TITLE", nil);
+
         [self addSubview:_quantityPairView];
         [self addSubview:_imageView];
         [self addSubview:_timerLabel];
-        [self setNeedsUpdateConstraints];
+        [self setupConstraints];
         
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(localeDidChange:) name:NSCurrentLocaleDidChangeNotification object:nil];
         
@@ -147,11 +150,7 @@
     _topConstraint.constant = (CaptionBaselineToTimerTop - CaptionBaselineToStepViewTop);
 }
 
-- (void)updateConstraints {
-    if (_constraints) {
-        [self removeConstraints:_constraints];
-        _constraints = nil;
-    }
+- (void)setupConstraints {
     NSMutableArray *constraints = [NSMutableArray array];
     NSDictionary *views = NSDictionaryOfVariableBindings(_timerLabel, _imageView, _quantityPairView, _imageSpacer1, _imageSpacer2);
     [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[_timerLabel][_imageSpacer1(>=0)][_imageView]"
@@ -239,8 +238,6 @@
     [constraints addObject:maxWidthConstraint];
     
     [self addConstraints:constraints];
-    _constraints = constraints;
-    [super updateConstraints];
 }
 
 - (void)setImage:(UIImage *)image {
@@ -277,7 +274,6 @@
 - (void)setHeartRate:(NSString *)heartRate {
     _heartRate = heartRate;
     [self heartRateView].value = heartRate;
-    [self heartRateView].title = ORKLocalizedString(@"FITNESS_HEARTRATE_TITLE", nil);
 }
 
 - (void)updateKeylineVisible {

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1096,7 +1096,6 @@ static NSString * const _ChildNavigationControllerRestorationKey = @"childNaviga
         stepViewController = [self viewControllerForStep:step];
         
         if (stepViewController == nil) {
-            
             if ([self.delegate respondsToSelector:@selector(taskViewController:didChangeResult:)]) {
                 [self.delegate taskViewController:self didChangeResult:[self result]];
             }
@@ -1104,7 +1103,6 @@ static NSString * const _ChildNavigationControllerRestorationKey = @"childNaviga
             [self finishAudioPromptSession];
             
             [self finishWithReason:ORKTaskViewControllerFinishReasonCompleted error:nil];
-            
         } else {
             [self showViewController:stepViewController goForward:YES animated:YES];
         }


### PR DESCRIPTION
This fixes a regression in quantity pair layout. The left view of
the quantity pair, the distance view, formerly always contained
content, which fixed the vertical height of the view. At some point
that content was no longer set, handling the no-pedometer-distance
case. The primary fix here is to ensure that a title and zero
quantity are present in the distance view, even if distance is
not available (as in the simulator).

Secondary fixes fix constraints to make them static, since they
do not need to be dynamically updated. We also introduce new baseline
constraints to better enforce alignment between the left and right
views.

Tested distance-only, heart-rate-only, both, and neither visible on
iPhone 6 on iOS 8.3. Tested with and without a value for heart rate,
with both visible.

Addresses issue #118.