### PR TITLE
Fix double bottom separator in boolean and text choice questions

### DIFF
--- a/ResearchKit/ActiveTasks/ORKToneAudiometryContentView.m
+++ b/ResearchKit/ActiveTasks/ORKToneAudiometryContentView.m
@@ -105,7 +105,7 @@
     ORKScreenType screenType = _screenType;
     const CGFloat HeaderBaselineToCaptionTop = ORKGetMetricForScreenType(ORKScreenMetricCaptionBaselineToTappingLabelTop, screenType);
     const CGFloat AssumedHeaderBaselineToStepViewTop = ORKGetMetricForScreenType(ORKScreenMetricLearnMoreBaselineToStepViewTop, screenType);
-    CGFloat margin = ORKStandardMarginForView(self);
+    CGFloat margin = ORKStandardHorizMarginForView(self);
     self.layoutMargins = (UIEdgeInsets) { .left=margin*2, .right=margin*2 };
 
     static const CGFloat TapButtonBottomToBottom = 36;

--- a/ResearchKit/Common/ORKQuestionStepViewController.m
+++ b/ResearchKit/Common/ORKQuestionStepViewController.m
@@ -560,7 +560,7 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
     tableView.layoutMargins = UIEdgeInsetsZero;
     
     if (indexPath.section == ORKQuestionSectionSpace1 || indexPath.section == ORKQuestionSectionSpace2) {
-        static NSString * SpaceIdentifier = @"Space";
+        static NSString *SpaceIdentifier = @"Space";
         UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:SpaceIdentifier];
         if (cell == nil) {
             cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:SpaceIdentifier];
@@ -591,7 +591,11 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
     cell.layoutMargins = UIEdgeInsetsZero;
-    cell.separatorInset = (UIEdgeInsets){.left=ORKStandardLeftMarginForTableViewCell(tableView)};
+    if (indexPath.section == ORKQuestionSectionSpace2) {
+        cell.separatorInset = (UIEdgeInsets){.left = 10000.0};
+    } else {
+        cell.separatorInset = (UIEdgeInsets){.left = ORKStandardLeftMarginForTableViewCell(tableView)};
+    };
 }
 
 - (BOOL)shouldContinue {

--- a/ResearchKit/Common/ORKResult.h
+++ b/ResearchKit/Common/ORKResult.h
@@ -234,8 +234,6 @@ ORK_CLASS_AVAILABLE
 @end
 
 
-<<<<<<< HEAD
-=======
 /**
  The `ORKToneAudiometryResult` class records the results of a tone audiometry test.
 
@@ -303,7 +301,6 @@ ORK_CLASS_AVAILABLE
 @end
 
 
->>>>>>> 075dc1f7b63c4df7aa546e4545e452be4d8fbdd5
 /**
  The `ORKSpatialSpanMemoryGameTouchSample` class represents a tap during the
  spatial span memory game.


### PR DESCRIPTION
Fixes [Issue #183](https://github.com/ResearchKit/ResearchKit/issues/183).

Needs [pull request #187](https://github.com/ResearchKit/ResearchKit/pull/187) as a pre-requisite.

