### PR TITLE
Fix identifier uniqueness issues

### DIFF
--- a/ResearchKit/Common/ORKFormStep.m
+++ b/ResearchKit/Common/ORKFormStep.m
@@ -87,7 +87,8 @@
 
 - (void)validateIdentifiersUnique {
     NSArray *uniqueIdentifiers = [_formItems valueForKeyPath:@"@distinctUnionOfObjects.identifier"];
-    BOOL itemsHaveNonUniqueIdentifiers = ( [_formItems count] != [uniqueIdentifiers count] );
+    NSArray *nonUniqueIdentifiers = [_formItems valueForKeyPath:@"@unionOfObjects.identifier"];
+    BOOL itemsHaveNonUniqueIdentifiers = ( [nonUniqueIdentifiers count] != [uniqueIdentifiers count] );
     
     if (itemsHaveNonUniqueIdentifiers) {
         @throw [NSException exceptionWithName:NSGenericException reason:@"Each form item should have a unique identifier" userInfo:nil];

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -1585,7 +1585,7 @@ static NSString * const ReactionTimeTaskIdentifier = @"react";
 
         scaleAnswerFormat.numberStyle = ORKNumberFormattingStylePercent;
         
-        ORKQuestionStep *step = [ORKQuestionStep questionStepWithIdentifier:@"scale_07"
+        ORKQuestionStep *step = [ORKQuestionStep questionStepWithIdentifier:@"scale_11"
                                                                       title:@"How much has your mood improved?"
                                                                      answer:scaleAnswerFormat];
         [steps addObject:step];


### PR DESCRIPTION
1) Form items can have no identifier if they are just placeholders
for section headers in the table view. We should ignore the nil
identifiers for the purpose of the uniqueness check.

2) In ORKTest, the scale questions task had a non-unique step
identifier in it.