### PR TITLE
Fix for Issue #148 - [iPad] Two finger tapping task vertical spacing improvement 

### DIFF
--- a/ResearchKit/ActiveTasks/ORKTappingContentView.m
+++ b/ResearchKit/ActiveTasks/ORKTappingContentView.m
@@ -38,6 +38,9 @@
 #import "ORKHelpers.h"
 
 
+// #define LAYOUT_DEBUG 1
+
+
 @interface ORKTappingContentView ()
 
 @property (nonatomic, strong) ORKSubheadlineLabel *tapCaptionLabel;
@@ -96,6 +99,13 @@
         [self setNeedsUpdateConstraints];
         
         _tapCountLabel.accessibilityTraits |= UIAccessibilityTraitUpdatesFrequently;
+        
+#if LAYOUT_DEBUG
+        self.backgroundColor = [[UIColor yellowColor] colorWithAlphaComponent:0.5];
+        self.tapCaptionLabel.backgroundColor = [UIColor orangeColor];
+        self.tapCountLabel.backgroundColor = [UIColor greenColor];
+        _buttonContainer.backgroundColor = [[UIColor blueColor] colorWithAlphaComponent:0.25];
+#endif
     }
      return self;
 }
@@ -150,6 +160,17 @@
     static const CGFloat CaptionBaselineToTapCountBaseline = 56;
     static const CGFloat TapButtonBottomToBottom = 36;
     
+    // On the iPhone, _progressView is positioned outside the bounds of this view, to be in-between the header and this view.
+    // On the iPad, we want to stretch this out a bit so it feels less compressed.
+    CGFloat progressViewOffset, topCaptionLabelOffset;
+    if (screenType == ORKScreenTypeiPad) {
+        progressViewOffset = 0;
+        topCaptionLabelOffset = AssumedHeaderBaselineToStepViewTop;
+    } else {
+        progressViewOffset = (HeaderBaselineToCaptionTop/3) - AssumedHeaderBaselineToStepViewTop;
+        topCaptionLabelOffset = HeaderBaselineToCaptionTop - AssumedHeaderBaselineToStepViewTop;
+    }
+    
     NSMutableArray *constraints = [NSMutableArray array];
     
     NSDictionary *views = NSDictionaryOfVariableBindings(_buttonContainer, _tapCaptionLabel, _tapCountLabel, _progressView, _tapButton1, _tapButton2);
@@ -158,14 +179,14 @@
                                                         relatedBy:NSLayoutRelationEqual
                                                            toItem:self
                                                         attribute:NSLayoutAttributeTop
-                                                       multiplier:1 constant:(HeaderBaselineToCaptionTop/3) - AssumedHeaderBaselineToStepViewTop]];
+                                                       multiplier:1 constant:progressViewOffset]];
     
     [constraints addObject:[NSLayoutConstraint constraintWithItem:_tapCaptionLabel
                                                         attribute:NSLayoutAttributeTop
                                                         relatedBy:NSLayoutRelationEqual
                                                            toItem:self
                                                         attribute:NSLayoutAttributeTop
-                                                       multiplier:1 constant:(HeaderBaselineToCaptionTop - AssumedHeaderBaselineToStepViewTop)]];
+                                                       multiplier:1 constant:topCaptionLabelOffset]];
     
     [constraints addObject:[NSLayoutConstraint constraintWithItem:_tapCountLabel
                                                         attribute:NSLayoutAttributeFirstBaseline


### PR DESCRIPTION
Implementation of enhancement #148.
* On iPad, added more space between title, progress bar, and tap count.  Refactored code should allow more space to be easily added in-between if desired.
* Added `LAYOUT_DEBUG` colors to aid in layout debugging (per observed convention)

**iPad Screenshot (Portrait)**
![ios simulator screen shot may 8 2015 4 26 41 pm](https://cloud.githubusercontent.com/assets/97080/7544953/c674b55c-f59f-11e4-9453-3804c04dcf2d.png)

**iPad Screenshot (Landscape)**
![ios simulator screen shot may 8 2015 4 26 48 pm](https://cloud.githubusercontent.com/assets/97080/7544959/cc53e466-f59f-11e4-8879-f238bc5d201a.png)
