### PR TITLE
LaunchScreen: fix nav bar height and table view content inset

### DIFF
--- a/samples/ORKCatalog/ORKCatalog/Base.lproj/LaunchScreen.xib
+++ b/samples/ORKCatalog/ORKCatalog/Base.lproj/LaunchScreen.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6751" systemVersion="14D107a" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -11,11 +11,14 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="pv7-RZ-bDW">
-                    <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
+                    <rect key="frame" x="0.0" y="64" width="480" height="416"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                 </tableView>
                 <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KFe-cA-LWE">
-                    <rect key="frame" x="0.0" y="0.0" width="480" height="44"/>
+                    <rect key="frame" x="0.0" y="0.0" width="480" height="64"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="64" id="ad9-qd-gKI"/>
+                    </constraints>
                     <items>
                         <navigationItem id="aNh-Ru-HQq"/>
                     </items>
@@ -28,7 +31,7 @@
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
             <constraints>
-                <constraint firstItem="pv7-RZ-bDW" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="9EV-EP-3Hb"/>
+                <constraint firstItem="pv7-RZ-bDW" firstAttribute="top" secondItem="KFe-cA-LWE" secondAttribute="bottom" id="ERQ-ec-2pG"/>
                 <constraint firstAttribute="trailing" secondItem="KFe-cA-LWE" secondAttribute="trailing" id="LXE-oi-EQd"/>
                 <constraint firstAttribute="bottom" secondItem="pv7-RZ-bDW" secondAttribute="bottom" id="LZE-hQ-KMI"/>
                 <constraint firstItem="KFe-cA-LWE" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="QkW-Rb-nKK"/>

--- a/samples/ORKCatalog/ORKCatalog/Base.lproj/Main.storyboard
+++ b/samples/ORKCatalog/ORKCatalog/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14D107a" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="49e-Tb-3d3">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="49e-Tb-3d3">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>


### PR DESCRIPTION
I fixed *ORKCatalog*'s `LaunchScreen.xib` so it matches the main view controller.

I just added a height constraint of `64` to the navigation bar, and pinned the top of the table to it (so the separator vertical positions are in sync with the live view controller content inset). Tell me if you think there's a better approach instead.