### PR TITLE
Fix margins in "Learn More" modal view

### DIFF
--- a/ResearchKit/Consent/ORKConsentLearnMoreViewController.m
+++ b/ResearchKit/Consent/ORKConsentLearnMoreViewController.m
@@ -32,6 +32,7 @@
 #import "ORKConsentLearnMoreViewController.h"
 #import "ORKConsentDocument_Internal.h"
 #import "ORKHelpers.h"
+#import "ORKSkin.h"
 
 
 @interface ORKConsentLearnMoreViewController ()<UIWebViewDelegate>
@@ -55,13 +56,43 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
+    self.view.backgroundColor = ORKColor(ORKBackgroundColorKey);
+
     _webView = [[UIWebView alloc] initWithFrame:self.view.bounds];
-    _webView.autoresizingMask = UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth;
+    
+    const CGFloat horizMargin = ORKStandardLeftMarginForTableViewCell(self.view);
+    _webView.backgroundColor = ORKColor(ORKBackgroundColorKey);
+    _webView.scrollView.backgroundColor = ORKColor(ORKBackgroundColorKey);
+    
+    _webView.clipsToBounds = NO;
+    _webView.scrollView.clipsToBounds = NO;
+    _webView.scrollView.scrollIndicatorInsets = (UIEdgeInsets){.left = -horizMargin, .right = -horizMargin};
+    _webView.opaque = NO; // If opaque is set to YES, _webView shows a black right margin during transition when modally presented. This is an artifact due to disabling clipsToBounds to be able to show the scroll indicator outside the view.
+    
     [_webView loadHTMLString:self.content baseURL:ORKCreateRandomBaseURL()];
     _webView.delegate = self;
     [self.view addSubview:_webView];
+
+    _webView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self setupConstraints];
     
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancel:)];
+}
+
+- (void)setupConstraints {
+    NSMutableArray *constraints = [NSMutableArray new];
+    
+    NSDictionary *views = NSDictionaryOfVariableBindings(_webView);
+    const CGFloat horizMargin = ORKStandardLeftMarginForTableViewCell(self.view);
+    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-horizMargin-[_webView]-horizMargin-|"
+                                                                             options:(NSLayoutFormatOptions)0
+                                                                             metrics:@{ @"horizMargin": @(horizMargin) }
+                                                                               views:views]];
+    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_webView]|"
+                                                                             options:(NSLayoutFormatOptions)0 metrics:nil
+                                                                               views:views]];
+    
+    [NSLayoutConstraint activateConstraints:constraints];
 }
 
 - (IBAction)cancel:(id)sender {

--- a/ResearchKit/Consent/ORKConsentReviewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewController.m
@@ -72,7 +72,8 @@
     
     _webView = [UIWebView new];
     [_webView loadHTMLString:_htmlString baseURL:ORKCreateRandomBaseURL()];
-    _webView.scrollView.bounces = NO;
+    _webView.backgroundColor = ORKColor(ORKBackgroundColorKey);
+    _webView.scrollView.backgroundColor = ORKColor(ORKBackgroundColorKey);
     _webView.delegate = self;
     [_webView setClipsToBounds:YES];
     _webView.translatesAutoresizingMaskIntoConstraints = NO;


### PR DESCRIPTION
[Pull request #166](https://github.com/ResearchKit/ResearchKit/pull/166) moved the margins from the mobile HTML document to the consent review view. This change broke "Learn More" margins.

This PR fixes that, and enables `bounces` in the consent review webview for homogeneity.

Also, tested after applying changes in [PR #168](https://github.com/ResearchKit/ResearchKit/pull/168): it looks ok as well.