### PR TITLE
Minor iPad layout fixes

### DIFF
--- a/ResearchKit/Common/ORKQuestionStepViewController.m
+++ b/ResearchKit/Common/ORKQuestionStepViewController.m
@@ -158,6 +158,7 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
             _tableView = _tableContainer.tableView;
             _tableView.delegate = self;
             _tableView.dataSource = self;
+            _tableView.clipsToBounds = YES;
             
             [self.view addSubview:_tableContainer];
             

--- a/ResearchKit/Consent/ORKConsentSharingStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentSharingStepViewController.m
@@ -56,6 +56,7 @@
     ORKConsentLearnMoreViewController *viewController = [[ORKConsentLearnMoreViewController alloc] initWithHTMLContent:step.localizedLearnMoreHTMLContent];
     viewController.title = ORKLocalizedString(@"CONSENT_LEARN_MORE_TITLE", nil);
     UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:viewController];
+    navigationController.modalPresentationStyle = UIModalPresentationFormSheet;
     [self presentViewController:navigationController animated:YES completion:nil];
 }
 


### PR DESCRIPTION
- Clip question step tableview to bounds to avoid visible artifact on
  consent sharing step.

- Make consent sharing step present its "learn more" content in a form sheet.