### PR TITLE
Allow users to add a dot to the signature view

### DIFF
--- a/ResearchKit/Consent/ORKSignatureView.m
+++ b/ResearchKit/Consent/ORKSignatureView.m
@@ -227,6 +227,7 @@ static const CGFloat kPointMinDistanceSquared = kPointMinDistance * kPointMinDis
     previousPoint2 = [touch previousLocationInView:self];
     currentPoint = [touch locationInView:self];
     [self.currentPath moveToPoint:currentPoint];
+    [self.currentPath addArcWithCenter:currentPoint radius:0.1 startAngle:0.0 endAngle:2.0 * M_PI clockwise:YES];
     [self gestureTouchesMoved:touches withEvent:event];
 }
 


### PR DESCRIPTION
Add a small circle to the current signature path in touchesBegan to
properly support dots in the signature view. This provides a nicer
experience to users, allowing them to dot their i's.