### PR TITLE
Fix unable to draw signature when scrolling is enabled

### DIFF
--- a/ResearchKit/Consent/ORKSignatureView.m
+++ b/ResearchKit/Consent/ORKSignatureView.m
@@ -33,6 +33,8 @@
 #import "ORKSkin.h"
 #import "ORKSelectionTitleLabel.h"
 
+#import <UIKit/UIGestureRecognizerSubclass.h>
+
 
 @protocol ORKSignatureGestureRecognizerDelegate <NSObject>
 
@@ -53,6 +55,7 @@
 @implementation ORKSignatureGestureRecognizer
 
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
+    self.state = UIGestureRecognizerStateBegan;
     [self.eventDelegate gestureTouchesBegan:(NSSet *)touches withEvent:(UIEvent *)event];
 }
 
@@ -61,17 +64,21 @@
 }
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
+    self.state = UIGestureRecognizerStateEnded;
     [self.eventDelegate gestureTouchesEnded:(NSSet *)touches withEvent:(UIEvent *)event];
 }
 
-- (BOOL)shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
-    // Disable swipe gestureRecognizer
-    if ([otherGestureRecognizer isKindOfClass:[UISwipeGestureRecognizer class]]) {
-        // Cancel the gesture recognition in progress.
-        otherGestureRecognizer.enabled = NO;
-        otherGestureRecognizer.enabled = YES;
+- (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event {
+    self.state = UIGestureRecognizerStateFailed;
+}
+
+- (BOOL)shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    // Prioritize over scrollView's pan gesture recognizer and swipe gesture recognizer
+    if ([otherGestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]]
+        || [otherGestureRecognizer isKindOfClass:[UISwipeGestureRecognizer class]]) {
+        return YES;
     }
-    return YES;
+    return NO;
 }
 
 @end


### PR DESCRIPTION
Fixes [issue #119](https://github.com/ResearchKit/ResearchKit/issues/119) by prioritizing the signature recognizer over the scrollview one. You can still scroll by dragging outside the signature area.