### PR TITLE
Fix various multitouch issues in ORKSignatureView

### DIFF
--- a/ResearchKit/Consent/ORKSignatureView.m
+++ b/ResearchKit/Consent/ORKSignatureView.m
@@ -55,8 +55,14 @@
 @implementation ORKSignatureGestureRecognizer
 
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
-    self.state = UIGestureRecognizerStateBegan;
-    [self.eventDelegate gestureTouchesBegan:(NSSet *)touches withEvent:(UIEvent *)event];
+    if (touches.count > 1 || self.numberOfTouches > 1) {
+        for (UITouch *touch in touches) {
+            [self ignoreTouch:touch forEvent:event];
+        }
+    } else {
+        self.state = UIGestureRecognizerStateBegan;
+        [self.eventDelegate gestureTouchesBegan:(NSSet *)touches withEvent:(UIEvent *)event];
+    }
 }
 
 - (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event {
@@ -212,10 +218,6 @@ static const CGFloat kPointMinDistanceSquared = kPointMinDistance * kPointMinDis
 #pragma mark Touch Event Handlers
 
 - (void)gestureTouchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
-    if (touches.count > 1 ) {
-        return;
-    }
-    
     UITouch *touch = [touches anyObject];
     
     self.currentPath = [self pathWithRoundedStyle];
@@ -235,10 +237,6 @@ static CGPoint mmid_Point(CGPoint p1, CGPoint p2) {
 }
 
 - (void)gestureTouchesMoved:(NSSet *)touches withEvent:(UIEvent *)event {
-    if (touches.count > 1) {
-        return;
-    }
-    
     UITouch *touch = [touches anyObject];
     
     CGPoint point = [touch locationInView:self];
@@ -276,7 +274,7 @@ static CGPoint mmid_Point(CGPoint p1, CGPoint p2) {
 
 - (void)gestureTouchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
     CGRect rect = [self.currentPath bounds];
-    if (touches.count > 1 || CGSizeEqualToSize(rect.size, CGSizeZero)) {
+    if (CGSizeEqualToSize(rect.size, CGSizeZero)) {
         return;
     }
     


### PR DESCRIPTION
This commit fixes a couple of issues with extra touches in the signature
view:

* Adding a second touch while signing would cause the path to jump to
  the second touch, which is probably not what the user wanted.
* Once two touches were applied to the signature view, if both touches
  ended simultaneously, gestureTouchesEnded: would return before calling
  signatureViewDidEditImage: on the delegate. This could get the UI into
  an odd state where there is a signature in the view but no clear
  button below the view.

By ignoring the extra touches completely, we can also clean up the code
a little and remove the extra touches checks in the various touch event
handlers.