### PR TITLE
Fix overviews' example code warnings by using fenced code blocks

### DIFF
--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -2119,7 +2119,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ ! -x /usr/local/bin/appledoc ]; then\n    echo \"error: appledoc is required for building ResearchKit's documentation. See http://appledoc.gentlebytes.com\" 1>&2\n    exit 1\nfi\n\necho \"warning: warnings are a result of https://github.com/tomaz/appledoc/issues/348\"\n\n/usr/local/bin/appledoc --print-settings --publish-docset --install-docset --output \"${BUILT_PRODUCTS_DIR}/docs/\" --include \"docs/ActiveTasks\" --include \"docs/InformedConsent\" --include \"docs/Overview\" --include \"docs/Survey\"  --ignore \"docs/templates\" --templates \"docs/templates\" \"${BUILT_PRODUCTS_DIR}/ResearchKit.framework\" \"docs\"\n\necho \"warning: Opening documentation in browser...\"\nopen \"$HOME/Library/Developer/Shared/Documentation/DocSets/org.researchkit.ResearchKit.docset/Contents/Resources/Documents/index.html\"";
+			shellScript = "if [ ! -x /usr/local/bin/appledoc ]; then\n    echo \"error: appledoc is required for building ResearchKit's documentation. See http://appledoc.gentlebytes.com\" 1>&2\n    exit 1\nfi\n\n/usr/local/bin/appledoc --print-settings --publish-docset --install-docset --output \"${BUILT_PRODUCTS_DIR}/docs/\" --include \"docs/ActiveTasks\" --include \"docs/InformedConsent\" --include \"docs/Overview\" --include \"docs/Survey\"  --ignore \"docs/templates\" --templates \"docs/templates\" \"${BUILT_PRODUCTS_DIR}/ResearchKit.framework\" \"docs\"\n\necho \"note: Opening documentation in browser...\"\nopen \"$HOME/Library/Developer/Shared/Documentation/DocSets/org.researchkit.ResearchKit.docset/Contents/Resources/Documents/index.html\"";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/docs/InformedConsent/InformedConsent-template.markdown
+++ b/docs/InformedConsent/InformedConsent-template.markdown
@@ -32,20 +32,22 @@ You use the predefined sections in the expected order, the ResearchKit framework
 
 After you create a section, you create a step to present the section. 
 
+```
     ORKConsentDocument *document = [ORKConsentDocument new];
-    ORKConsentSection *section =
+    ORKConsentSection *section1 =
       [[ORKConsentSection alloc] initWithType:ORKConsentSectionTypeDataGathering];
-    section.title = @"The title of the section goes here ...";
-    section.summary = @"The summary about the section goes here ...";
-    section.content = @"The content to show in learn more ...";
+    section1.title = @"The title of the section goes here ...";
+    section1.summary = @"The summary about the section goes here ...";
+    section1.content = @"The content to show in learn more ...";
     
     // Create additional section objects for later sections
-    document.sections = @[s, ...];
+    document.sections = @[section1, ...];
     
     ORKVisualConsentStep *step =
       [[ORKVisualConsentStep alloc] initWithIdentifier:kVisualConsent document:document];
     
     // And then create and present a task including this step.
+```
 
 If the predefined consent sections do not adequately cover the sections of your consent document, you can create your own custom sections. You can also create your own images and animations and add them to your consent section, to complete the experience. The animations you add should be H.264 videos; for best results, try to match the assets included with the ResearchKit framework.
 
@@ -56,6 +58,7 @@ It is your responsibility to populate the visual consent step with
 content; the `ORKVisualConsentStep` object doesn't contain any
 default content.
 
+```
     // Add consent sections for each page of visual consent; for example:
     ORKConsentSection *section1 =
       [[ORKConsentSection alloc] initWithType:ORKConsentSectionTypeDataGathering];
@@ -66,6 +69,8 @@ default content.
       [[ORKVisualConsentStep alloc] initWithIdentifier:kVisualConsentIdentifier document:document];
     
     // Create and present a task including this step.
+```
+
 Visual step is presented as:
 
 <p style="float: left; font-size: 9pt; text-align: center; width: 25%; margin-right: 5%; margin-bottom: 0.5em;"><img src="VisualStep_Images/VisualStep_1.png" style="width: 100%;border: solid black 1px; ">Consent overview screen (ORKConsentSectionTypeOverview object)</p><p style="float: left; font-size: 9pt; text-align: center; width: 25%; margin-right: 5%; margin-bottom: 0.5em;"><img src="VisualStep_Images/VisualStep_2.png" style="width: 100%;border: solid black 1px;">Data gathering (ORKConsentSectionTypeDataGathering object).</p><p style="float: left; font-size: 9pt; text-align: center; width: 25%; margin-right: 3%; margin-bottom: 0.5em;"><img src="VisualStep_Images/VisualStep_3.png" style="width: 100%;border: solid black 1px;">Privacy (ORKConsentSectionTypePrivacy object)</p>
@@ -76,6 +81,7 @@ Visual step is presented as:
 <p style="clear: both;">
 
 ### Add a Review Step
+
 Users review the consent review document in the consent review step (`ORKConsentReviewStep`). Depending on your signature requirements, users can also be asked to enter their name and write a signature on the screen.
 
 The content for consent review can either be produced as a concatenation of all the consent sections in your document model, or you can provide entirely separate review content as HTML in the consent document's `htmlReviewContent` property.
@@ -84,6 +90,7 @@ When the user agrees to the content in the consent form, a confirmation dialog i
 
 The name entry page is included in a consent review step if the step’s `signature` property contains a signature object in which the `requiresName` property is YES. Similarly, the signature entry page is included in a consent review step if the step’s `signature` property contains a signature object in which the `requiresSignature` property is YES.
 
+```
     ORKConsentDocument *consent = [[ORKConsentDocument alloc] init];
     consent.title = @"Demo Consent";
     consent.signaturePageTitle = @"Consent";
@@ -96,6 +103,8 @@ The name entry page is included in a consent review step if the step’s `signat
     reviewStep.reasonForConsent = @"Lorem ipsum ...";
     
     // Add the content to a task and present it.
+```
+
 Review step is presented as:
 
 <p style="float: left; font-size: 9pt; text-align: center; width: 25%; margin-right: 5%; margin-bottom: 0.5em;"><img src="VisualStep_Images/VisualStep_10.png" style="width: 100%;border: solid black 1px; ">Consent review (ORKConsentReviewStep object)</p><p style="float: left; font-size: 9pt; text-align: center; width: 25%; margin-right: 5%; margin-bottom: 0.5em;"><img src="VisualStep_Images/VisualStep_11.png" style="width: 100%;border: solid black 1px;"> Agreeing to the consent document (reasonForConsent property of ORKConsentReviewStep object).</p><p style="float: left; font-size: 9pt; text-align: center; width: 25%; margin-right: 3%; margin-bottom: 0.5em;"><img src="VisualStep_Images/VisualStep_12.png" style="width: 100%;border: solid black 1px;"> Consent review name entry (signature property in ORKConsentReviewStep)</p>
@@ -114,6 +123,7 @@ to share their data that you collect for your study with other researchers, if a
 your IRB or EC if applicable. To use a consent sharing step, include it in a task, perhaps
 just before a consent review step.
 
+```
     ORKConsentSharingStep *sharingStep =
       [[ORKConsentSharingStep alloc] initWithIdentifier:kConsentSharingIdentifier
                            investigatorShortDescription:@"MyInstitution"
@@ -121,6 +131,7 @@ just before a consent review step.
                           localizedLearnMoreHTMLContent:@"Lorem ipsum..."];
 
     // Then include this step to a task and present with a task view controller.
+```
 
 The consent sharing step looks like this:
 <center>
@@ -136,6 +147,7 @@ After you create the step(s), create an `ORKOrderedTask` task and add them to it
 
 The following code snippet shows how to create a task with a visual consent step and a consent review step:
 
+```
     ORKVisualConsentStep *visualStep =
       [[ORKVisualConsentStep alloc] initWithIdentifier:kVisualConsentIdentifier
                                               document:consent];
@@ -154,7 +166,7 @@ The following code snippet shows how to create a task with a visual consent step
       [[ORKTaskViewController alloc] initWithTask:task taskRunUUID:nil];
 
     // And then present the task view controller.
-    
+```
 
 ##3. Optionally, Generate a PDF
 
@@ -162,6 +174,7 @@ The ResearchKit framework can help you generate a PDF of the signed consent form
 
 To do this, first take any signature results from the completed consent review, and apply the resulting signatures to a copy of your consent document. Then, call the `makePDFWithCompletionHandler:` method of `ORKConsentDocument` as shown here.
 
+```
     ORKConsentDocument *documentCopy = [document copy];
 
     ORKConsentSignatureResult *signatureResult =
@@ -171,5 +184,6 @@ To do this, first take any signature results from the completed consent review, 
     [documentCopy makePDFWithCompletionHandler:^(NSData *pdfData, NSError *error) {
         // Write the PDF data to disk, email it, display it, or send it to a server.
     }];
-    
+```
+
 You can only apply a signature result to a new copy of a consent document. 

--- a/docs/Survey/CreatingSurveys-template.markdown
+++ b/docs/Survey/CreatingSurveys-template.markdown
@@ -39,10 +39,12 @@ instruction step does not collect any data, it yields an empty
 `ORKStepResult` that nonetheless records how long the instruction was
 on screen.
 
+```
     ORKInstructionStep *step =
       [[ORKInstructionStep alloc] initWithIdentifier:@"identifier"];
     step.title = @"Selection Survey";
     step.text = @"This survey can help us understand your eligibility for the fitness study";
+```
 
 Creating a step as shown in the code above, including it in a task, and
 presenting with a task view controller, yields something like this:
@@ -72,6 +74,7 @@ user's answer.
 
 The following code configures a simple numeric question step.
 
+```
     ORKNumericAnswerFormat *format =
       [ORKNumericAnswerFormat integerAnswerFormatWithUnit:@"years"];
     format.minimum = @(18);
@@ -80,6 +83,7 @@ The following code configures a simple numeric question step.
       [ORKQuestionStep questionStepWithIdentifier:kIdentifierAge
                                             title:@"How old are you?"
                                            answer:format];
+```
 
 Adding this question step to a task and presenting the task produces
 a screen that looks like this:
@@ -91,9 +95,7 @@ a screen that looks like this:
 </figure>
 </center>
 
-
 ###Form Step
-
 
 When the user needs to answer several related questions together, it
 may be preferable to use a form step (`ORKFormStep`) in order to present them all on one page.  Form steps support all the same answer formats as question
@@ -111,6 +113,7 @@ their identifiers (the `identifier` property).
 
 For example, the following code shows how to create a form that requests some basic details, using default values extracted from HealthKit on iOS to accelerate data entry:
 
+```
     ORKFormStep *step =
     [[ORKFormStep alloc] initWithIdentifier:kFormIdentifier
                                        title:@"Form"
@@ -151,7 +154,7 @@ For example, the following code shows how to create a form that requests some ba
 
     // ... And so on, adding additional items
     step.formItems = items;
-
+```
 
 The code above gives you something like this:
 <center>
@@ -196,6 +199,7 @@ Health database.
 Once you create one or more steps, create an `ORKOrderedTask` to
 hold them. The code below shows a Boolean step being added to a task.
 
+```
     // Create a boolean step to include in the task.
     ORKStep *booleanStep = 
       [[ORKQuestionStep alloc] initWithIdentifier:kNutritionIdentifier];
@@ -206,13 +210,14 @@ hold them. The code below shows a Boolean step being added to a task.
     ORKOrderedTask *task =
       [[ORKOrderedTask alloc] initWithIdentifier:kTaskIdentifier
                                            steps:@[booleanStep]];
-
+```
 
 You must assign a string identifier to each step. The step identifier should be unique within the task, because it is the key that connects a step in the task hierarchy with the step result in the result hierarchy.
 
 To present the task, attach it to a task view controller and present
 it. The code below shows how to create a task view controller and present it modally.
 
+```
     // Create a task view controller using the task and set a delegate.
     ORKTaskViewController *taskViewController =
       [[ORKTaskViewController alloc] initWithTask:task taskRunUUID:nil];
@@ -220,7 +225,7 @@ it. The code below shows how to create a task view controller and present it mod
 
     // Present the task view controller.
     [self presentViewController:taskViewController animated:YES completion:nil];
-
+```
 
 <p><i>Note: `ORKOrderedTask` assumes that you will always present all the questions,
 and will never decide what question to show based on previous answers.
@@ -263,7 +268,6 @@ includes start and end times, using the `startDate` and `endDate`
 properties respectively. These properties can be used to infer how long the user
 spent on the step.
 
- 
 #### Step Results That Determine the Next Step
 
 Sometimes it's important to know the result of a step before
@@ -277,6 +281,7 @@ The following example demonstrates how to subclass
 user's answer to a Boolean question. Although the code shows the step after step method, a corresponding implementation of "step before step"
 is usually necessary.
 
+```
     - (ORKStep *)stepAfterStep:(ORKStep *)step
                     withResult:(id<ORKTaskResultSource>)result {
         NSString *identifier = step.identifier;  
@@ -296,7 +301,7 @@ is usually necessary.
         }
         return [super stepAfterStep:step withResult:result];
     }
-     
+```
 
 #### Saving Results on Task Completion
 
@@ -314,6 +319,7 @@ saving and restoring tasks, the user may save the task, so this
 example also demonstrates how to obtain the restoration data that
 would later be needed to restore the task.
 
+```
     - (void)taskViewController:(ORKTaskViewController *)taskViewController
            didFinishWithReason:(ORKTaskViewControllerFinishReason)reason
                          error:(NSError *)error
@@ -340,3 +346,4 @@ would later be needed to restore the task.
             break;
         }
     }
+```


### PR DESCRIPTION
I have submitted an [*appledoc* pull request](https://github.com/tomaz/appledoc/pull/535) which allows us to fix the spurious cross reference warnings in the sample code blocks within the overview markdown documents.

This *ResearchKit* pull request makes the sample code in the markdown overviews *fenced code blocks* (these don't interfere with the current appledoc version either), and removes the *echo warnings* in the docs building script.

If you update to *appledoc v2.2.1 (build 1334)* (find it in the above PR) and merge this, the warnings when building the documentation will be gone.