### PR TITLE
_signaturePageContent not copied (fix for issue 196)

### DIFF
--- a/ResearchKit/Consent/ORKConsentDocument.m
+++ b/ResearchKit/Consent/ORKConsentDocument.m
@@ -278,7 +278,7 @@
     ORKConsentDocument *doc = [[[self class] allocWithZone:zone] init];
     doc.title = _title;
     doc.signaturePageTitle = _signaturePageTitle;
-    doc.signaturePageContent = _signaturePageTitle;
+    doc.signaturePageContent = _signaturePageContent;
     doc.htmlReviewContent = _htmlReviewContent;
     
     // Deep copy the signatures


### PR DESCRIPTION
Changes to ConsentDocument.m to fix bug outlined in issue 196, _signaturePageContent not being copied when the consent document is copied.