### PR TITLE
Remove unneeded @class forward declaration in ORKObserver

### DIFF
--- a/ResearchKit/Common/ORKObserver.h
+++ b/ResearchKit/Common/ORKObserver.h
@@ -34,8 +34,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class ORKTaskViewController;
-
 @interface ORKObserver : NSObject
 
 @property (nonatomic, strong) NSArray *keyPaths;


### PR DESCRIPTION
Very small cleanup. That line slipped when I extracted `ORKObserver` to its own file.