### PR TITLE
Device motion reaction time code improvements

### DIFF
--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -375,6 +375,7 @@
 		BCA5C0351AEC05F20092AC8D /* ORKStepNavigationRule.h in Headers */ = {isa = PBXBuildFile; fileRef = BCA5C0331AEC05F20092AC8D /* ORKStepNavigationRule.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BCA5C0361AEC05F20092AC8D /* ORKStepNavigationRule.m in Sources */ = {isa = PBXBuildFile; fileRef = BCA5C0341AEC05F20092AC8D /* ORKStepNavigationRule.m */; };
 		BCAD50E81B0201EE0034806A /* ORKTaskTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BCAD50E71B0201EE0034806A /* ORKTaskTests.m */; };
+		BCB96C131B19C0EC002A0B96 /* ORKStepTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BCB96C121B19C0EC002A0B96 /* ORKStepTests.m */; };
 		BCFF24BD1B0798D10044EC35 /* ORKResultPredicate.m in Sources */ = {isa = PBXBuildFile; fileRef = BCFF24BC1B0798D10044EC35 /* ORKResultPredicate.m */; };
 		D42FEFB81AF7557000A124F8 /* ORKImageCaptureView.h in Headers */ = {isa = PBXBuildFile; fileRef = D42FEFB61AF7557000A124F8 /* ORKImageCaptureView.h */; };
 		D42FEFB91AF7557000A124F8 /* ORKImageCaptureView.m in Sources */ = {isa = PBXBuildFile; fileRef = D42FEFB71AF7557000A124F8 /* ORKImageCaptureView.m */; };
@@ -808,6 +809,7 @@
 		BCA5C0331AEC05F20092AC8D /* ORKStepNavigationRule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKStepNavigationRule.h; sourceTree = "<group>"; };
 		BCA5C0341AEC05F20092AC8D /* ORKStepNavigationRule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKStepNavigationRule.m; sourceTree = "<group>"; };
 		BCAD50E71B0201EE0034806A /* ORKTaskTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKTaskTests.m; sourceTree = "<group>"; };
+		BCB96C121B19C0EC002A0B96 /* ORKStepTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKStepTests.m; sourceTree = "<group>"; };
 		BCFB2EAF1AE70E4E0070B5D0 /* ORKConsentSceneViewController_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ORKConsentSceneViewController_Internal.h; sourceTree = "<group>"; };
 		BCFF24BC1B0798D10044EC35 /* ORKResultPredicate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKResultPredicate.m; sourceTree = "<group>"; };
 		D42FEFB61AF7557000A124F8 /* ORKImageCaptureView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKImageCaptureView.h; sourceTree = "<group>"; };
@@ -988,18 +990,19 @@
 			isa = PBXGroup;
 			children = (
 				FA7A9D351B09362D005A2BEA /* Consent */,
-				86D348001AC16175006DB02B /* ORKRecorderTests.m */,
+				86CC8EA71AC09383001CCD89 /* Info.plist */,
 				86CC8EA81AC09383001CCD89 /* ORKAccessibilityTests.m */,
 				86CC8EA91AC09383001CCD89 /* ORKChoiceAnswerFormatHelperTests.m */,
 				86CC8EAB1AC09383001CCD89 /* ORKDataLoggerManagerTests.m */,
 				86CC8EAC1AC09383001CCD89 /* ORKDataLoggerTests.m */,
 				86CC8EAD1AC09383001CCD89 /* ORKHKSampleTests.m */,
+				86D348001AC16175006DB02B /* ORKRecorderTests.m */,
 				86CC8EAF1AC09383001CCD89 /* ORKResultTests.m */,
+				BCB96C121B19C0EC002A0B96 /* ORKStepTests.m */,
+				BCAD50E71B0201EE0034806A /* ORKTaskTests.m */,
 				86CC8EB01AC09383001CCD89 /* ORKTextChoiceCellGroupTests.m */,
-				86CC8EA71AC09383001CCD89 /* Info.plist */,
 				2EBFE11C1AE1B32D00CB8254 /* ORKUIViewAccessibilityTests.m */,
 				2EBFE11F1AE1B74100CB8254 /* ORKVoiceEngineTests.m */,
-				BCAD50E71B0201EE0034806A /* ORKTaskTests.m */,
 			);
 			path = ResearchKitTests;
 			sourceTree = "<group>";
@@ -2133,6 +2136,7 @@
 				86CC8EBA1AC09383001CCD89 /* ORKResultTests.m in Sources */,
 				FA7A9D391B0969A7005A2BEA /* ORKConsentSignatureFormatterTests.m in Sources */,
 				86CC8EB81AC09383001CCD89 /* ORKHKSampleTests.m in Sources */,
+				BCB96C131B19C0EC002A0B96 /* ORKStepTests.m in Sources */,
 				86CC8EB51AC09383001CCD89 /* ORKConsentTests.m in Sources */,
 				2EBFE11D1AE1B32D00CB8254 /* ORKUIViewAccessibilityTests.m in Sources */,
 				86CC8EB41AC09383001CCD89 /* ORKChoiceAnswerFormatHelperTests.m in Sources */,

--- a/ResearchKit/ActiveTasks/ORKDeviceMotionReactionTimeContentView.h
+++ b/ResearchKit/ActiveTasks/ORKDeviceMotionReactionTimeContentView.h
@@ -36,10 +36,10 @@
 
 - (void)setStimulusHidden:(BOOL)hidden;
 
-- (void)startSuccessAnimationWithDuration:(NSTimeInterval)duration completion: (nullable void (^)(void))completion;
+- (void)startSuccessAnimationWithDuration:(NSTimeInterval)duration completion:(nullable void (^)(void))completion;
 
-- (void)startFailureAnimationWithDuration:(NSTimeInterval)duration completion: (nullable void (^)(void))completion;
+- (void)startFailureAnimationWithDuration:(NSTimeInterval)duration completion:(nullable void (^)(void))completion;
 
-- (void)resetAfterDelay:(NSTimeInterval)delay completion: (nullable void (^)(void))completion;
+- (void)resetAfterDelay:(NSTimeInterval)delay completion:(nullable void (^)(void))completion;
 
 @end

--- a/ResearchKit/ActiveTasks/ORKDeviceMotionReactionTimeContentView.m
+++ b/ResearchKit/ActiveTasks/ORKDeviceMotionReactionTimeContentView.m
@@ -40,17 +40,16 @@
 
 @end
 
-@implementation ORKDeviceMotionReactionTimeContentView {
-    
-    NSArray *_constraints;
-}
+
+@implementation ORKDeviceMotionReactionTimeContentView
 
 - (instancetype)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
+        self.translatesAutoresizingMaskIntoConstraints = NO;
         [self addStimulusView];
     }
-    return  self;
+    return self;
 }
 
 - (void)startSuccessAnimationWithDuration:(NSTimeInterval)duration completion:(void (^)(void))completion {
@@ -61,63 +60,54 @@
     [_stimulusView startFailureAnimationWithDuration:duration completion:completion];
 }
 
-- (void)resetAfterDelay:(NSTimeInterval)delay completion: (nullable void (^)(void))completion {
+- (void)resetAfterDelay:(NSTimeInterval)delay completion:(nullable void (^)(void))completion {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        [self removeConstraints];
-        [_stimulusView removeFromSuperview];
-        [self addStimulusView];
-        [_stimulusView setStimulusHidden:true];
-        completion();
+        [_stimulusView reset];
+        if (completion) {
+            completion();
+        }
     });
 }
 
 - (void)addStimulusView {
-    _stimulusView = [ORKDeviceMotionReactionTimeStimulusView new];
-    _stimulusView.translatesAutoresizingMaskIntoConstraints = NO;
-    _stimulusView.backgroundColor = self.tintColor;
-    self.translatesAutoresizingMaskIntoConstraints = NO;
-    [self addSubview:_stimulusView];
-    [self setNeedsUpdateConstraints];
-}
-
-- (void)setStimulusHidden:(BOOL)hidden {
-    [_stimulusView setStimulusHidden:hidden];
-}
-
-- (void)removeConstraints {
-    if ([_constraints count]) {
-        [NSLayoutConstraint deactivateConstraints:_constraints];
-        _constraints = nil;
+    if (!_stimulusView) {
+        _stimulusView = [ORKDeviceMotionReactionTimeStimulusView new];
+        _stimulusView.translatesAutoresizingMaskIntoConstraints = NO;
+        _stimulusView.backgroundColor = self.tintColor;
+        [self addSubview:_stimulusView];
+        [self setUpStimulusViewConstraints];
     }
 }
 
-- (void)updateConstraints {
-    [self removeConstraints];
+- (void)setStimulusHidden:(BOOL)hidden {
+    _stimulusView.hidden = hidden;
+}
+
+- (void)setUpStimulusViewConstraints {
     NSMutableArray *constraints = [NSMutableArray array];
-    NSDictionary *views = NSDictionaryOfVariableBindings(_stimulusView);
     
     [constraints addObject:[NSLayoutConstraint constraintWithItem:_stimulusView
-                                                               attribute:NSLayoutAttributeCenterX
-                                                               relatedBy:NSLayoutRelationEqual
-                                                                  toItem:self
-                                                               attribute:NSLayoutAttributeCenterX
-                                                              multiplier:1 constant:0]];
+                                                        attribute:NSLayoutAttributeCenterX
+                                                        relatedBy:NSLayoutRelationEqual
+                                                           toItem:self
+                                                        attribute:NSLayoutAttributeCenterX
+                                                       multiplier:1.0
+                                                         constant:0.0]];
     
     [constraints addObject:[NSLayoutConstraint constraintWithItem:_stimulusView
-                                                               attribute:NSLayoutAttributeTop
-                                                               relatedBy:NSLayoutRelationEqual
-                                                                  toItem:self
-                                                               attribute:NSLayoutAttributeTop
-                                                              multiplier:1 constant: 8]];
+                                                        attribute:NSLayoutAttributeTop
+                                                        relatedBy:NSLayoutRelationEqual
+                                                           toItem:self
+                                                        attribute:NSLayoutAttributeTop
+                                                       multiplier:1.0
+                                                         constant:8.0]];
     
-    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=0)-[_stimulusView]-(>=0)-|"
+    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[_stimulusView]-(>=0)-|"
                                                                              options:NSLayoutFormatAlignAllCenterX
                                                                              metrics:nil
-                                                                               views:views]];
+                                                                               views:NSDictionaryOfVariableBindings(_stimulusView)]];
     
-    _constraints = constraints;
     [NSLayoutConstraint activateConstraints:constraints];
-    [super updateConstraints];
 }
 
 @end

--- a/ResearchKit/ActiveTasks/ORKDeviceMotionReactionTimeStep.h
+++ b/ResearchKit/ActiveTasks/ORKDeviceMotionReactionTimeStep.h
@@ -30,6 +30,7 @@
 
 
 #import <ResearchKit/ResearchKit.h>
+#import <AudioToolbox/AudioServices.h>
 
 
 NS_ASSUME_NONNULL_BEGIN
@@ -47,11 +48,11 @@ ORK_CLASS_AVAILABLE
 
 @property (nonatomic, assign) double thresholdAcceleration;
 
-@property (nonatomic, assign) UInt32 successSound;
+@property (nonatomic, assign) SystemSoundID successSound;
 
-@property (nonatomic, assign) UInt32 timeoutSound;
+@property (nonatomic, assign) SystemSoundID timeoutSound;
 
-@property (nonatomic, assign) UInt32 failureSound;
+@property (nonatomic, assign) SystemSoundID failureSound;
 
 @end
 

--- a/ResearchKit/ActiveTasks/ORKDeviceMotionReactionTimeStep.m
+++ b/ResearchKit/ActiveTasks/ORKDeviceMotionReactionTimeStep.m
@@ -28,6 +28,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+
 #import "ORKDeviceMotionReactionTimeStep.h"
 #import "ORKDeviceMotionReactionTimeViewController.h"
 #import "ORKHelpers.h"
@@ -35,7 +36,7 @@
 
 @implementation ORKDeviceMotionReactionTimeStep
 
-+ (Class) stepViewControllerClass {
++ (Class)stepViewControllerClass {
     return [ORKDeviceMotionReactionTimeViewController class];
 }
 
@@ -52,9 +53,9 @@
     step.thresholdAcceleration = self.thresholdAcceleration;
     step.timeout = self.timeout;
     step.numberOfAttempts = self.numberOfAttempts;
-    self.successSound = self.successSound;
-    self.timeoutSound = self.timeoutSound;
-    self.failureSound = self.failureSound;
+    step.successSound = self.successSound;
+    step.timeoutSound = self.timeoutSound;
+    step.failureSound = self.failureSound;
     return step;
 }
 

--- a/ResearchKit/ActiveTasks/ORKDeviceMotionReactionTimeStep.m
+++ b/ResearchKit/ActiveTasks/ORKDeviceMotionReactionTimeStep.m
@@ -62,6 +62,11 @@
 - (void)validateParameters {
     [super validateParameters];
     
+    if (self.minimumStimulusInterval <= 0) {
+        @throw [NSException exceptionWithName:NSInvalidArgumentException
+                                       reason:@"minimumStimulusInterval must be greater than zero"
+                                     userInfo:nil];
+    }
     if (self.maximumStimulusInterval < self.minimumStimulusInterval) {
         @throw [NSException exceptionWithName:NSInvalidArgumentException
                                        reason:@"maximumStimulusInterval can not be less than minimumStimulusInterval"
@@ -70,6 +75,11 @@
     if (self.thresholdAcceleration <= 0) {
         @throw [NSException exceptionWithName:NSInvalidArgumentException
                                        reason:@"thresholdAcceleration must be greater than zero"
+                                     userInfo:nil];
+    }
+    if (self.timeout <= 0) {
+        @throw [NSException exceptionWithName:NSInvalidArgumentException
+                                       reason:@"timeout must be greater than zero"
                                      userInfo:nil];
     }
     if (self.numberOfAttempts <= 0) {

--- a/ResearchKit/ActiveTasks/ORKDeviceMotionReactionTimeStimulusView.h
+++ b/ResearchKit/ActiveTasks/ORKDeviceMotionReactionTimeStimulusView.h
@@ -34,10 +34,10 @@
 
 @interface ORKDeviceMotionReactionTimeStimulusView : UIView
 
+- (void)reset;
+
 - (void)startSuccessAnimationWithDuration:(NSTimeInterval)duration completion:(nullable void(^)(void))completion;
 
 - (void)startFailureAnimationWithDuration:(NSTimeInterval)duration completion:(nullable void(^)(void))completion;
-
-- (void)setStimulusHidden: (BOOL) hidden;
 
 @end

--- a/ResearchKit/ActiveTasks/ORKDeviceMotionReactionTimeStimulusView.m
+++ b/ResearchKit/ActiveTasks/ORKDeviceMotionReactionTimeStimulusView.m
@@ -33,14 +33,13 @@
 
 
 @implementation ORKDeviceMotionReactionTimeStimulusView {
-    
     CAShapeLayer *_tickLayer;
     CAShapeLayer *_crossLayer;
 }
 
 static const CGFloat RoundReactionTimeViewDiameter = 122;
 
-- (instancetype) init {
+- (instancetype)init {
     self = [super init];
     if (self) {
         self.layer.cornerRadius = RoundReactionTimeViewDiameter * 0.5;
@@ -52,7 +51,23 @@ static const CGFloat RoundReactionTimeViewDiameter = 122;
     return CGSizeMake(RoundReactionTimeViewDiameter, RoundReactionTimeViewDiameter);
 }
 
+- (void)reset {
+    [_tickLayer removeFromSuperlayer];
+    [_crossLayer removeFromSuperlayer];
+    _tickLayer = nil;
+    _crossLayer = nil;
+    self.layer.backgroundColor = self.tintColor.CGColor;
+    self.hidden = YES;
+}
+
 - (void)startSuccessAnimationWithDuration:(NSTimeInterval)duration completion:(void(^)(void))completion {
+    if (self.hidden) {
+        if (completion) {
+            completion();
+        }
+        return;
+    }
+    
     [self addTickLayer];
     [CATransaction begin];
     [CATransaction setCompletionBlock:completion];
@@ -68,9 +83,15 @@ static const CGFloat RoundReactionTimeViewDiameter = 122;
     [CATransaction commit];
 }
 
-
 - (void)startFailureAnimationWithDuration:(NSTimeInterval)duration completion:(void(^)(void))completion {
-    [self setStimulusHidden:true];
+    if (self.hidden) {
+        if (completion) {
+            completion();
+        }
+        return;
+    }
+
+    self.layer.backgroundColor = [UIColor clearColor].CGColor;
     [self addCrossLayer];
     [CATransaction begin];
     [CATransaction setCompletionBlock:completion];
@@ -84,19 +105,15 @@ static const CGFloat RoundReactionTimeViewDiameter = 122;
     [CATransaction commit];
 }
 
-- (void)setStimulusHidden: (BOOL) hidden {
-    self.layer.backgroundColor = hidden ? [UIColor clearColor].CGColor : self.tintColor.CGColor;
-}
-
 - (void)addCrossLayer {
-     _crossLayer =  [self lineDrawingLayer];
+    _crossLayer = [self lineDrawingLayer];
     _crossLayer.strokeColor = [UIColor redColor].CGColor;
     _crossLayer.path = [self crossPath];
     [self.layer addSublayer:_crossLayer];
 }
 
 - (void)addTickLayer {
-    _tickLayer =  [self lineDrawingLayer];
+    _tickLayer = [self lineDrawingLayer];
     _tickLayer.strokeColor = [UIColor whiteColor].CGColor;
     _tickLayer.path = [self tickPath];
     [self.layer addSublayer:_tickLayer];
@@ -104,7 +121,7 @@ static const CGFloat RoundReactionTimeViewDiameter = 122;
 
 - (CGPathRef)concealPath:(CGFloat)radius {
     return [[UIBezierPath bezierPathWithArcCenter:CGPointMake(radius, radius)
-                                           radius: radius / 2
+                                           radius:radius / 2
                                        startAngle:M_PI + M_PI_2
                                          endAngle:-M_PI_2
                                         clockwise:NO] CGPath];

--- a/ResearchKit/Common/ORKOrderedTask.m
+++ b/ResearchKit/Common/ORKOrderedTask.m
@@ -873,28 +873,28 @@ static void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
     
     NSMutableArray *steps = [NSMutableArray array];
     
-    if (! (options & ORKPredefinedTaskOptionExcludeInstructions)) {
-            {
-                ORKInstructionStep *step = [[ORKInstructionStep alloc] initWithIdentifier:ORKInstruction0StepIdentifier];
-                step.title = ORKLocalizedString(@"REACTION_TIME_TASK_TITLE", nil);
-                step.text = intendedUseDescription;
-                step.detailText = ORKLocalizedString(@"REACTION_TIME_TASK_INTENDED_USE", nil);
-                step.image = [UIImage imageNamed:@"phoneshake" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
-                step.shouldTintImages = YES;
+    if (!(options & ORKPredefinedTaskOptionExcludeInstructions)) {
+        {
+            ORKInstructionStep *step = [[ORKInstructionStep alloc] initWithIdentifier:ORKInstruction0StepIdentifier];
+            step.title = ORKLocalizedString(@"REACTION_TIME_TASK_TITLE", nil);
+            step.text = intendedUseDescription;
+            step.detailText = ORKLocalizedString(@"REACTION_TIME_TASK_INTENDED_USE", nil);
+            step.image = [UIImage imageNamed:@"phoneshake" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
+            step.shouldTintImages = YES;
             
-                ORKStepArrayAddStep(steps, step);
-            }
-            {
-                ORKInstructionStep *step = [[ORKInstructionStep alloc] initWithIdentifier:ORKInstruction1StepIdentifier];
-                step.title = ORKLocalizedString(@"REACTION_TIME_TASK_TITLE", nil);
-                step.text = [NSString stringWithFormat: ORKLocalizedString(@"REACTION_TIME_TASK_INTRO_TEXT_FORMAT", nil), numberOfAttempts];
-                step.detailText = ORKLocalizedString(@"REACTION_TIME_TASK_CALL_TO_ACTION", nil);
-                step.image = [UIImage imageNamed:@"phoneshakecircle" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
-                step.shouldTintImages = YES;
-              
-                ORKStepArrayAddStep(steps, step);
-            }
+            ORKStepArrayAddStep(steps, step);
         }
+        {
+            ORKInstructionStep *step = [[ORKInstructionStep alloc] initWithIdentifier:ORKInstruction1StepIdentifier];
+            step.title = ORKLocalizedString(@"REACTION_TIME_TASK_TITLE", nil);
+            step.text = [NSString stringWithFormat: ORKLocalizedString(@"REACTION_TIME_TASK_INTRO_TEXT_FORMAT", nil), numberOfAttempts];
+            step.detailText = ORKLocalizedString(@"REACTION_TIME_TASK_CALL_TO_ACTION", nil);
+            step.image = [UIImage imageNamed:@"phoneshakecircle" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
+            step.shouldTintImages = YES;
+            
+            ORKStepArrayAddStep(steps, step);
+        }
+    }
     
     ORKDeviceMotionReactionTimeStep *step = [[ORKDeviceMotionReactionTimeStep alloc] initWithIdentifier:ORKDeviceMotionReactionTimeStepIdentifier];
     step.maximumStimulusInterval = maximumStimulusInterval;
@@ -909,7 +909,7 @@ static void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
 
     ORKStepArrayAddStep(steps, step);
     
-    if (! (options & ORKPredefinedTaskOptionExcludeConclusion)) {
+    if (!(options & ORKPredefinedTaskOptionExcludeConclusion)) {
         ORKInstructionStep *step = [self makeCompletionStep];
         ORKStepArrayAddStep(steps, step);
     }

--- a/ResearchKit/Common/ORKResult.h
+++ b/ResearchKit/Common/ORKResult.h
@@ -465,6 +465,7 @@ ORK_CLASS_AVAILABLE
 
 @end
 
+
 /**
  The `ORKFileResult` class is a result that references the location of a file produced
  during a task.
@@ -508,6 +509,7 @@ ORK_CLASS_AVAILABLE
 
 @end
 
+
 /**
  The 'ORKDeviceMotionReactionTimeResult' class represents the result of a single successful attempt within an ORKDeviceMotionReactionTimeStep.
  
@@ -520,7 +522,6 @@ Using the time taken to reach the thresholdAcceleration as the reactionTime of a
  completes, it may be appropriate to serialize the sample for transmission to a server,
  or to immediately perform analysis on it.
  */
-
 ORK_CLASS_AVAILABLE
 @interface ORKDeviceMotionReactionTimeResult: ORKResult
 
@@ -529,6 +530,7 @@ ORK_CLASS_AVAILABLE
 @property (nonatomic, strong) ORKFileResult *fileResult;
 
 @end
+
 
 /**
  The `ORKQuestionResult` class is the base class for leaf results from an item that uses an answer format (`ORKAnswerFormat`).

--- a/ResearchKit/Common/ORKResult.m
+++ b/ResearchKit/Common/ORKResult.m
@@ -609,6 +609,7 @@
 
 @end
 
+
 @implementation ORKDataResult
 
 - (BOOL)isSaveable {

--- a/ResearchKit/Consent/ORKEAGLMoviePlayerView.m
+++ b/ResearchKit/Consent/ORKEAGLMoviePlayerView.m
@@ -137,7 +137,7 @@ const GLfloat DefaultPreferredRotation = 0;
         // Get and configure the layer.
         CAEAGLLayer *eaglLayer = (CAEAGLLayer *)self.layer;
         
-        eaglLayer.opaque = TRUE;
+        eaglLayer.opaque = YES;
         eaglLayer.drawableProperties = @{ kEAGLDrawablePropertyRetainedBacking : @YES,
                                           kEAGLDrawablePropertyColorFormat : kEAGLColorFormatRGBA8};
         

--- a/ResearchKitTests/ORKStepTests.m
+++ b/ResearchKitTests/ORKStepTests.m
@@ -1,0 +1,113 @@
+/*
+ Copyright (c) 2015, Ricardo Sánchez-Sáez.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#import <XCTest/XCTest.h>
+#import <ResearchKit/ResearchKit.h>
+#import "ORKDeviceMotionReactionTimeStep.h"
+
+
+@interface ORKStepTests : XCTestCase
+
+@end
+
+
+@implementation ORKStepTests
+
+- (void)testFormStep {
+    // Test duplicate form step identifier validation
+    ORKFormStep *formStep = [[ORKFormStep alloc] initWithIdentifier:@"form" title:@"Form" text:@"Form test"];
+    NSMutableArray *items = [NSMutableArray new];
+    
+    ORKFormItem *item = nil;
+    item = [[ORKFormItem alloc] initWithIdentifier:@"formItem1"
+                                              text:@"formItem1"
+                                      answerFormat:[ORKNumericAnswerFormat decimalAnswerFormatWithUnit:nil]];
+    [items addObject:item];
+
+    item = [[ORKFormItem alloc] initWithIdentifier:@"formItem2"
+                                              text:@"formItem2"
+                                      answerFormat:[ORKNumericAnswerFormat decimalAnswerFormatWithUnit:nil]];
+    [items addObject:item];
+
+    [formStep setFormItems:items];
+    XCTAssertNoThrow([formStep validateParameters]);
+
+    item = [[ORKFormItem alloc] initWithIdentifier:@"formItem2"
+                                              text:@"formItem2"
+                                      answerFormat:[ORKNumericAnswerFormat decimalAnswerFormatWithUnit:nil]];
+    [items addObject:item];
+
+    [formStep setFormItems:items];
+    XCTAssertThrows([formStep validateParameters]);
+}
+
+- (void)testDeviceMotionReactionTimeStep {
+    ORKDeviceMotionReactionTimeStep *validReactionTimeStep = [[ORKDeviceMotionReactionTimeStep alloc] initWithIdentifier:@"ReactionTimeStep"];
+    
+    validReactionTimeStep.maximumStimulusInterval = 8;
+    validReactionTimeStep.minimumStimulusInterval = 4;
+    validReactionTimeStep.thresholdAcceleration = 0.5;
+    validReactionTimeStep.numberOfAttempts = 3;
+    validReactionTimeStep.timeout = 10;
+
+    XCTAssertNoThrow([validReactionTimeStep validateParameters]);
+    
+    ORKDeviceMotionReactionTimeStep *reactionTimeStep = [validReactionTimeStep copy];
+    XCTAssertEqualObjects(reactionTimeStep, validReactionTimeStep);
+
+    // minimumStimulusInterval cannot be zero or less
+    reactionTimeStep = [validReactionTimeStep copy];
+    validReactionTimeStep.minimumStimulusInterval = 0;
+    XCTAssertThrows([validReactionTimeStep validateParameters]);
+
+    // minimumStimulusInterval cannot be higher than maximumStimulusInterval
+    reactionTimeStep = [validReactionTimeStep copy];
+    validReactionTimeStep.maximumStimulusInterval = 8;
+    validReactionTimeStep.minimumStimulusInterval = 10;
+    XCTAssertThrows([validReactionTimeStep validateParameters]);
+
+    // thresholdAcceleration cannot be zero or less
+    reactionTimeStep = [validReactionTimeStep copy];
+    validReactionTimeStep.thresholdAcceleration = 0;
+    XCTAssertThrows([validReactionTimeStep validateParameters]);
+
+    // timeout cannot be zero or less
+    reactionTimeStep = [validReactionTimeStep copy];
+    validReactionTimeStep.timeout = 0;
+    XCTAssertThrows([validReactionTimeStep validateParameters]);
+
+    // numberOfAttempts cannot be zero or less
+    reactionTimeStep = [validReactionTimeStep copy];
+    validReactionTimeStep.numberOfAttempts = 0;
+    XCTAssertThrows([validReactionTimeStep validateParameters]);
+}
+
+@end

--- a/ResearchKitTests/ORKTaskTests.m
+++ b/ResearchKitTests/ORKTaskTests.m
@@ -342,34 +342,6 @@ typedef NS_OPTIONS(NSUInteger, TestsTaskResultOptions) {
     XCTAssertThrows([orderedTask validateParameters]);
 }
 
-- (void)testFormStep {
-    // Test duplicate form step identifier validation
-    ORKFormStep *formStep = [[ORKFormStep alloc] initWithIdentifier:@"form" title:@"Form" text:@"Form test"];
-    NSMutableArray *items = [NSMutableArray new];
-    
-    ORKFormItem *item = nil;
-    item = [[ORKFormItem alloc] initWithIdentifier:@"formItem1"
-                                              text:@"formItem1"
-                                      answerFormat:[ORKNumericAnswerFormat decimalAnswerFormatWithUnit:nil]];
-    [items addObject:item];
-
-    item = [[ORKFormItem alloc] initWithIdentifier:@"formItem2"
-                                              text:@"formItem2"
-                                      answerFormat:[ORKNumericAnswerFormat decimalAnswerFormatWithUnit:nil]];
-    [items addObject:item];
-
-    [formStep setFormItems:items];
-    XCTAssertNoThrow([formStep validateParameters]);
-
-    item = [[ORKFormItem alloc] initWithIdentifier:@"formItem2"
-                                              text:@"formItem2"
-                                      answerFormat:[ORKNumericAnswerFormat decimalAnswerFormatWithUnit:nil]];
-    [items addObject:item];
-
-    [formStep setFormItems:items];
-    XCTAssertThrows([formStep validateParameters]);
-}
-
 #define getIndividualNavigableOrderedTaskSteps() \
     __unused ORKStep *symptomStep = _navigableOrderedTaskSteps[0];\
     __unused ORKStep *severityStep = _navigableOrderedTaskSteps[1];\

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -396,21 +396,21 @@ static NSString * const StepNavigationTaskIdentifier = @"step_navigation";
     } else if ([identifier isEqualToString:TwoFingerTapTaskIdentifier]) {
         return [ORKOrderedTask twoFingerTappingIntervalTaskWithIdentifier:TwoFingerTapTaskIdentifier
                                                    intendedUseDescription:nil
-                                                                 duration:20.0 options:(ORKPredefinedTaskOption)0];
+                                                                 duration:20.0
+                                                                  options:(ORKPredefinedTaskOption)0];
     }
     else if ([identifier isEqualToString:ReactionTimeTaskIdentifier]) {
-        return [ORKOrderedTask
-                deviceMotionReactionTimeTaskWithIdentifier:ReactionTimeTaskIdentifier
-                intendedUseDescription:nil
-                maximumStimulusInterval:8
-                minimumStimulusInterval:4
-                thresholdAcceleration:0.5
-                numberOfAttempts:3
-                timeout:10
-                successSound:0
-                timeoutSound:0
-                failureSound:0
-                options:0];
+        return [ORKOrderedTask deviceMotionReactionTimeTaskWithIdentifier:ReactionTimeTaskIdentifier
+                                                   intendedUseDescription:nil
+                                                  maximumStimulusInterval:8
+                                                  minimumStimulusInterval:4
+                                                    thresholdAcceleration:0.5
+                                                         numberOfAttempts:3
+                                                                  timeout:10
+                                                             successSound:0
+                                                             timeoutSound:0
+                                                             failureSound:0
+                                                                  options:0];
     } else if ([identifier isEqualToString:StepNavigationTaskIdentifier]) {
         return [self makeStepNavigationTask];
     }


### PR DESCRIPTION
This spun off while I was refactoring the constraints code. I'm submitting it as a separate PR because it fixes an erroneous `ORKDeviceMotionReactionTimeStep`'s *copy* method. 

Also:
- Refactors and simplifies constraint code.
- Conforms to whitespace conventions.
- Replaces `true`/`false` usage by `YES`/`NO`.
- Uses `SystemSoundID` instead of `UInt32`.