### PR TITLE
Add optional NSNumberFormatter to scale & continuous scale

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -84,6 +84,14 @@ typedef NS_ENUM(NSInteger, ORKChoiceAnswerStyle) {
     ORKChoiceAnswerStyleMultipleChoice
 } ORK_ENUM_AVAILABLE;
 
+/// An enumeration of the format styles available for scale answers.
+typedef NS_ENUM(NSInteger, ORKNumberFormattingStyle) {
+    /// The default decimal style.
+    ORKNumberFormattingStyleDefault,
+    
+    /// Percent style.
+    ORKNumberFormattingStylePercent
+} ORK_ENUM_AVAILABLE;
 
 @class ORKScaleAnswerFormat;
 @class ORKContinuousScaleAnswerFormat;
@@ -270,6 +278,11 @@ ORK_CLASS_AVAILABLE
  */
 @property (readonly, getter=isVertical) BOOL vertical;
 
+/**
+ Number formatter applied to the minimum, maximum, and slider values. Can be overridden by subclasses.
+ */
+@property (readonly) NSNumberFormatter *numberFormatter;
+
 @end
 
 
@@ -344,6 +357,16 @@ ORK_CLASS_AVAILABLE
  A Boolean value indicating whether the scale is oriented vertically. (read-only)
  */
 @property (readonly, getter=isVertical) BOOL vertical;
+
+/**
+ Formatting style applied to the minimum, maximum, and slider values.
+ */
+@property ORKNumberFormattingStyle numberStyle;
+
+/**
+ Number formatter applied to the minimum, maximum, and slider values. Can be overridden by subclasses.
+ */
+@property (readonly) NSNumberFormatter *numberFormatter;
 
 @end
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1,5 +1,6 @@
 /*
  Copyright (c) 2015, Apple Inc. All rights reserved.
+ Copyright (c) 2015, Scott Guelich.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -59,6 +60,10 @@ NSString *ORKQuestionTypeString(ORKQuestionType questionType) {
             SQT_CASE(TimeInterval);
     }
 #undef SQT_CASE
+}
+
+NSNumberFormatterStyle ORKNumberFormattingStyleConvert(ORKNumberFormattingStyle style) {
+    return style == ORKNumberFormattingStylePercent ? NSNumberFormatterPercentStyle : NSNumberFormatterDecimalStyle;
 }
 
 @implementation ORKAnswerDefaultSource {
@@ -1180,7 +1185,9 @@ static NSArray *ork_processTextChoices(NSArray *textChoices) {
 
 #pragma mark - ORKScaleAnswerFormat
 
-@implementation ORKScaleAnswerFormat
+@implementation ORKScaleAnswerFormat {
+    NSNumberFormatter *_numberFormatter;
+}
 
 - (Class)questionResultClass {
     return [ORKScaleQuestionResult class];
@@ -1231,7 +1238,17 @@ static NSArray *ork_processTextChoices(NSArray *textChoices) {
     return @(integer);
 }
 - (NSString *)localizedStringForNumber:(NSNumber *)number {
-    return [NSNumberFormatter localizedStringFromNumber:number numberStyle:NSNumberFormatterDecimalStyle];
+    return [self.numberFormatter stringFromNumber:number];
+}
+
+- (NSNumberFormatter *)numberFormatter {
+    if (! _numberFormatter) {
+        _numberFormatter = [[NSNumberFormatter alloc] init];
+        _numberFormatter.numberStyle = NSNumberFormatterDecimalStyle;
+        _numberFormatter.locale = [NSLocale autoupdatingCurrentLocale];
+        _numberFormatter.maximumFractionDigits = 0;
+    }
+    return _numberFormatter;
 }
 
 - (NSInteger)numberOfSteps {
@@ -1320,7 +1337,7 @@ static NSArray *ork_processTextChoices(NSArray *textChoices) {
             (_maximum == castObject.maximum) &&
             (_minimum == castObject.minimum) &&
             (_step == castObject.step) &&
-            (_defaultValue == castObject.defaultValue)) ;
+            (_defaultValue == castObject.defaultValue));
 }
 
 - (ORKQuestionType) questionType {
@@ -1382,13 +1399,16 @@ static NSArray *ork_processTextChoices(NSArray *textChoices) {
     return @(_defaultValue);
 }
 - (NSString *)localizedStringForNumber:(NSNumber *)number {
+    return [self.numberFormatter stringFromNumber:number];
+}
+
+- (NSNumberFormatter *)numberFormatter {
     if (! _numberFormatter) {
         _numberFormatter = [[NSNumberFormatter alloc] init];
-        _numberFormatter.numberStyle = NSNumberFormatterDecimalStyle;
-        _numberFormatter.locale = [NSLocale autoupdatingCurrentLocale];
+        _numberFormatter.numberStyle = ORKNumberFormattingStyleConvert(_numberStyle);
         _numberFormatter.maximumFractionDigits = _maximumFractionDigits;
     }
-    return [_numberFormatter stringFromNumber:number];
+    return _numberFormatter;
 }
 
 - (NSInteger)numberOfSteps {
@@ -1438,6 +1458,7 @@ static NSArray *ork_processTextChoices(NSArray *textChoices) {
         ORK_DECODE_DOUBLE(aDecoder, defaultValue);
         ORK_DECODE_INTEGER(aDecoder, maximumFractionDigits);
         ORK_DECODE_BOOL(aDecoder, vertical);
+        ORK_DECODE_ENUM(aDecoder, numberStyle);
     }
     return self;
 }
@@ -1449,6 +1470,7 @@ static NSArray *ork_processTextChoices(NSArray *textChoices) {
     ORK_ENCODE_DOUBLE(aCoder, defaultValue);
     ORK_ENCODE_INTEGER(aCoder, maximumFractionDigits);
     ORK_ENCODE_BOOL(aCoder, vertical);
+    ORK_ENCODE_ENUM(aCoder, numberStyle);
 }
 
 + (BOOL)supportsSecureCoding {
@@ -1463,7 +1485,8 @@ static NSArray *ork_processTextChoices(NSArray *textChoices) {
             (_maximum == castObject.maximum) &&
             (_minimum == castObject.minimum) &&
             (_defaultValue == castObject.defaultValue) &&
-            (_maximumFractionDigits == castObject.maximumFractionDigits)) ;
+            (_maximumFractionDigits == castObject.maximumFractionDigits) &&
+            (_numberStyle == castObject.numberStyle));
 }
 
 - (ORKQuestionType) questionType {

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -1432,11 +1432,28 @@ static NSString * const TwoFingerTapTaskIdentifier = @"tap";
                                                                                              vertical:YES];
         
         ORKQuestionStep *step = [ORKQuestionStep questionStepWithIdentifier:@"scale_06"
-                                                                      title:@"How would you measure your mood improvement?"
+                                                                      title:@"How was your mood yesterday?"
                                                                      answer:scaleAnswerFormat];
         [steps addObject:step];
     }
 
+    {
+        /*
+         Vertical continuous scale with three decimal places, a default, and a format style.
+         */
+        ORKContinuousScaleAnswerFormat *scaleAnswerFormat =  [ORKAnswerFormat continuousScaleAnswerFormatWithMaximumValue:1.0
+                                                                                                             minimumValue:0.0
+                                                                                                             defaultValue:0.8725
+                                                                                                    maximumFractionDigits:0
+                                                                                                                 vertical:YES];
+        scaleAnswerFormat.numberStyle = ORKNumberFormattingStylePercent;
+        
+        ORKQuestionStep *step = [ORKQuestionStep questionStepWithIdentifier:@"scale_07"
+                                                                      title:@"How much has your mood improved?"
+                                                                     answer:scaleAnswerFormat];
+        [steps addObject:step];
+    }
+    
     ORKOrderedTask *task = [[ORKOrderedTask alloc] initWithIdentifier:ScalesTaskIdentifier steps:steps];
     return task;
     

--- a/Testing/ORKTest/ORKTest/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTest/ORKESerialization.m
@@ -288,6 +288,15 @@ static NSArray *memoryGameStatusTable() {
     return table;
 }
 
+static NSArray *numberFormattingStyleTable() {
+    static NSArray *table = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        table = @[@"default", @"percent"];
+    });
+    return table;
+}
+
 #define GETPROP(d,x) getter(d, @ESTRINGIFY(x))
 static NSMutableDictionary *ORKESerializationEncodingTable() {
     static dispatch_once_t onceToken;
@@ -629,7 +638,10 @@ ret =
           PROPERTY(maximum, NSNumber, NSObject, NO, nil, nil),
           PROPERTY(defaultValue, NSNumber, NSObject, NO, nil, nil),
           PROPERTY(maximumFractionDigits, NSNumber, NSObject, NO, nil, nil),
-          PROPERTY(vertical, NSNumber, NSObject, NO, nil, nil)
+          PROPERTY(vertical, NSNumber, NSObject, NO, nil, nil),
+          PROPERTY(numberStyle, NSNumber, NSObject, YES,
+                   ^id(id numeric) { return tableMapForward([numeric integerValue], numberFormattingStyleTable()); },
+                   ^id(id string) { return @(tableMapReverse(string, numberFormattingStyleTable())); })
           })),
   ENTRY(ORKTextAnswerFormat,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -269,6 +269,7 @@
                                               @"ORKConsentDocument.writer",
                                               @"ORKConsentDocument.sections",
                                               @"ORKConsentDocument.signatures",
+                                              @"ORKContinuousScaleAnswerFormat.numberFormatter",
                                               @"ORKFormItem.step",
                                               @"ORKHealthKitCharacteristicTypeAnswerFormat.characteristicType",
                                               @"ORKTimeIntervalAnswerFormat.maximumInterval",
@@ -283,6 +284,7 @@
                                               @"ORKImageChoice.selectedStateImage",
                                               @"ORKActiveStep.requestedPermissions",
                                               @"ORKOrderedTask.providesBackgroundAudioPrompts",
+                                              @"ORKScaleAnswerFormat.numberFormatter",
                                               @"ORKSpatialSpanMemoryStep.customTargetImage",
                                               @"ORKStep.allowsBackNavigation",
                                               @"ORKAnswerFormat.healthKitUserUnit",
@@ -347,6 +349,7 @@
         
         if ([aClass isSubclassOfClass:[ORKContinuousScaleAnswerFormat class]]) {
             [instance setValue:@(100) forKey:@"maximum"];
+            [instance setValue:@(ORKNumberFormattingStylePercent) forKey:@"numberStyle"];
         } else if ([aClass isSubclassOfClass:[ORKScaleAnswerFormat class]]) {
             [instance setValue:@(0) forKey:@"minimum"];
             [instance setValue:@(100) forKey:@"maximum"];

--- a/samples/ORKCatalog/ORKCatalog/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/TaskListRow.swift
@@ -307,8 +307,9 @@ enum TaskListRow: Int, Printable {
         
         steps += [questionStep1]
         
-        // The second step is a scale control that allows continuous movement.
-        let step2AnswerFormat = ORKAnswerFormat.continuousScaleAnswerFormatWithMaximumValue(5.0, minimumValue: 1.0, defaultValue: 99.0, maximumFractionDigits: 2, vertical: false)
+        // The second step is a scale control that allows continuous movement with a percent formatter.
+        let step2AnswerFormat = ORKAnswerFormat.continuousScaleAnswerFormatWithMaximumValue(1.0, minimumValue: 0.0, defaultValue: 99.0, maximumFractionDigits: 0, vertical: false)
+        step2AnswerFormat.numberStyle = .Percent
         
         let questionStep2 = ORKQuestionStep(identifier: Identifier.ContinuousScaleQuestionStep.rawValue, title: exampleQuestionText, answer: step2AnswerFormat)
         


### PR DESCRIPTION
This adds a numberFormatter property to ORKScaleAnswerFormat and ORKContinuousAnswerFormat. Our motivation for this is to enable a continuous slider that displays a percentage, though it could be used for currency or other number formats.

Because this property is optional and likely to be used infrequently, I did not add it to the initializers.

This PR also includes a small change to ORKCatalog to display the second step for Scale Question as a continuous percentage, so you can view the appearance there.