### PR TITLE
Fix autolayout warnings after rotation on form with vertical scales

### DIFF
--- a/ResearchKit/Common/ORKFormItemCell.m
+++ b/ResearchKit/Common/ORKFormItemCell.m
@@ -834,18 +834,9 @@ static const CGFloat kHMargin = 15.0;
 
 #pragma mark - ORKFormItemScaleCell
 
-@interface ORKFormItemScaleCell () <ORKScaleSliderLayoutWidthProvider>
-
-@end
-
-
 @implementation ORKFormItemScaleCell {
     ORKScaleSliderView *_sliderView;
     id<ORKScaleAnswerFormatProvider> _formatProvider;
-}
-
-- (CGFloat)sliderLayoutWidth {
-    return self.expectedLayoutWidth;
 }
 
 - (id<ORKScaleAnswerFormatProvider>)formatProvider {
@@ -859,7 +850,6 @@ static const CGFloat kHMargin = 15.0;
     self.labelLabel.text = nil;
     
     _sliderView = [[ORKScaleSliderView alloc] initWithFormatProvider:(ORKScaleAnswerFormat *)self.formItem.answerFormat];
-    _sliderView.delegate = self;
     [_sliderView.slider addTarget:self action:@selector(inputValueDidChange) forControlEvents:UIControlEventValueChanged];
     
     [self.contentView addSubview:_sliderView];

--- a/ResearchKit/Common/ORKScaleSlider.h
+++ b/ResearchKit/Common/ORKScaleSlider.h
@@ -32,13 +32,6 @@
 #import <UIKit/UIKit.h>
 
 
-@protocol ORKScaleSliderLayoutWidthProvider <NSObject>
-
-@property (nonatomic, readonly) CGFloat sliderLayoutWidth;
-
-@end
-
-
 @interface ORKScaleSlider : UISlider
 
 @property (nonatomic, assign) BOOL showThumb;
@@ -46,7 +39,5 @@
 @property (nonatomic, assign) NSUInteger numberOfSteps;
 
 @property (nonatomic, assign, getter=isVertical) BOOL vertical;
-
-@property (nonatomic, weak, nullable) id<ORKScaleSliderLayoutWidthProvider> delegate;
 
 @end

--- a/ResearchKit/Common/ORKScaleSlider.m
+++ b/ResearchKit/Common/ORKScaleSlider.m
@@ -35,11 +35,7 @@
 #import "ORKAccessibility.h"
 #import "ORKDefines_Private.h"
 #import "ORKAnswerFormat_Internal.h"
-
-
-@interface ORKScaleSlider ()
-
-@end
+#import "ORKSkin.h"
 
 
 @implementation ORKScaleSlider {
@@ -79,6 +75,7 @@
         _vertical = vertical;
         self.transform = _vertical ? CGAffineTransformMakeRotation(-M_PI_2) : CGAffineTransformIdentity;
         _thumbImageNeedsTransformUpdate = YES;
+        [self invalidateIntrinsicContentSize];
     }
 }
 
@@ -109,13 +106,9 @@
 
 - (CGSize)intrinsicContentSize {
     CGSize intrinsicContentSize = [super intrinsicContentSize];
-    // If we have a layout width provided by our delegate and we are vertical, use the provided
-    // width for the intrinsic content height, and leave the intrinsic content width alone.
-    // The intrinsic content width is typically -1, which will allow the slider to fill the
-    // available width in the superview.
-    CGFloat sliderLayoutWidth = self.delegate.sliderLayoutWidth;
-    if(_vertical && sliderLayoutWidth > 0) {
-        intrinsicContentSize = CGSizeMake(intrinsicContentSize.width, sliderLayoutWidth);
+    if (_vertical) {
+        CGFloat verticalScaleHeight = ORKGetMetricForWindow(ORKScreenMetricVerticalScaleHeight, self.window);
+        intrinsicContentSize = (CGSize){.width = verticalScaleHeight, .height = verticalScaleHeight};
     }
     return intrinsicContentSize;
 }

--- a/ResearchKit/Common/ORKScaleSliderView.h
+++ b/ResearchKit/Common/ORKScaleSliderView.h
@@ -56,8 +56,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, nullable) NSNumber *currentValue;
 
-@property (nonatomic, weak, nullable) id<ORKScaleSliderLayoutWidthProvider> delegate;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKScaleSliderView.m
+++ b/ResearchKit/Common/ORKScaleSliderView.m
@@ -41,7 +41,7 @@
 
 // #define LAYOUT_DEBUG 1
 
-@interface ORKScaleSliderView () <ORKScaleSliderLayoutWidthProvider>
+@interface ORKScaleSliderView ()
 
 @property (nonatomic, strong) id<ORKScaleAnswerFormatProvider> formatProvider;
 
@@ -56,8 +56,6 @@
 @property (nonatomic, strong) ORKScaleRangeDescriptionLabel *rightRangeDescriptionLabel;
 
 @property (nonatomic, strong) ORKScaleValueLabel *valueLabel;
-
-@property (nonatomic) CGFloat previousLayoutWidth;
 
 @end
 
@@ -102,11 +100,13 @@
             // Keep the shadow of the thumb inside the bounds
             const CGFloat kSliderMargin = 20.0;
             const CGFloat kSideLabelMargin = 24;
-            [self addConstraints:
-             [NSLayoutConstraint constraintsWithVisualFormat:@"H:|-kVerticalSliderHorizontalMargin-[_slider]-kVerticalSliderHorizontalMargin-|"
-                                                     options:NSLayoutFormatDirectionLeadingToTrailing
-                                                     metrics:@{@"kVerticalSliderHorizontalMargin": @(ORKGetMetricForWindow(ORKScreenMetricVerticalScaleHorizontalMargin, self.window))}
-                                                       views:views]];
+            [self addConstraint:[NSLayoutConstraint constraintWithItem:_slider
+                                                             attribute:NSLayoutAttributeCenterX
+                                                             relatedBy:NSLayoutRelationEqual
+                                                                toItem:self
+                                                             attribute:NSLayoutAttributeCenterX
+                                                            multiplier:1.0
+                                                              constant:0.0]];
             
             [self addConstraints:
              [NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_valueLabel]-kValueLabelSliderMargin-[_slider]-kSliderMargin-|"
@@ -246,7 +246,6 @@
     if (self) {
         self.slider = [[ORKScaleSlider alloc] initWithFrame:CGRectZero];
         self.slider.userInteractionEnabled = YES;
-        self.slider.delegate = self;
         self.slider.contentMode = UIViewContentModeRedraw;
         [self addSubview:_slider];
         
@@ -300,25 +299,6 @@
 - (IBAction)sliderValueChanged:(id)sender {
     NSNumber *newValue = [_formatProvider normalizedValueForNumber:@(self.slider.value)];
     [self setCurrentValue:newValue];
-}
-
-- (CGFloat)sliderLayoutWidth {
-    // Use the delegate expected width, if available, or if we have no delegate, then use our own width.
-    // Subtract the left and right margins from the width, to give the appropriate slider width.
-    return (self.delegate ? self.delegate.sliderLayoutWidth : self.previousLayoutWidth) -
-    (ORKGetMetricForWindow(ORKScreenMetricVerticalScaleHorizontalMargin, self.window) * 2);
-}
-
-- (void)layoutSubviews {
-    [super layoutSubviews];
-    // This is currently only used by vertical sliders, but keep track of the width to implement the Protocol anyway
-    CGFloat currentLayoutWidth = self.delegate ? self.delegate.sliderLayoutWidth : self.bounds.size.width;
-    if (self.previousLayoutWidth != currentLayoutWidth) {
-        self.previousLayoutWidth = currentLayoutWidth;
-        if ([_formatProvider isVertical]) {
-            [self.slider invalidateIntrinsicContentSize];
-        }
-    }
 }
 
 #pragma mark - Accessibility

--- a/ResearchKit/Common/ORKSkin.h
+++ b/ResearchKit/Common/ORKSkin.h
@@ -103,7 +103,7 @@ typedef NS_ENUM(NSInteger, ORKScreenMetric) {
     ORKScreenMetricLearnMoreButtonSideMargin,
     ORKScreenMetricHeadlineSideMargin,
     ORKScreenMetricToolbarHeight,
-    ORKScreenMetricVerticalScaleHorizontalMargin,
+    ORKScreenMetricVerticalScaleHeight,
     ORKScreenMetricSignatureViewHeight,
     ORKScreenMetric_COUNT
 };

--- a/ResearchKit/Common/ORKSkin.m
+++ b/ResearchKit/Common/ORKSkin.m
@@ -161,7 +161,7 @@ CGFloat ORKGetMetricForScreenType(ORKScreenMetric metric, ORKScreenType screenTy
         {         30,        30,        20,        20,        30},      // ORKScreenMetricLearnMoreButtonSideMargin
         {         10,        10,         0,         0,        10},      // ORKScreenMetricHeadlineSideMargin
         {         44,        44,        44,        44,        44},      // ORKScreenMetricToolbarHeight
-        {         48,        51,        52,        48,        48},      // ORKScreenMetricVerticalScaleHorizontalMargin
+        {        322,       274,       217,       217,       446},      // ORKScreenMetricVerticalScaleHeight
         {        156,       156,       156,       156,       256},      // ORKScreenMetricSignatureViewHeight
     };
     return metrics[metric][screenType];


### PR DESCRIPTION
Fixes [Issue #202](https://github.com/ResearchKit/ResearchKit/issues/202).

Also simplifies vertical scale autolayout code: I have replaced the `ORKScreenMetricVerticalScaleHorizontalMargin` metric (which was an indirect way of calculating the vertical scale height to avoid scrolling on *iPhone 5s* and up) with the simpler `ORKScreenMetricVerticalScaleHeight`. This avoids the use of the two layered delegate to obtain the scale height.