### PR TITLE
ActiveStep fixes

### DIFF
--- a/ResearchKit/ActiveTasks/ORKAudioStep.h
+++ b/ResearchKit/ActiveTasks/ORKAudioStep.h
@@ -37,8 +37,6 @@ NS_ASSUME_NONNULL_BEGIN
 ORK_CLASS_AVAILABLE
 @interface ORKAudioStep : ORKActiveStep
 
-@property (nonatomic, assign) NSTimeInterval duration;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/ActiveTasks/ORKAudioStep.m
+++ b/ResearchKit/ActiveTasks/ORKAudioStep.m
@@ -41,49 +41,26 @@
     return [ORKAudioStepViewController class];
 }
 
+- (instancetype)initWithIdentifier:(NSString *)identifier {
+    self = [super initWithIdentifier:identifier];
+    if (self) {
+        self.shouldShowDefaultTimer = NO;
+    }
+    return self;
+}
+
 - (void)validateParameters {
     [super validateParameters];
     
     NSTimeInterval const ORKAudioTaskMinimumDuration = 5.0;
     
-    if ( self.duration < ORKAudioTaskMinimumDuration) {
+    if ( self.stepDuration < ORKAudioTaskMinimumDuration) {
         @throw [NSException exceptionWithName:NSInvalidArgumentException reason:[NSString stringWithFormat:@"duration can not be shorter than %@ seconds.", @(ORKAudioTaskMinimumDuration)]  userInfo:nil];
     }
 }
 
-- (instancetype)copyWithZone:(NSZone *)zone {
-    ORKAudioStep *step = [super copyWithZone:zone];
-    step.duration = self.duration;
-    return step;
-}
-
 - (BOOL)startsFinished {
     return NO;
-}
-
-- (instancetype)initWithCoder:(NSCoder *)aDecoder {
-    self = [super initWithCoder:aDecoder];
-    if (self) {
-        ORK_DECODE_DOUBLE(aDecoder, duration);
-    }
-    return self;
-}
-
-- (void)encodeWithCoder:(NSCoder *)aCoder {
-    [super encodeWithCoder:aCoder];
-    ORK_ENCODE_DOUBLE(aCoder, duration);
-}
-
-+ (BOOL)supportsSecureCoding {
-    return YES;
-}
-
-- (BOOL)isEqual:(id)object {
-    BOOL isParentSame = [super isEqual:object];
-    
-    __typeof(self) castObject = object;
-    return (isParentSame &&
-            (self.duration == castObject.duration)) ;
 }
 
 @end

--- a/ResearchKit/ActiveTasks/ORKAudioStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKAudioStepViewController.m
@@ -70,7 +70,7 @@
     [super viewDidLoad];
     // Do any additional setup after loading the view.
     _audioContentView = [ORKAudioContentView new];
-    _audioContentView.timeLeft = self.audioStep.duration;
+    _audioContentView.timeLeft = self.audioStep.stepDuration;
     self.activeStepView.activeCustomView = _audioContentView;
 }
 
@@ -114,7 +114,7 @@
 
 - (void)startNewTimerIfNeeded {
     if (! _timer) {
-        NSTimeInterval duration = self.audioStep.duration;
+        NSTimeInterval duration = self.audioStep.stepDuration;
         __weak typeof(self) weakSelf = self;
         _timer = [[ORKActiveStepTimer alloc] initWithDuration:duration interval:duration/100 runtime:0 handler:^(ORKActiveStepTimer *timer, BOOL finished) {
             typeof(self) strongSelf = weakSelf;

--- a/ResearchKit/ActiveTasks/ORKFitnessStep.m
+++ b/ResearchKit/ActiveTasks/ORKFitnessStep.m
@@ -39,6 +39,14 @@
     return [ORKFitnessStepViewController class];
 }
 
+- (instancetype)initWithIdentifier:(NSString *)identifier {
+    self = [super initWithIdentifier:identifier];
+    if (self) {
+        self.shouldShowDefaultTimer = NO;
+    }
+    return self;
+}
+
 - (void)validateParameters {
     [super validateParameters];
     

--- a/ResearchKit/ActiveTasks/ORKSpatialSpanMemoryStep.m
+++ b/ResearchKit/ActiveTasks/ORKSpatialSpanMemoryStep.m
@@ -43,8 +43,10 @@
 
 - (instancetype)initWithIdentifier:(NSString *)identifier {
     self = [super initWithIdentifier:identifier];
-    self.shouldStartTimerAutomatically = YES;
-    self.shouldContinueOnFinish = YES;
+    if (self) {
+        self.shouldStartTimerAutomatically = YES;
+        self.shouldContinueOnFinish = YES;
+    }
     return self;
 }
 

--- a/ResearchKit/ActiveTasks/ORKTappingIntervalStep.m
+++ b/ResearchKit/ActiveTasks/ORKTappingIntervalStep.m
@@ -39,6 +39,14 @@
     return [ORKTappingIntervalStepViewController class];
 }
 
+- (instancetype)initWithIdentifier:(NSString *)identifier {
+    self = [super initWithIdentifier:identifier];
+    if (self) {
+        self.shouldShowDefaultTimer = NO;
+    }
+    return self;
+}
+
 - (void)validateParameters {
     [super validateParameters];
     

--- a/ResearchKit/ActiveTasks/ORKWalkingTaskStep.m
+++ b/ResearchKit/ActiveTasks/ORKWalkingTaskStep.m
@@ -41,6 +41,14 @@
     return [ORKWalkingTaskStepViewController class];
 }
 
+- (instancetype)initWithIdentifier:(NSString *)identifier {
+    self = [super initWithIdentifier:identifier];
+    if (self) {
+        self.shouldShowDefaultTimer = NO;
+    }
+    return self;
+}
+
 - (void)validateParameters {
     [super validateParameters];
     

--- a/ResearchKit/Common/ORKCountdownLabel.m
+++ b/ResearchKit/Common/ORKCountdownLabel.m
@@ -41,13 +41,24 @@
 @end
 
 
-@implementation ORKCountdownLabel
+@implementation ORKCountdownLabel {
+    NSInteger _currentCountDownValue;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _currentCountDownValue = 0;
+    }
+    return self;
+}
 
 - (void)updateAppearance {
-    [self setCountDownValue:0];
+    [self setCountDownValue:_currentCountDownValue];
 }
 
 - (void)setCountDownValue:(NSInteger)value {
+    _currentCountDownValue = value;
     _minutesString = [NSString stringWithFormat:@"%02ld", (long)(value/60)];
     _secondsString= [NSString stringWithFormat:@"%02ld", (long)(value%60)];
     

--- a/ResearchKit/Common/ORKOrderedTask.m
+++ b/ResearchKit/Common/ORKOrderedTask.m
@@ -519,7 +519,6 @@ static void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
             fitnessStep.title = [NSString stringWithFormat:ORKLocalizedString(@"FITNESS_WALK_INSTRUCTION_FORMAT", nil), [formatter stringFromTimeInterval:walkDuration]];
             fitnessStep.spokenInstruction = fitnessStep.title;
             fitnessStep.recorderConfigurations = recorderConfigurations;
-            fitnessStep.shouldShowDefaultTimer = NO;
             fitnessStep.shouldContinueOnFinish = YES;
             fitnessStep.optional = NO;
             fitnessStep.shouldStartTimerAutomatically = YES;
@@ -551,7 +550,6 @@ static void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
             stillStep.title = [NSString stringWithFormat:ORKLocalizedString(@"FITNESS_SIT_INSTRUCTION_FORMAT", nil), [formatter stringFromTimeInterval:restDuration]];
             stillStep.spokenInstruction = stillStep.title;
             stillStep.recorderConfigurations = recorderConfigurations;
-            stillStep.shouldShowDefaultTimer = NO;
             stillStep.shouldContinueOnFinish = YES;
             stillStep.optional = NO;
             stillStep.shouldStartTimerAutomatically = YES;
@@ -632,7 +630,6 @@ static void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
             walkingStep.title = [NSString stringWithFormat:ORKLocalizedString(@"WALK_OUTBOUND_INSTRUCTION_FORMAT", nil), (long long)numberOfStepsPerLeg];
             walkingStep.spokenInstruction = walkingStep.title;
             walkingStep.recorderConfigurations = recorderConfigurations;
-            walkingStep.shouldShowDefaultTimer = NO;
             walkingStep.shouldContinueOnFinish = YES;
             walkingStep.optional = NO;
             walkingStep.shouldStartTimerAutomatically = YES;
@@ -662,7 +659,6 @@ static void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
             walkingStep.title = [NSString stringWithFormat:ORKLocalizedString(@"WALK_RETURN_INSTRUCTION_FORMAT", nil), (long long)numberOfStepsPerLeg];
             walkingStep.spokenInstruction = walkingStep.title;
             walkingStep.recorderConfigurations = recorderConfigurations;
-            walkingStep.shouldShowDefaultTimer = NO;
             walkingStep.shouldContinueOnFinish = YES;
             walkingStep.shouldStartTimerAutomatically = YES;
             walkingStep.optional = NO;
@@ -691,7 +687,6 @@ static void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
             activeStep.spokenInstruction = [NSString stringWithFormat:ORKLocalizedString(@"WALK_STAND_VOICE_INSTRUCTION_FORMAT", nil), durationString];
             activeStep.shouldStartTimerAutomatically = YES;
             activeStep.stepDuration = restDuration;
-            activeStep.shouldShowDefaultTimer = NO;
             activeStep.shouldContinueOnFinish = YES;
             activeStep.optional = NO;
             activeStep.shouldVibrateOnStart = YES;

--- a/ResearchKit/Common/ORKOrderedTask.m
+++ b/ResearchKit/Common/ORKOrderedTask.m
@@ -420,7 +420,7 @@ static void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
         step.title = shortSpeechInstruction ? : ORKLocalizedString(@"AUDIO_INSTRUCTION", nil);
         step.recorderConfigurations = @[[[ORKAudioRecorderConfiguration alloc] initWithIdentifier:ORKAudioRecorderIdentifier
                                                                                  recorderSettings:recordingSettings]];
-        step.duration = duration;
+        step.stepDuration = duration;
         step.shouldContinueOnFinish = YES;
         
         ORKStepArrayAddStep(steps, step);

--- a/ResearchKit/Common/ORKStepViewController.m
+++ b/ResearchKit/Common/ORKStepViewController.m
@@ -65,14 +65,18 @@
 #pragma clang diagnostic ignored "-Wobjc-designated-initializers"
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
-    [self initializeInternalButtonItems];
+    if (self) {
+        [self initializeInternalButtonItems];
+    }
     return self;
 }
 #pragma clang diagnostic pop
 
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
     self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
-    [self initializeInternalButtonItems];
+    if (self) {
+        [self initializeInternalButtonItems];
+    }
     return self;
 }
 

--- a/Testing/ORKTest/ORKTest/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTest/ORKESerialization.m
@@ -383,7 +383,6 @@ ret =
             return [[ORKAudioStep alloc] initWithIdentifier:GETPROP(dict, identifier)];
         },
         (@{
-          PROPERTY(duration, NSNumber, NSObject, YES, nil, nil),
           })),
   ENTRY(ORKSpatialSpanMemoryStep,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {


### PR DESCRIPTION
- An `ORKCountdownLabel` fix which caused the `ORKActiveStepTimerView` to always show 0 as the starting value.
- A small `ORKActiveStep` subclass code homogenization.
- Fix some erroneous init methods missing the `[super init]` success check.