### PR TITLE
Fix ORKQuestionStepViewController losing its default value when going back

### DIFF
--- a/ResearchKit/Common/ORKQuestionStepViewController.m
+++ b/ResearchKit/Common/ORKQuestionStepViewController.m
@@ -127,7 +127,6 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
 }
 
 - (instancetype)initWithStep:(ORKStep *)step {
-    
     self = [super initWithStep:step];
     if (self) {
         _defaultSource = [ORKAnswerDefaultSource sourceWithHealthStore:[HKHealthStore new]];
@@ -378,25 +377,27 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
     ORKStepResult *parentResult = [super result];
     ORKQuestionStep *questionStep = self.questionStep;
     
-    ORKQuestionResult *result = [questionStep.answerFormat resultWithIdentifier:questionStep.identifier answer:self.answer];
-    ORKAnswerFormat *impliedAnswerFormat = [questionStep impliedAnswerFormat];
-    
-    if ([impliedAnswerFormat isKindOfClass:[ORKDateAnswerFormat class]]) {
-        ORKDateQuestionResult *dateQuestionResult = (ORKDateQuestionResult *)result;
-        if (dateQuestionResult.dateAnswer) {
-            NSCalendar *usedCalendar = [(ORKDateAnswerFormat *)impliedAnswerFormat calendar]? : _savedSystemCalendar;
-            dateQuestionResult.calendar = [NSCalendar calendarWithIdentifier:usedCalendar.calendarIdentifier ? : [NSCalendar currentCalendar].calendarIdentifier];
-            dateQuestionResult.timeZone = _savedSystemTimeZone? : [NSTimeZone systemTimeZone];
+    if (self.answer) {
+        ORKQuestionResult *result = [questionStep.answerFormat resultWithIdentifier:questionStep.identifier answer:self.answer];
+        ORKAnswerFormat *impliedAnswerFormat = [questionStep impliedAnswerFormat];
+        
+        if ([impliedAnswerFormat isKindOfClass:[ORKDateAnswerFormat class]]) {
+            ORKDateQuestionResult *dateQuestionResult = (ORKDateQuestionResult *)result;
+            if (dateQuestionResult.dateAnswer) {
+                NSCalendar *usedCalendar = [(ORKDateAnswerFormat *)impliedAnswerFormat calendar]? : _savedSystemCalendar;
+                dateQuestionResult.calendar = [NSCalendar calendarWithIdentifier:usedCalendar.calendarIdentifier ? : [NSCalendar currentCalendar].calendarIdentifier];
+                dateQuestionResult.timeZone = _savedSystemTimeZone? : [NSTimeZone systemTimeZone];
+            }
+        } else if ([impliedAnswerFormat isKindOfClass:[ORKNumericAnswerFormat class]]) {
+            ORKNumericQuestionResult *nqr = (ORKNumericQuestionResult *)result;
+            nqr.unit = [(ORKNumericAnswerFormat *)impliedAnswerFormat unit];
         }
-    } else if ([impliedAnswerFormat isKindOfClass:[ORKNumericAnswerFormat class]]) {
-        ORKNumericQuestionResult *nqr = (ORKNumericQuestionResult *)result;
-        nqr.unit = [(ORKNumericAnswerFormat *)impliedAnswerFormat unit];
+        
+        result.startDate = parentResult.startDate;
+        result.endDate = parentResult.endDate;
+        
+        parentResult.results = @[result];
     }
-    
-    result.startDate = parentResult.startDate;
-    result.endDate = parentResult.endDate;
-    
-    parentResult.results = @[result];
     
     return parentResult;
 }

--- a/ResearchKit/Common/ORKScaleSlider.m
+++ b/ResearchKit/Common/ORKScaleSlider.m
@@ -71,6 +71,7 @@
 
 - (void)setShowThumb:(BOOL)showThumb {
     _showThumb = showThumb;
+    [self setNeedsLayout];
 }
 
 - (void)setVertical:(BOOL)vertical {


### PR DESCRIPTION
Fixes [issue #135](https://github.com/ResearchKit/ResearchKit/issues/135)

 When you skip the step, the default value is hidden. Default value doesn't reappear when you go back twice, and go forward again.

I have also fixed a small visual glitch (occurring in stable as well): when you skip a step, the current value was hidden before the step transition. I guess we don't need to update the view just before an outgoing transition: the cell will be fine and empty if the user ever comes back.