### PR TITLE
Tests for ORKConsentDocument

### DIFF
--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -374,6 +374,7 @@
 		FA7A9D331B0843A9005A2BEA /* ORKConsentSignatureFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = FA7A9D311B0843A9005A2BEA /* ORKConsentSignatureFormatter.h */; };
 		FA7A9D341B0843A9005A2BEA /* ORKConsentSignatureFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7A9D321B0843A9005A2BEA /* ORKConsentSignatureFormatter.m */; };
 		FA7A9D371B09365F005A2BEA /* ORKConsentSectionFormatterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7A9D361B09365F005A2BEA /* ORKConsentSectionFormatterTests.m */; };
+		FA7A9D391B0969A7005A2BEA /* ORKConsentSignatureFormatterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7A9D381B0969A7005A2BEA /* ORKConsentSignatureFormatterTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -791,6 +792,7 @@
 		FA7A9D311B0843A9005A2BEA /* ORKConsentSignatureFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKConsentSignatureFormatter.h; sourceTree = "<group>"; };
 		FA7A9D321B0843A9005A2BEA /* ORKConsentSignatureFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKConsentSignatureFormatter.m; sourceTree = "<group>"; };
 		FA7A9D361B09365F005A2BEA /* ORKConsentSectionFormatterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKConsentSectionFormatterTests.m; sourceTree = "<group>"; };
+		FA7A9D381B0969A7005A2BEA /* ORKConsentSignatureFormatterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKConsentSignatureFormatterTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1678,6 +1680,7 @@
 				86CC8EAA1AC09383001CCD89 /* ORKConsentTests.m */,
 				FA7A9D2A1B082688005A2BEA /* ORKConsentDocumentTests.m */,
 				FA7A9D361B09365F005A2BEA /* ORKConsentSectionFormatterTests.m */,
+				FA7A9D381B0969A7005A2BEA /* ORKConsentSignatureFormatterTests.m */,
 			);
 			name = Consent;
 			sourceTree = "<group>";
@@ -2062,6 +2065,7 @@
 			files = (
 				86CC8EB71AC09383001CCD89 /* ORKDataLoggerTests.m in Sources */,
 				86CC8EBA1AC09383001CCD89 /* ORKResultTests.m in Sources */,
+				FA7A9D391B0969A7005A2BEA /* ORKConsentSignatureFormatterTests.m in Sources */,
 				86CC8EB81AC09383001CCD89 /* ORKHKSampleTests.m in Sources */,
 				86CC8EB51AC09383001CCD89 /* ORKConsentTests.m in Sources */,
 				2EBFE11D1AE1B32D00CB8254 /* ORKUIViewAccessibilityTests.m in Sources */,

--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -368,6 +368,11 @@
 		BC4194291AE8453A00073D6B /* ORKObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = BC4194271AE8453A00073D6B /* ORKObserver.h */; };
 		BC41942A1AE8453A00073D6B /* ORKObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = BC4194281AE8453A00073D6B /* ORKObserver.m */; };
 		BCAD50E81B0201EE0034806A /* ORKTaskTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BCAD50E71B0201EE0034806A /* ORKTaskTests.m */; };
+		FA7A9D2B1B082688005A2BEA /* ORKConsentDocumentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7A9D2A1B082688005A2BEA /* ORKConsentDocumentTests.m */; };
+		FA7A9D2F1B083DD3005A2BEA /* ORKConsentSectionFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = FA7A9D2D1B083DD3005A2BEA /* ORKConsentSectionFormatter.h */; };
+		FA7A9D301B083DD3005A2BEA /* ORKConsentSectionFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7A9D2E1B083DD3005A2BEA /* ORKConsentSectionFormatter.m */; };
+		FA7A9D331B0843A9005A2BEA /* ORKConsentSignatureFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = FA7A9D311B0843A9005A2BEA /* ORKConsentSignatureFormatter.h */; };
+		FA7A9D341B0843A9005A2BEA /* ORKConsentSignatureFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7A9D321B0843A9005A2BEA /* ORKConsentSignatureFormatter.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -779,6 +784,11 @@
 		BC4194281AE8453A00073D6B /* ORKObserver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKObserver.m; sourceTree = "<group>"; };
 		BCAD50E71B0201EE0034806A /* ORKTaskTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKTaskTests.m; sourceTree = "<group>"; };
 		BCFB2EAF1AE70E4E0070B5D0 /* ORKConsentSceneViewController_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ORKConsentSceneViewController_Internal.h; sourceTree = "<group>"; };
+		FA7A9D2A1B082688005A2BEA /* ORKConsentDocumentTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKConsentDocumentTests.m; sourceTree = "<group>"; };
+		FA7A9D2D1B083DD3005A2BEA /* ORKConsentSectionFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKConsentSectionFormatter.h; sourceTree = "<group>"; };
+		FA7A9D2E1B083DD3005A2BEA /* ORKConsentSectionFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKConsentSectionFormatter.m; sourceTree = "<group>"; };
+		FA7A9D311B0843A9005A2BEA /* ORKConsentSignatureFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKConsentSignatureFormatter.h; sourceTree = "<group>"; };
+		FA7A9D321B0843A9005A2BEA /* ORKConsentSignatureFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKConsentSignatureFormatter.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -929,6 +939,7 @@
 		86C40BEB1A8D7C5C00081FAC /* Consent */ = {
 			isa = PBXGroup;
 			children = (
+				FA7A9D2C1B083D90005A2BEA /* Formatters */,
 				B12EFF451AB214E000A80147 /* Model */,
 				B12EFF461AB2150C00A80147 /* Visual */,
 				B12EFF481AB2152D00A80147 /* Sharing */,
@@ -944,6 +955,7 @@
 				86CC8EA81AC09383001CCD89 /* ORKAccessibilityTests.m */,
 				86CC8EA91AC09383001CCD89 /* ORKChoiceAnswerFormatHelperTests.m */,
 				86CC8EAA1AC09383001CCD89 /* ORKConsentTests.m */,
+				FA7A9D2A1B082688005A2BEA /* ORKConsentDocumentTests.m */,
 				86CC8EAB1AC09383001CCD89 /* ORKDataLoggerManagerTests.m */,
 				86CC8EAC1AC09383001CCD89 /* ORKDataLoggerTests.m */,
 				86CC8EAD1AC09383001CCD89 /* ORKHKSampleTests.m */,
@@ -1648,6 +1660,17 @@
 			name = Misc;
 			sourceTree = "<group>";
 		};
+		FA7A9D2C1B083D90005A2BEA /* Formatters */ = {
+			isa = PBXGroup;
+			children = (
+				FA7A9D2D1B083DD3005A2BEA /* ORKConsentSectionFormatter.h */,
+				FA7A9D2E1B083DD3005A2BEA /* ORKConsentSectionFormatter.m */,
+				FA7A9D311B0843A9005A2BEA /* ORKConsentSignatureFormatter.h */,
+				FA7A9D321B0843A9005A2BEA /* ORKConsentSignatureFormatter.m */,
+			);
+			name = Formatters;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -1742,6 +1765,7 @@
 				86C40D7C1A8D7C5C00081FAC /* ORKScaleValueLabel.h in Headers */,
 				86C40E2C1A8D7C5C00081FAC /* ORKVisualConsentStep.h in Headers */,
 				86C40CB81A8D7C5C00081FAC /* ORKVoiceEngine.h in Headers */,
+				FA7A9D331B0843A9005A2BEA /* ORKConsentSignatureFormatter.h in Headers */,
 				86C40C5A1A8D7C5C00081FAC /* ORKWalkingTaskStep.h in Headers */,
 				86C40E361A8D7C5C00081FAC /* ORKVisualConsentTransitionAnimator.h in Headers */,
 				86AD910D1AB7AE4100361FEB /* ORKNavigationContainerView_Internal.h in Headers */,
@@ -1788,6 +1812,7 @@
 				86C40C821A8D7C5C00081FAC /* ORKActiveStep_Internal.h in Headers */,
 				86C40D481A8D7C5C00081FAC /* ORKInstructionStepViewController_Internal.h in Headers */,
 				86C40D341A8D7C5C00081FAC /* ORKHelpers.h in Headers */,
+				FA7A9D2F1B083DD3005A2BEA /* ORKConsentSectionFormatter.h in Headers */,
 				86C40E341A8D7C5C00081FAC /* ORKVisualConsentStepViewController_Internal.h in Headers */,
 				86C40D381A8D7C5C00081FAC /* ORKHTMLPDFWriter.h in Headers */,
 				86C40D561A8D7C5C00081FAC /* ORKOrderedTask.h in Headers */,
@@ -2033,6 +2058,7 @@
 				2EBFE1201AE1B74100CB8254 /* ORKVoiceEngineTests.m in Sources */,
 				BCAD50E81B0201EE0034806A /* ORKTaskTests.m in Sources */,
 				86CC8EBB1AC09383001CCD89 /* ORKTextChoiceCellGroupTests.m in Sources */,
+				FA7A9D2B1B082688005A2BEA /* ORKConsentDocumentTests.m in Sources */,
 				86D348021AC161B0006DB02B /* ORKRecorderTests.m in Sources */,
 				86CC8EB61AC09383001CCD89 /* ORKDataLoggerManagerTests.m in Sources */,
 				86CC8EB31AC09383001CCD89 /* ORKAccessibilityTests.m in Sources */,
@@ -2112,6 +2138,7 @@
 				86C40D7E1A8D7C5C00081FAC /* ORKScaleValueLabel.m in Sources */,
 				86C40D901A8D7C5C00081FAC /* ORKStep.m in Sources */,
 				86C40D2E1A8D7C5C00081FAC /* ORKHeadlineLabel.m in Sources */,
+				FA7A9D341B0843A9005A2BEA /* ORKConsentSignatureFormatter.m in Sources */,
 				86C40CFC1A8D7C5C00081FAC /* ORKCaption1Label.m in Sources */,
 				86C40E001A8D7C5C00081FAC /* ORKConsentDocument.m in Sources */,
 				86C40CDE1A8D7C5C00081FAC /* ORKTintedImageView.m in Sources */,
@@ -2177,6 +2204,7 @@
 				86C40D661A8D7C5C00081FAC /* ORKQuestionStepViewController.m in Sources */,
 				86C40DF41A8D7C5C00081FAC /* ORKConsentReviewController.m in Sources */,
 				147503BA1AEE807C004B17F3 /* ORKToneAudiometryStep.m in Sources */,
+				FA7A9D301B083DD3005A2BEA /* ORKConsentSectionFormatter.m in Sources */,
 				86C40D2A1A8D7C5C00081FAC /* ORKFormTextView.m in Sources */,
 				86C40DD41A8D7C5C00081FAC /* ORKTextButton.m in Sources */,
 				86C40C981A8D7C5C00081FAC /* ORKDataLogger.m in Sources */,

--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -373,6 +373,7 @@
 		FA7A9D301B083DD3005A2BEA /* ORKConsentSectionFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7A9D2E1B083DD3005A2BEA /* ORKConsentSectionFormatter.m */; };
 		FA7A9D331B0843A9005A2BEA /* ORKConsentSignatureFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = FA7A9D311B0843A9005A2BEA /* ORKConsentSignatureFormatter.h */; };
 		FA7A9D341B0843A9005A2BEA /* ORKConsentSignatureFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7A9D321B0843A9005A2BEA /* ORKConsentSignatureFormatter.m */; };
+		FA7A9D371B09365F005A2BEA /* ORKConsentSectionFormatterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7A9D361B09365F005A2BEA /* ORKConsentSectionFormatterTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -789,6 +790,7 @@
 		FA7A9D2E1B083DD3005A2BEA /* ORKConsentSectionFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKConsentSectionFormatter.m; sourceTree = "<group>"; };
 		FA7A9D311B0843A9005A2BEA /* ORKConsentSignatureFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKConsentSignatureFormatter.h; sourceTree = "<group>"; };
 		FA7A9D321B0843A9005A2BEA /* ORKConsentSignatureFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKConsentSignatureFormatter.m; sourceTree = "<group>"; };
+		FA7A9D361B09365F005A2BEA /* ORKConsentSectionFormatterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKConsentSectionFormatterTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -951,11 +953,10 @@
 		86CC8EA61AC09383001CCD89 /* ResearchKitTests */ = {
 			isa = PBXGroup;
 			children = (
+				FA7A9D351B09362D005A2BEA /* Consent */,
 				86D348001AC16175006DB02B /* ORKRecorderTests.m */,
 				86CC8EA81AC09383001CCD89 /* ORKAccessibilityTests.m */,
 				86CC8EA91AC09383001CCD89 /* ORKChoiceAnswerFormatHelperTests.m */,
-				86CC8EAA1AC09383001CCD89 /* ORKConsentTests.m */,
-				FA7A9D2A1B082688005A2BEA /* ORKConsentDocumentTests.m */,
 				86CC8EAB1AC09383001CCD89 /* ORKDataLoggerManagerTests.m */,
 				86CC8EAC1AC09383001CCD89 /* ORKDataLoggerTests.m */,
 				86CC8EAD1AC09383001CCD89 /* ORKHKSampleTests.m */,
@@ -1671,6 +1672,16 @@
 			name = Formatters;
 			sourceTree = "<group>";
 		};
+		FA7A9D351B09362D005A2BEA /* Consent */ = {
+			isa = PBXGroup;
+			children = (
+				86CC8EAA1AC09383001CCD89 /* ORKConsentTests.m */,
+				FA7A9D2A1B082688005A2BEA /* ORKConsentDocumentTests.m */,
+				FA7A9D361B09365F005A2BEA /* ORKConsentSectionFormatterTests.m */,
+			);
+			name = Consent;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -2059,6 +2070,7 @@
 				BCAD50E81B0201EE0034806A /* ORKTaskTests.m in Sources */,
 				86CC8EBB1AC09383001CCD89 /* ORKTextChoiceCellGroupTests.m in Sources */,
 				FA7A9D2B1B082688005A2BEA /* ORKConsentDocumentTests.m in Sources */,
+				FA7A9D371B09365F005A2BEA /* ORKConsentSectionFormatterTests.m in Sources */,
 				86D348021AC161B0006DB02B /* ORKRecorderTests.m in Sources */,
 				86CC8EB61AC09383001CCD89 /* ORKDataLoggerManagerTests.m in Sources */,
 				86CC8EB31AC09383001CCD89 /* ORKAccessibilityTests.m in Sources */,

--- a/ResearchKit/Consent/ORKConsentDocument.h
+++ b/ResearchKit/Consent/ORKConsentDocument.h
@@ -32,6 +32,8 @@
 #import <ResearchKit/ResearchKit.h>
 #import <ResearchKit/ORKConsentSignature.h>
 
+@class ORKHTMLPDFWriter;
+
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -139,6 +141,14 @@ ORK_CLASS_AVAILABLE
 @property (nonatomic, copy, nullable) NSString *htmlReviewContent;
 
 /// @name PDF generation
+
+/**
+ Initializer with ORKHTMLPDFWriter parameter. Allows for injecting mock dependency for the
+ purposes of isolated unit testing.
+
+ @param writer   The instance of the ORKHTMLPDFWriter upon which the class depends.
+ */
+- (instancetype)initWithHTMLPDFWriter:(ORKHTMLPDFWriter *)writer;
 
 /**
  Writes the document's content into a PDF file.

--- a/ResearchKit/Consent/ORKConsentDocument.h
+++ b/ResearchKit/Consent/ORKConsentDocument.h
@@ -33,6 +33,8 @@
 #import <ResearchKit/ORKConsentSignature.h>
 
 @class ORKHTMLPDFWriter;
+@class ORKConsentSectionFormatter;
+@class ORKConsentSignatureFormatter;
 
 
 NS_ASSUME_NONNULL_BEGIN
@@ -148,7 +150,9 @@ ORK_CLASS_AVAILABLE
 
  @param writer   The instance of the ORKHTMLPDFWriter upon which the class depends.
  */
-- (instancetype)initWithHTMLPDFWriter:(ORKHTMLPDFWriter *)writer;
+- (instancetype)initWithHTMLPDFWriter:(ORKHTMLPDFWriter *)writer
+              consentSectionFormatter:(ORKConsentSectionFormatter *)sectionFormatter
+            consentSignatureFormatter:(ORKConsentSignatureFormatter *)signatureFormatter;
 
 /**
  Writes the document's content into a PDF file.

--- a/ResearchKit/Consent/ORKConsentDocument.m
+++ b/ResearchKit/Consent/ORKConsentDocument.m
@@ -45,9 +45,30 @@
     NSMutableArray *_signatures;
 }
 
+#pragma mark - Initializers
+
+- (instancetype)init {
+    return [self initWithHTMLPDFWriter:[[ORKHTMLPDFWriter alloc] init]];
+}
+
+- (instancetype)initWithHTMLPDFWriter:(ORKHTMLPDFWriter * __nonnull)writer {
+    if (self = [super init]) {
+        _writer = writer;
+    }
+    return self;
+}
+
+#pragma mark - Accessors
+
 - (void)setSignatures:(NSArray *)signatures {
     _signatures = [signatures mutableCopy];
 }
+
+- (NSArray *)signatures {
+    return [_signatures copy];
+}
+
+#pragma mark - Public
 
 - (void)addSignature:(ORKConsentSignature *)signature {
     if (! _signatures) {
@@ -56,12 +77,7 @@
     [_signatures addObject:signature];
 }
 
-- (NSArray *)signatures {
-    return [_signatures copy];
-}
-
 - (void)makePDFWithCompletionHandler:(void (^)(NSData *data, NSError *error))completionBlock {
-    self.writer = [[ORKHTMLPDFWriter alloc] init];
     return [_writer writePDFFromHTML:[self htmlForMobile:NO withTitle:nil detail:nil] withCompletionBlock:^(NSData *data, NSError *error) {
         if (error) {
             // Pass the webview error straight through. This is a pretty exceptional
@@ -72,6 +88,8 @@
         }
     }];
 }
+
+#pragma mark - Private
 
 - (NSString *)mobileHTMLWithTitle:(NSString *)title detail:(NSString *)detail {
     return [self htmlForMobile:YES withTitle:title detail:detail];
@@ -229,9 +247,7 @@
     return [[self class] wrapHTMLBody:body mobile:mobile];
 }
 
-+ (BOOL)supportsSecureCoding {
-    return YES;
-}
+#pragma mark - <NSSecureCoding>
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super init];
@@ -256,23 +272,11 @@
     ORK_ENCODE_OBJ(aCoder, sections);
 }
 
-- (BOOL)isEqual:(id)object {
-    if ([self class] != [object class]) {
-        return NO;
-    }
-    
-    __typeof(self) castObject = object;
-    return (ORKEqualObjects(self.title, castObject.title)
-            && ORKEqualObjects(self.signaturePageTitle, castObject.signaturePageTitle)
-            && ORKEqualObjects(self.signaturePageContent, castObject.signaturePageContent)
-            && ORKEqualObjects(self.htmlReviewContent, castObject.htmlReviewContent)
-            && ORKEqualObjects(self.signatures, castObject.signatures)
-            && ORKEqualObjects(self.sections, castObject.sections));
++ (BOOL)supportsSecureCoding {
+    return YES;
 }
 
-- (NSUInteger)hash {
-    return [_title hash] ^ [_sections hash];
-}
+#pragma mark - <NSCopying>
 
 - (instancetype)copyWithZone:(NSZone *)zone {
     ORKConsentDocument *doc = [[[self class] allocWithZone:zone] init];
@@ -288,6 +292,26 @@
     doc.sections = ORKArrayCopyObjects(_sections);
     
     return doc;
+}
+
+#pragma mark - <NSObject>
+
+- (BOOL)isEqual:(id)object {
+    if ([self class] != [object class]) {
+        return NO;
+    }
+
+    __typeof(self) castObject = object;
+    return (ORKEqualObjects(self.title, castObject.title)
+            && ORKEqualObjects(self.signaturePageTitle, castObject.signaturePageTitle)
+            && ORKEqualObjects(self.signaturePageContent, castObject.signaturePageContent)
+            && ORKEqualObjects(self.htmlReviewContent, castObject.htmlReviewContent)
+            && ORKEqualObjects(self.signatures, castObject.signatures)
+            && ORKEqualObjects(self.sections, castObject.sections));
+}
+
+- (NSUInteger)hash {
+    return [_title hash] ^ [_sections hash];
 }
 
 @end

--- a/ResearchKit/Consent/ORKConsentDocument_Internal.h
+++ b/ResearchKit/Consent/ORKConsentDocument_Internal.h
@@ -35,10 +35,14 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class ORKHTMLPDFWriter;
+@class ORKConsentSectionFormatter;
+@class ORKConsentSignatureFormatter;
 
 @interface ORKConsentDocument ()
 
 @property (nonatomic, strong, nullable) ORKHTMLPDFWriter *writer;
+@property (nonatomic, strong, nullable) ORKConsentSectionFormatter *sectionFormatter;
+@property (nonatomic, strong, nullable) ORKConsentSignatureFormatter *signatureFormatter;
 
 + (NSString *)wrapHTMLBody:(NSString *)body mobile:(BOOL)mobile;
 

--- a/ResearchKit/Consent/ORKConsentSectionFormatter.h
+++ b/ResearchKit/Consent/ORKConsentSectionFormatter.h
@@ -1,0 +1,7 @@
+#import <ResearchKit/ResearchKit.h>
+
+@interface ORKConsentSectionFormatter : NSObject
+
+- (NSString *)HTMLForSection:(ORKConsentSection *)section;
+
+@end

--- a/ResearchKit/Consent/ORKConsentSectionFormatter.m
+++ b/ResearchKit/Consent/ORKConsentSectionFormatter.m
@@ -1,0 +1,12 @@
+#import "ORKConsentSectionFormatter.h"
+#import "ORKConsentSection_Internal.h"
+
+@implementation ORKConsentSectionFormatter
+
+- (NSString *)HTMLForSection:(ORKConsentSection *)section {
+    NSString *title = [NSString stringWithFormat:@"<h4>%@</h4>", section.formalTitle?:(section.title?:@"")];
+    NSString *content = [NSString stringWithFormat:@"<p>%@</p>", section.htmlContent?:(section.escapedContent?:@"")];
+    return [NSString stringWithFormat:@"%@%@", title, content];
+}
+
+@end

--- a/ResearchKit/Consent/ORKConsentSignatureFormatter.h
+++ b/ResearchKit/Consent/ORKConsentSignatureFormatter.h
@@ -1,0 +1,8 @@
+#import <ResearchKit/ResearchKit.h>
+#import <ResearchKit/ORKConsentSignature.h>
+
+@interface ORKConsentSignatureFormatter : NSObject
+
+- (NSString *)HTMLForSignature:(ORKConsentSignature *)signature;
+
+@end

--- a/ResearchKit/Consent/ORKConsentSignatureFormatter.m
+++ b/ResearchKit/Consent/ORKConsentSignatureFormatter.m
@@ -1,0 +1,68 @@
+#import "ORKConsentSignatureFormatter.h"
+#import "ORKDefines_Private.h"
+
+@implementation ORKConsentSignatureFormatter
+
+- (NSString *)HTMLForSignature:(ORKConsentSignature *)signature {
+    NSMutableString *body = [NSMutableString new];
+
+    NSString *hr = @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />";
+
+    NSString *signatureElementWrapper = @"<p><br/><div class='sigbox'><div class='inbox'>%@</div></div>%@%@</p>";
+
+    BOOL addedSig = NO;
+
+    NSMutableArray *signatureElements = [NSMutableArray array];
+
+    // Signature
+    if (signature.requiresName || signature.familyName || signature.givenName) {
+        addedSig = YES;
+        NSString *nameStr = @"&nbsp;";
+        if (signature.familyName || signature.givenName) {
+            NSMutableArray *names = [NSMutableArray array];
+            if (signature.givenName) {
+                [names addObject:signature.givenName];
+            }
+            if (signature.familyName) {
+                [names addObject:signature.familyName];
+            }
+            nameStr = [names componentsJoinedByString:@"&nbsp;"];
+        }
+
+        NSString *titleFormat = ORKLocalizedString(@"CONSENT_DOC_LINE_PRINTED_NAME", nil);
+        [signatureElements addObject:[NSString stringWithFormat:signatureElementWrapper, nameStr, hr, [NSString stringWithFormat:titleFormat,signature.title]]];
+    }
+
+    if (signature.requiresSignatureImage || signature.signatureImage) {
+        addedSig = YES;
+        NSString *imageTag = nil;
+
+        if (signature.signatureImage) {
+            NSString *base64 = [UIImagePNGRepresentation(signature.signatureImage) base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+            imageTag = [NSString stringWithFormat:@"<img width='100%%' alt='star' src='data:image/png;base64,%@' />", base64];
+        } else {
+            [body appendString:@"<br/>"];
+        }
+        NSString *titleFormat = ORKLocalizedString(@"CONSENT_DOC_LINE_SIGNATURE", nil);
+        [signatureElements addObject:[NSString stringWithFormat:signatureElementWrapper, imageTag?:@"&nbsp;", hr, [NSString stringWithFormat:titleFormat, signature.title]]];
+    }
+
+    if (addedSig) {
+        [signatureElements addObject:[NSString stringWithFormat:signatureElementWrapper, signature.signatureDate?:@"&nbsp;", hr, ORKLocalizedString(@"CONSENT_DOC_LINE_DATE", nil)]];
+    }
+
+    NSInteger numElements = [signatureElements count];
+    if (numElements > 1) {
+        [body appendString:[NSString stringWithFormat:@"<div class='grid border'>"]];
+        for (NSString *element in signatureElements) {
+            [body appendString:[NSString stringWithFormat:@"<div class='col-1-3 border'>%@</div>",element]];
+        }
+
+        [body appendString:@"</div>"];
+    } else if (numElements == 1) {
+        [body appendString:[NSString stringWithFormat:@"<div width='200'>%@</div>",[signatureElements lastObject]]];
+    }
+    return body;
+}
+
+@end

--- a/ResearchKitTests/ORKConsentDocumentTests.m
+++ b/ResearchKitTests/ORKConsentDocumentTests.m
@@ -1,0 +1,135 @@
+#import <XCTest/XCTest.h>
+#import "ORKConsentDocument.h"
+#import "ORKHTMLPDFWriter.h"
+#import "ORKConsentSectionFormatter.h"
+#import "ORKConsentSignatureFormatter.h"
+
+@interface ORKMockHTMLPDFWriter : ORKHTMLPDFWriter
+@property (nonatomic, copy) NSString *html;
+@property (nonatomic, copy) void (^completionBlock)(NSData *, NSError *);
+@end
+
+@implementation ORKMockHTMLPDFWriter
+
+- (void)writePDFFromHTML:(NSString *)html withCompletionBlock:(void (^)(NSData *, NSError *))completionBlock {
+    self.html = html;
+    self.completionBlock = completionBlock;
+}
+
+@end
+
+@interface ORKMockConsentSectionFormatter : ORKConsentSectionFormatter
+@end
+
+@implementation ORKMockConsentSectionFormatter
+
+- (NSString *)HTMLForSection:(ORKConsentSection *)section {
+    return @"html for section";
+}
+
+@end
+
+@interface ORKMockConsentSignatureFormatter : ORKConsentSignatureFormatter
+
+@end
+
+@implementation ORKMockConsentSignatureFormatter
+
+- (NSString *)HTMLForSignature:(ORKConsentSignature *)signature {
+    return @"html for signature";
+}
+
+@end
+
+
+@interface ORKConsentDocumentTests : XCTestCase
+@property (nonatomic, strong) ORKConsentDocument *document;
+@property (nonatomic, strong) ORKMockHTMLPDFWriter *mockWriter;
+@end
+
+@implementation ORKConsentDocumentTests
+
+- (void)setUp {
+    [super setUp];
+
+    self.mockWriter = [[ORKMockHTMLPDFWriter alloc] init];
+
+    self.document = [[ORKConsentDocument alloc] initWithHTMLPDFWriter:self.mockWriter
+                                              consentSectionFormatter:[[ORKMockConsentSectionFormatter alloc] init]
+                                            consentSignatureFormatter:[[ORKMockConsentSignatureFormatter alloc] init]];
+}
+
+- (void)tearDown {
+    self.document = nil;
+    [super tearDown];
+}
+
+- (NSString *)htmlWithContent:(NSString *)content {
+    NSString *boilerplateHeader = @"<html><head><style>@media print { .pagebreak { page-break-before: always; } }\nh1, h2 { text-align: center; }\nh2, h3 { margin-top: 3em; }\nbody, p, h1, h2, h3 { font-family: Helvetica; }\n.col-1-3 { width: 33.3%; float: left; padding-right: 20px; }\n.sigbox { position: relative; height: 100px; max-height:100px; display: inline-block; bottom: 10px }\n.inbox { position: relative; top: 100%%; transform: translateY(-100%%); -webkit-transform: translateY(-100%%);  }\n.grid:after { content: \"\"; display: table; clear: both; }\n.border { -webkit-box-sizing: border-box; box-sizing: border-box; }\n</style></head><body><div class='header'></div>";
+    NSString *boilerplateFooter = @"</body></html>";
+
+    return [NSString stringWithFormat:@"%@%@%@", boilerplateHeader, content, boilerplateFooter];
+}
+
+- (void)testMakePDFWithCompletionHandler_withHTMLReviewContent_callsWriterWithCorrectHTML {
+    self.document.htmlReviewContent = @"some content";
+    [self.document makePDFWithCompletionHandler:^(NSData *data, NSError *error) {}];
+    XCTAssertEqualObjects(self.mockWriter.html, [self htmlWithContent:@"some content"]);
+}
+
+- (void)testMakePDFWithCompletionHandler_withoutHTMLReviewContent_callsWriterWithCorrectHTML {
+    self.document.title = @"A Title";
+    self.document.sections = @[
+                               [[ORKConsentSection alloc] init],
+                               [[ORKConsentSection alloc] init]
+                               ];
+    self.document.signaturePageTitle = @"Signature Page Title";
+    self.document.signaturePageContent = @"signature page content";
+    self.document.signatures = @[
+                                 [[ORKConsentSignature alloc] init],
+                                 [[ORKConsentSignature alloc] init]
+                                 ];
+
+    NSString *content = @"<h3>A Title</h3>"
+                        @"html for section"
+                        @"html for section"
+                        @"<h4 class=\"pagebreak\" >Signature Page Title</h4>"
+                        @"<p>signature page content</p>"
+                        @"html for signature"
+                        @"html for signature";
+
+    [self.document makePDFWithCompletionHandler:^(NSData *data, NSError *error) {}];
+    XCTAssertEqualObjects(self.mockWriter.html, [self htmlWithContent:content]);
+}
+
+- (void)testMakePDFWithCompletionHandler_whenWriterReturnsData_callsCompletionBlockWithData {
+    __block NSData *passedData;
+    __block NSError *passedError;
+    [self.document makePDFWithCompletionHandler:^(NSData *data, NSError *error) {
+        passedData = data;
+        passedError = error;
+    }];
+
+    NSData *data = [NSData data];
+    self.mockWriter.completionBlock(data, nil);
+
+    XCTAssertEqualObjects(passedData, data);
+    XCTAssertEqualObjects(passedError, nil);
+}
+
+- (void)testMakePDFWithCompletionHandler_whenWriterReturnsError_callsCompletionBlockWithError {
+    __block NSData *passedData;
+    __block NSError *passedError;
+    [self.document makePDFWithCompletionHandler:^(NSData *data, NSError *error) {
+        passedData = data;
+        passedError = error;
+    }];
+
+    NSError *error = [NSError errorWithDomain:@"some error domain" code:123 userInfo:@{}];
+    self.mockWriter.completionBlock(nil, error);
+
+    XCTAssertEqualObjects(passedData, nil);
+    XCTAssertEqualObjects(passedError, error);
+}
+
+@end

--- a/ResearchKitTests/ORKConsentSectionFormatterTests.m
+++ b/ResearchKitTests/ORKConsentSectionFormatterTests.m
@@ -1,0 +1,40 @@
+//
+//  ORKConsentSectionFormatterTests.m
+//  ResearchKit
+//
+//  Created by Alex on 5/17/15.
+//  Copyright (c) 2015 researchkit.org. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+#import <XCTest/XCTest.h>
+
+@interface ORKConsentSectionFormatterTests : XCTestCase
+
+@end
+
+@implementation ORKConsentSectionFormatterTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    XCTAssert(YES, @"Pass");
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end

--- a/ResearchKitTests/ORKConsentSectionFormatterTests.m
+++ b/ResearchKitTests/ORKConsentSectionFormatterTests.m
@@ -1,40 +1,46 @@
-//
-//  ORKConsentSectionFormatterTests.m
-//  ResearchKit
-//
-//  Created by Alex on 5/17/15.
-//  Copyright (c) 2015 researchkit.org. All rights reserved.
-//
-
-#import <Cocoa/Cocoa.h>
 #import <XCTest/XCTest.h>
+#import "ORKConsentSectionFormatter.h"
+#import "ORKConsentSection_Internal.h"
 
 @interface ORKConsentSectionFormatterTests : XCTestCase
-
+@property (nonatomic, strong) ORKConsentSectionFormatter *formatter;
+@property (nonatomic, strong) ORKConsentSection *section;
 @end
 
 @implementation ORKConsentSectionFormatterTests
 
 - (void)setUp {
     [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
+    self.formatter = [[ORKConsentSectionFormatter alloc] init];
+    self.section = [[ORKConsentSection alloc] init];
 }
 
 - (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    self.formatter = nil;
+    self.section = nil;
     [super tearDown];
 }
 
-- (void)testExample {
-    // This is an example of a functional test case.
-    XCTAssert(YES, @"Pass");
+- (void)testHTMLForSection_whenSectionHasFormalTitle_formatsFormalTitle {
+    self.section.formalTitle = @"Formal Title";
+    self.section.title = @"Informal Title";
+    XCTAssertEqualObjects([self.formatter HTMLForSection:self.section], @"<h4>Formal Title</h4><p></p>");
 }
 
-- (void)testPerformanceExample {
-    // This is an example of a performance test case.
-    [self measureBlock:^{
-        // Put the code you want to measure the time of here.
-    }];
+- (void)testHTMLForSection_whenSectionHasNoFormalTitle_formatsFormalTitle {
+    self.section.title = @"Informal Title";
+    XCTAssertEqualObjects([self.formatter HTMLForSection:self.section], @"<h4>Informal Title</h4><p></p>");
+}
+
+- (void)testHTMLForSection_whenSectionHasHTMLContent_formatsHTMLContent {
+    self.section.htmlContent = @"html content";
+    self.section.content = @"other content";
+    XCTAssertEqualObjects([self.formatter HTMLForSection:self.section], @"<h4></h4><p>html content</p>");
+}
+
+- (void)testHTMLForSection_whenSectionHasNoHTMLContent_formatsEscapedContent {
+    self.section.content = @"unescaped content\nwith special characters such as < >";
+    XCTAssertEqualObjects([self.formatter HTMLForSection:self.section], @"<h4></h4><p>unescaped content<br/>with special characters such as &lt; &gt;</p>");
 }
 
 @end

--- a/ResearchKitTests/ORKConsentSignatureFormatterTests.m
+++ b/ResearchKitTests/ORKConsentSignatureFormatterTests.m
@@ -1,40 +1,148 @@
-//
-//  ORKConsentSignatureFormatterTests.m
-//  ResearchKit
-//
-//  Created by Alex on 5/17/15.
-//  Copyright (c) 2015 researchkit.org. All rights reserved.
-//
-
-#import <Cocoa/Cocoa.h>
 #import <XCTest/XCTest.h>
+#import "ORKConsentSignatureFormatter.h"
 
 @interface ORKConsentSignatureFormatterTests : XCTestCase
-
+@property (nonatomic, strong) ORKConsentSignatureFormatter *formatter;
+@property (nonatomic, strong) ORKConsentSignature *signature;
 @end
 
 @implementation ORKConsentSignatureFormatterTests
 
 - (void)setUp {
     [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
+
+    self.formatter = [[ORKConsentSignatureFormatter alloc] init];
+    self.signature = [[ORKConsentSignature alloc] init];
 }
 
 - (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    self.formatter = nil;
+    self.signature = nil;
+
     [super tearDown];
 }
 
-- (void)testExample {
-    // This is an example of a functional test case.
-    XCTAssert(YES, @"Pass");
+- (void)testHTMLForSignature_withNameNotRequired_formatsNames {
+    self.signature.requiresName = NO;
+    NSString *html;
+    html =  @"<br/><div class='grid border'><div class='col-1-3 border'><p><br/>"
+            @"<div class='sigbox'><div class='inbox'>&nbsp;</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />"
+            @"(null)'s Signature</p></div>"
+            @"<div class='col-1-3 border'><p><br/><div class='sigbox'><div class='inbox'>&nbsp;</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />"
+            @"Date</p></div></div>";
+    XCTAssertEqualObjects([self.formatter HTMLForSignature:self.signature], html);
 }
 
-- (void)testPerformanceExample {
-    // This is an example of a performance test case.
-    [self measureBlock:^{
-        // Put the code you want to measure the time of here.
-    }];
+- (void)testHTMLForSignature_withNameRequired_formatsNames {
+    self.signature.requiresName = YES;
+    self.signature.title = @"Title";
+    NSString *html;
+    html =  @"<br/><div class='grid border'><div class='col-1-3 border'><p><br/><div class='sigbox'>"
+            @"<div class='inbox'>&nbsp;</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />"
+            @"Title's Name (printed)</p></div>"
+            @"<div class='col-1-3 border'><p><br/><div class='sigbox'><div class='inbox'>&nbsp;</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />"
+            @"Title's Signature</p></div>"
+            @"<div class='col-1-3 border'><p><br/><div class='sigbox'><div class='inbox'>&nbsp;</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />"
+            @"Date</p></div></div>";
+    XCTAssertEqualObjects([self.formatter HTMLForSignature:self.signature], html);
+
+    self.signature.familyName = @"Family";
+    html =  @"<br/><div class='grid border'><div class='col-1-3 border'><p><br/><div class='sigbox'>"
+            @"<div class='inbox'>Family</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />"
+            @"Title's Name (printed)</p></div>"
+            @"<div class='col-1-3 border'><p><br/><div class='sigbox'><div class='inbox'>&nbsp;</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />"
+            @"Title's Signature</p></div>"
+            @"<div class='col-1-3 border'><p><br/><div class='sigbox'><div class='inbox'>&nbsp;</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />"
+            @"Date</p></div></div>";
+    XCTAssertEqualObjects([self.formatter HTMLForSignature:self.signature], html);
+
+    self.signature.givenName = @"Given";
+    html =  @"<br/><div class='grid border'><div class='col-1-3 border'><p><br/><div class='sigbox'>"
+            @"<div class='inbox'>Given&nbsp;Family</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />"
+            @"Title's Name (printed)</p></div><div class='col-1-3 border'>"
+            @"<p><br/><div class='sigbox'><div class='inbox'>&nbsp;</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />"
+            @"Title's Signature</p></div>"
+            @"<div class='col-1-3 border'><p><br/><div class='sigbox'><div class='inbox'>&nbsp;</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />"
+            @"Date</p></div></div>";
+    XCTAssertEqualObjects([self.formatter HTMLForSignature:self.signature], html);
+}
+
+- (void)testHTMLForSignature_withSignatureImageNotRequired_formatsImage {
+    self.signature.requiresSignatureImage = NO;
+    NSString *html;
+    html =  @"<div class='grid border'><div class='col-1-3 border'><p><br/><div class='sigbox'>"
+            @"<div class='inbox'>&nbsp;</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />"
+            @"(null)'s Name (printed)</p></div>"
+            @"<div class='col-1-3 border'><p><br/><div class='sigbox'><div class='inbox'>&nbsp;</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />"
+            @"Date</p></div></div>";
+    XCTAssertEqualObjects([self.formatter HTMLForSignature:self.signature], html);
+}
+
+- (void)testHTMLForSignature_withSignatureImageRequired_formatsImage {
+    self.signature.requiresSignatureImage = YES;
+    NSString *html;
+    html =  @"<br/><div class='grid border'><div class='col-1-3 border'><p><br/><div class='sigbox'>"
+            @"<div class='inbox'>&nbsp;</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />"
+            @"(null)'s Name (printed)</p></div>"
+            @"<div class='col-1-3 border'><p><br/><div class='sigbox'><div class='inbox'>&nbsp;</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />"
+            @"(null)'s Signature</p></div>"
+            @"<div class='col-1-3 border'><p><br/><div class='sigbox'><div class='inbox'>&nbsp;</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />Date</p></div></div>";
+    XCTAssertEqualObjects([self.formatter HTMLForSignature:self.signature], html);
+
+}
+
+- (void)testHTMLForSignature_withSignatureImage_formatsImage {
+    self.signature.signatureImage = [UIImage imageNamed:@"arrowLeft"];
+    NSString *html;
+    html =  @"<br/><div class='grid border'><div class='col-1-3 border'><p><br/><div class='sigbox'>"
+            @"<div class='inbox'>&nbsp;</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />"
+            @"(null)'s Name (printed)</p></div>"
+            @"<div class='col-1-3 border'><p><br/><div class='sigbox'><div class='inbox'>&nbsp;</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />"
+            @"(null)'s Signature</p></div>"
+            @"<div class='col-1-3 border'><p><br/><div class='sigbox'><div class='inbox'>&nbsp;</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />"
+            @"Date</p></div></div>";
+    XCTAssertEqualObjects([self.formatter HTMLForSignature:self.signature], html);
+}
+
+- (void)testHTMLForSignature_withNameAndImage_formatsSignature {
+    self.signature.requiresName = YES;
+    self.signature.familyName = @"Family";
+    self.signature.givenName = @"Given";
+    self.signature.title = @"Title";
+    self.signature.requiresSignatureImage = YES;
+    self.signature.signatureImage = [UIImage imageNamed:@"arrowLeft"];
+
+    NSString *html;
+    html =  @"<br/><div class='grid border'><div class='col-1-3 border'><p><br/><div class='sigbox'>"
+            @"<div class='inbox'>Given&nbsp;Family</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />"
+            @"Title's Name (printed)</p></div>"
+            @"<div class='col-1-3 border'><p><br/><div class='sigbox'><div class='inbox'>&nbsp;</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />"
+            @"Title's Signature</p></div>"
+            @"<div class='col-1-3 border'><p><br/><div class='sigbox'><div class='inbox'>&nbsp;</div></div>"
+            @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />"
+            @"Date</p></div></div>";
+    XCTAssertEqualObjects([self.formatter HTMLForSignature:self.signature], html);
 }
 
 @end

--- a/ResearchKitTests/ORKConsentSignatureFormatterTests.m
+++ b/ResearchKitTests/ORKConsentSignatureFormatterTests.m
@@ -1,0 +1,40 @@
+//
+//  ORKConsentSignatureFormatterTests.m
+//  ResearchKit
+//
+//  Created by Alex on 5/17/15.
+//  Copyright (c) 2015 researchkit.org. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+#import <XCTest/XCTest.h>
+
+@interface ORKConsentSignatureFormatterTests : XCTestCase
+
+@end
+
+@implementation ORKConsentSignatureFormatterTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    XCTAssert(YES, @"Pass");
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end


### PR DESCRIPTION
This PR adds test coverage for `ORKConsentDocument`. To do so required a multi-stage process, as reflected in the commits:

1) Add an initializer to `ORKConsentDocument` to allow for dependency injection, as it depends on `ORKPDFHTMLWriter`. `-init` now calls through to this initializer, injecting default objects for the dependencies.
2) Write tests to cover `-makePDFWithCompletionHandler`. In the process of writing these tests, it became apparent that it would be beneficial to use formatter objects for `ORKConsentSection` and `ORKConsentSignature`, so those formatter classes were extracted.
3) Write tests to cover the formatters mentioned above.

As this process added three tests classes to the cover consent behavior, a Consent group was added under the ResearchKitTests group to hold consent-related test classes.