### PR TITLE
Extract ORKDefineStringKey() (was 'DEF_KEY()') to helpers

### DIFF
--- a/ResearchKit/Common/ORKHelpers.h
+++ b/ResearchKit/Common/ORKHelpers.h
@@ -199,3 +199,5 @@ ORKCGFloatNearlyEqualToFloat(CGFloat f1, CGFloat f2) {
     return (ABS(f1 - f2) <= ORKCGFloatEpsilon);
 }
 
+#define ORKDefineStringKey(x) static NSString * const x = @STRINGIFY(x)
+

--- a/ResearchKit/Common/ORKStepHeaderView.m
+++ b/ResearchKit/Common/ORKStepHeaderView.m
@@ -34,20 +34,15 @@
 #import "ORKHelpers.h"
 
 
-#define DEF_KEY(x) static NSString * const x = @STRINGIFY(x)
+ORKDefineStringKey(_IllustrationToCaptionBaselineKey);
+ORKDefineStringKey(_IllustrationToCaptionTopKey);
+ORKDefineStringKey(_CaptionToInstructionKey);
+ORKDefineStringKey(_InstructionToLearnMoreKey);
+ORKDefineStringKey(_LearnMoreToStepViewKey);
 
-DEF_KEY(_IllustrationToCaptionBaselineKey);
-DEF_KEY(_IllustrationToCaptionTopKey);
-DEF_KEY(_CaptionToInstructionKey);
-DEF_KEY(_InstructionToLearnMoreKey);
-DEF_KEY(_LearnMoreToStepViewKey);
-
-DEF_KEY(_InstructionMinBottomSpacingKey);
-DEF_KEY(_CaptionMinBottomSpacingKey);
-DEF_KEY(_HeaderZeroHeightKey);
-
-#undef DEF_KEY
-
+ORKDefineStringKey(_InstructionMinBottomSpacingKey);
+ORKDefineStringKey(_CaptionMinBottomSpacingKey);
+ORKDefineStringKey(_HeaderZeroHeightKey);
 
 #define ORKVerticalContainerLog(...)
 

--- a/ResearchKit/Common/ORKVerticalContainerView.m
+++ b/ResearchKit/Common/ORKVerticalContainerView.m
@@ -34,19 +34,14 @@
 #import "ORKVerticalContainerView_Internal.h"
 
 
-#define DEF_KEY(x) static NSString * const x = @STRINGIFY(x)
+ORKDefineStringKey(_TopToIllustrationConstraintKey);
+ORKDefineStringKey(_IllustrationHeightConstraintKey);
 
-DEF_KEY(_TopToIllustrationConstraintKey);
-DEF_KEY(_IllustrationHeightConstraintKey);
+ORKDefineStringKey(_StepViewToContinueKey);
+ORKDefineStringKey(_StepViewToContinueMinimumKey);
+ORKDefineStringKey(_HeaderMinimumHeightKey);
 
-DEF_KEY(_StepViewToContinueKey);
-DEF_KEY(_StepViewToContinueMinimumKey);
-DEF_KEY(_HeaderMinimumHeightKey);
-
-DEF_KEY(_StepViewCenteringOnWholeViewKey);
-
-#undef DEF_KEY
-
+ORKDefineStringKey(_StepViewCenteringOnWholeViewKey);
 
 static const CGFloat AssumedNavBarHeight = 44;
 static const CGFloat AssumedStatusBarHeight = 20;


### PR DESCRIPTION
Mini pull request: cherry-picked this from the `navigationrules` branch to avoid future conflicts. I plan to define new keys in the constraint refactor.

---

By the way the `_UppercaseConstraintKey` static string names in `ORKStepHeaderView.m` and `ORKVerticalContainerView.m` look a little weird. The `_` prefix feels like it should only be used for *ivar* names. Should we come up with a better naming convention for those?

How about this:
`_IllustrationToCaptionBaselineKey` -> `ORKStepHeaderViewIllustrationToCaptionBaselineKey`,
`_TopToIllustrationConstraintKey` -> `ORKVerticalContainerViewTopToIllustrationConstraintKey `,
etc.