### PR TITLE
Exclusive Text Choices - Issue #186

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -673,7 +673,7 @@ ORK_CLASS_AVAILABLE
  
  In general, this is used to indicate a "None of the above" choice.
  */
-@property BOOL exclusive;
+@property (readonly) BOOL exclusive;
 
 @end
 

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -581,6 +581,18 @@ ORK_CLASS_AVAILABLE
 + (instancetype)choiceWithText:(NSString *)text detailText:(nullable NSString *)detailText value:(id<NSCopying, NSCoding, NSObject>)value;
 
 /**
+ Returns a text choice object that includes the specified primary text, detail text, and exclusivity.
+ 
+ @param text        The primary text that describes the choice in a localized string.
+ @param detailText  The detail text to display below the primary text, in a localized string.
+ @param value       The value to record in a result object when this item is selected.
+ @param exclusive   Whether this choice is to be considered exclusive within the set of choices.
+ 
+ @return A text choice instance.
+ */
++ (instancetype)choiceWithText:(NSString *)text detailText:(nullable NSString *)detailText value:(id<NSCopying, NSCoding, NSObject>)value exclusive:(BOOL)exclusive;
+
+/**
  Returns a choice object that includes the specified primary text.
  
  @param text        The primary text that describes the choice in a localized string.
@@ -591,9 +603,20 @@ ORK_CLASS_AVAILABLE
 + (instancetype)choiceWithText:(NSString *)text value:(id<NSCopying, NSCoding, NSObject>)value;
 
 /**
+ Returns a choice object that includes the specified primary text and exclusivity.
+ 
+ @param text        The primary text that describes the choice in a localized string.
+ @param value       The value to record in a result object when this item is selected.
+ @param exclusive   Whether this choice is to be considered exclusive within the set of choices.
+ 
+ @return A text choice instance.
+ */
++ (instancetype)choiceWithText:(NSString *)text value:(id<NSCopying, NSCoding, NSObject>)value exclusive:(BOOL)exclusive;
+
+/**
  Returns an initialized text choice object using the specified primary and detail text.
  
- This method is the designated initializer.
+ This method is a convenience initializer.
  
  @param text        The primary text that describes the choice in a localized string.
  @param detailText  The detail text to display below the primary text, in a localized string.
@@ -603,7 +626,24 @@ ORK_CLASS_AVAILABLE
  */
 - (instancetype)initWithText:(NSString *)text
                   detailText:(nullable NSString *)detailText
-                       value:(id<NSCopying, NSCoding, NSObject>)value NS_DESIGNATED_INITIALIZER;
+                       value:(id<NSCopying, NSCoding, NSObject>)value;
+
+/**
+ Returns an initialized text choice object using the specified primary text, detail text, and exclusivity.
+ 
+ This method is the designated initializer.
+ 
+ @param text        The primary text that describes the choice in a localized string.
+ @param detailText  The detail text to display below the primary text, in a localized string.
+ @param value       The value to record in a result object when this item is selected.
+ @param exclusive   Whether this choice is to be considered exclusive within the set of choices.
+ 
+ @return An initialized text choice.
+ */
+- (instancetype)initWithText:(NSString *)text
+                  detailText:(nullable NSString *)detailText
+                       value:(id<NSCopying, NSCoding, NSObject>)value
+                    exclusive:(BOOL)exclusive NS_DESIGNATED_INITIALIZER;
 
 /**
  The text that describes the choice in a localized string.
@@ -627,6 +667,13 @@ ORK_CLASS_AVAILABLE
  The detail text can span multiple lines. Note that `ORKValuePickerAnswerFormat` ignores detail text.
   */
 @property (copy, readonly, nullable) NSString *detailText;
+
+/**
+ In a multiple choice format, this indicates whether this choice requires all other choices to be unselected.
+ 
+ In general, this is used to indicate a "None of the above" choice.
+ */
+@property BOOL exclusive;
 
 @end
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -654,23 +654,36 @@ static NSArray *ork_processTextChoices(NSArray *textChoices) {
     id<NSCopying, NSCoding, NSObject> _value;
 }
 
-+ (instancetype)choiceWithText:(NSString *)text detailText:(NSString *)detailText value:(id<NSCopying, NSCoding, NSObject>)value {
-    ORKTextChoice *option = [[ORKTextChoice alloc] initWithText:text detailText:detailText value:value];
++ (instancetype)choiceWithText:(NSString *)text detailText:(NSString *)detailText value:(id<NSCopying, NSCoding, NSObject>)value exclusive:(BOOL)exclusive {
+    ORKTextChoice *option = [[ORKTextChoice alloc] initWithText:text detailText:detailText value:value exclusive:exclusive];
     return option;
+}
+
++ (instancetype)choiceWithText:(NSString *)text detailText:(NSString *)detailText value:(id<NSCopying, NSCoding, NSObject>)value {
+    return [ORKTextChoice choiceWithText:text detailText:detailText value:value exclusive:NO];
+}
+
++ (instancetype)choiceWithText:(NSString *)text value:(id<NSCopying, NSCoding, NSObject>)value exclusive:(BOOL)exclusive {
+    return [ORKTextChoice choiceWithText:text detailText:nil value:value exclusive:exclusive];
 }
 
 + (instancetype)choiceWithText:(NSString *)text value:(id<NSCopying, NSCoding, NSObject>)value {
     return [ORKTextChoice choiceWithText:text detailText:nil value:value];
 }
 
-- (instancetype)initWithText:(NSString *)text detailText:(NSString *)detailText value:(id<NSCopying,NSCoding,NSObject>)value {
+- (instancetype)initWithText:(NSString *)text detailText:(NSString *)detailText value:(id<NSCopying,NSCoding,NSObject>)value exclusive:(BOOL)exclusive {
     self = [super init];
     if (self) {
         _text = [text copy];
         _detailText = [detailText copy];
         _value = value;
+        _exclusive = exclusive;
     }
     return self;
+}
+
+- (instancetype)initWithText:(NSString *)text detailText:(NSString *)detailText value:(id<NSCopying,NSCoding,NSObject>)value {
+    return [self initWithText:text detailText:detailText value:value exclusive:NO];
 }
 
 + (BOOL)supportsSecureCoding {
@@ -690,7 +703,8 @@ static NSArray *ork_processTextChoices(NSArray *textChoices) {
     __typeof(self) castObject = object;
     return (ORKEqualObjects(self.text, castObject.text)
             && ORKEqualObjects(self.detailText, castObject.detailText)
-            && ORKEqualObjects(self.value, castObject.value));
+            && ORKEqualObjects(self.value, castObject.value)
+            && self.exclusive == castObject.exclusive);
 }
 
 - (NSUInteger)hash {
@@ -704,6 +718,7 @@ static NSArray *ork_processTextChoices(NSArray *textChoices) {
         ORK_DECODE_OBJ_CLASS(aDecoder, text, NSString);
         ORK_DECODE_OBJ_CLASS(aDecoder, detailText, NSString);
         ORK_DECODE_OBJ(aDecoder, value);
+        ORK_DECODE_BOOL(aDecoder, exclusive);
     }
     return self;
 }
@@ -712,6 +727,7 @@ static NSArray *ork_processTextChoices(NSArray *textChoices) {
     ORK_ENCODE_OBJ(aCoder, text);
     ORK_ENCODE_OBJ(aCoder, value);
     ORK_ENCODE_OBJ(aCoder, detailText);
+    ORK_ENCODE_BOOL(aCoder, exclusive);
 }
 
 @end

--- a/ResearchKit/Common/ORKTextChoiceCellGroup.m
+++ b/ResearchKit/Common/ORKTextChoiceCellGroup.m
@@ -107,6 +107,15 @@
         }
     } else {
         touchedCell.selectedItem = !touchedCell.selectedItem;
+        if (touchedCell.selectedItem) {
+            ORKTextChoice *touchedChoice = [_helper textChoiceAtIndex:index];
+            for (NSNumber *num in [_cells allKeys]) {
+                ORKChoiceViewCell *cell = _cells[num];
+                if (cell != touchedCell && (touchedChoice.exclusive || (cell.selectedItem && [_helper textChoiceAtIndex:[num unsignedIntegerValue]].exclusive))) {
+                    cell.selectedItem = NO;
+                }
+            }
+        }
     }
     
     _answer = [_helper answerForSelectedIndexes:[self selectedIndexes]];

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -602,7 +602,7 @@ static NSString * const ReactionTimeTaskIdentifier = @"react";
         /*
          A single-choice question presented in the tableview format.
          */
-        ORKTextChoiceAnswerFormat *answerFormat = [ORKAnswerFormat choiceAnswerFormatWithStyle:ORKChoiceAnswerStyleMultipleChoice textChoices:
+        ORKTextChoiceAnswerFormat *answerFormat = [ORKAnswerFormat choiceAnswerFormatWithStyle:ORKChoiceAnswerStyleSingleChoice textChoices:
                                                    @[
                                                      [ORKTextChoice choiceWithText:@"Less than seven"
                                                                         detailText:nil
@@ -616,6 +616,32 @@ static NSString * const ReactionTimeTaskIdentifier = @"react";
                                                      ]];
         ORKQuestionStep *step = [ORKQuestionStep questionStepWithIdentifier:@"qid_003"
                                                                       title:@"How many hours did you sleep last night?"
+                                                                     answer:answerFormat];
+        [steps addObject:step];
+    }
+    
+    {
+        /*
+         A multiple-choice question presented in the tableview format.
+         */
+        ORKTextChoiceAnswerFormat *answerFormat = [ORKAnswerFormat choiceAnswerFormatWithStyle:ORKChoiceAnswerStyleMultipleChoice textChoices:
+                                                   @[
+                                                     [ORKTextChoice choiceWithText:@"Cough"
+                                                                        detailText:nil
+                                                                             value:@"cough"],
+                                                     [ORKTextChoice choiceWithText:@"Fever"
+                                                                        detailText:nil
+                                                                             value:@"fever"],
+                                                     [ORKTextChoice choiceWithText:@"Headaches"
+                                                                        detailText:nil
+                                                                             value:@"headache"],
+                                                     [ORKTextChoice choiceWithText:@"None of the above"
+                                                                        detailText:nil
+                                                                             value:@"none"
+                                                                          exclusive:YES]
+                                                     ]];
+        ORKQuestionStep *step = [ORKQuestionStep questionStepWithIdentifier:@"qid_004a"
+                                                                      title:@"Which symptoms do you have?"
                                                                      answer:answerFormat];
         [steps addObject:step];
     }

--- a/Testing/ORKTest/ORKTest/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTest/ORKESerialization.m
@@ -566,12 +566,13 @@ ret =
           })),
   ENTRY(ORKTextChoice,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
-            return [[ORKTextChoice alloc] initWithText:GETPROP(dict, text) detailText:GETPROP(dict, detailText) value:GETPROP(dict, value)];
+            return [[ORKTextChoice alloc] initWithText:GETPROP(dict, text) detailText:GETPROP(dict, detailText) value:GETPROP(dict, value) exclusive:[GETPROP(dict, exclusive) boolValue]];
         },
         (@{
           PROPERTY(text, NSString, NSObject, NO, nil, nil),
           PROPERTY(value, NSObject, NSObject, NO, nil, nil),
           PROPERTY(detailText, NSString, NSObject, NO, nil, nil),
+          PROPERTY(exclusive, NSNumber, NSObject, NO, nil, nil),
           })),
   ENTRY(ORKImageChoice,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {


### PR DESCRIPTION
Implemented the concept of a text choice being "exclusive" for issue #186.  I handled this via a property on `ORKTextChoice`, and not via a change to `ORKTextChoiceAnswerFormat`.  If having a `exclusiveTextChoice` property on the `ORKTextChoiceAnswerFormat` is preferred over a `exclusive` property on `ORKTextChoice`, I could go in that direction.