### PR TITLE
Reaction time task: fix issues

### DIFF
--- a/ResearchKit/ActiveTasks/ORKActiveStepViewController_Internal.h
+++ b/ResearchKit/ActiveTasks/ORKActiveStepViewController_Internal.h
@@ -59,6 +59,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)applicationWillResignActive:(NSNotification *)notification;
 - (void)applicationDidBecomeActive:(NSNotification *)notification;
 
+- (void)stopRecorders;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/ActiveTasks/ORKDeviceMotionReactionTimeContentView.m
+++ b/ResearchKit/ActiveTasks/ORKDeviceMotionReactionTimeContentView.m
@@ -62,7 +62,7 @@
 
 - (void)resetAfterDelay:(NSTimeInterval)delay completion:(nullable void (^)(void))completion {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        [_stimulusView reset];
+        _stimulusView.hidden = YES;
         if (completion) {
             completion();
         }

--- a/ResearchKit/ActiveTasks/ORKDeviceMotionReactionTimeStimulusView.m
+++ b/ResearchKit/ActiveTasks/ORKDeviceMotionReactionTimeStimulusView.m
@@ -57,7 +57,6 @@ static const CGFloat RoundReactionTimeViewDiameter = 122;
     _tickLayer = nil;
     _crossLayer = nil;
     self.layer.backgroundColor = self.tintColor.CGColor;
-    self.hidden = YES;
 }
 
 - (void)startSuccessAnimationWithDuration:(NSTimeInterval)duration completion:(void(^)(void))completion {
@@ -84,12 +83,7 @@ static const CGFloat RoundReactionTimeViewDiameter = 122;
 }
 
 - (void)startFailureAnimationWithDuration:(NSTimeInterval)duration completion:(void(^)(void))completion {
-    if (self.hidden) {
-        if (completion) {
-            completion();
-        }
-        return;
-    }
+    self.hidden = NO;
 
     self.layer.backgroundColor = [UIColor clearColor].CGColor;
     [self addCrossLayer];
@@ -103,6 +97,11 @@ static const CGFloat RoundReactionTimeViewDiameter = 122;
     _crossLayer.strokeEnd = 1;
     [_crossLayer addAnimation:animation forKey:@"strokeEnd"];
     [CATransaction commit];
+}
+
+- (void)setHidden:(BOOL)hidden {
+    [self reset];
+    [super setHidden:hidden];
 }
 
 - (void)addCrossLayer {

--- a/ResearchKit/ActiveTasks/ORKDeviceMotionReactionTimeViewController.m
+++ b/ResearchKit/ActiveTasks/ORKDeviceMotionReactionTimeViewController.m
@@ -118,9 +118,7 @@ static const NSTimeInterval OutcomeAnimationDuration = 0.3;
     CMAcceleration v = motion.userAcceleration;
     double vectorMagnitude = sqrt(((v.x * v.x) + (v.y * v.y) + (v.z * v.z)));
     if (vectorMagnitude > [self reactionTimeStep].thresholdAcceleration) {
-        for (ORKRecorder *recorder in self.recorders) {
-            [recorder stop];
-        }
+        [self stopRecorders];
     }
 }
 
@@ -144,7 +142,11 @@ static const NSTimeInterval OutcomeAnimationDuration = 0.3;
             [self resetAfterDelay:2];
         }
     };
-    _validResult ? [self indicateSuccess:completion] : [self indicateFailure:completion];
+    if (_validResult) {
+        [self indicateSuccess:completion];
+    } else {
+        [self indicateFailure:completion];
+    }
     _validResult = NO;
     _timedOut = NO;
     [_stimulusTimer invalidate];
@@ -194,7 +196,7 @@ static const NSTimeInterval OutcomeAnimationDuration = 0.3;
 - (void)timeoutTimerDidFire {
     _validResult = NO;
     _timedOut = YES;
-    [self attemptDidFinish];
+    [self stopRecorders];
 }
 
 - (NSTimeInterval)stimulusInterval {

--- a/samples/ORKCatalog/ORKCatalog/ResultTableViewProviders.swift
+++ b/samples/ORKCatalog/ORKCatalog/ResultTableViewProviders.swift
@@ -445,12 +445,6 @@ class TappingIntervalResultTableViewProvider: ResultTableViewProvider {
         return "Samples"
     }
     
-    // MARK: UITableViewDelegate
-    
-    func tableView(tableView: UITableView, shouldHighlightRowAtIndexPath indexPath: NSIndexPath) -> Bool {
-        return false
-    }
-    
     // MARK: ResultTableViewProvider
     
     override func resultRowsForSection(section: Int) -> [ResultRow] {
@@ -500,12 +494,6 @@ class ToneAudiometryResultTableViewProvider: ResultTableViewProvider {
         }
 
         return "Samples"
-    }
-
-    // MARK: UITableViewDelegate
-
-    func tableView(tableView: UITableView, shouldHighlightRowAtIndexPath indexPath: NSIndexPath) -> Bool {
-        return false
     }
 
     // MARK: ResultTableViewProvider
@@ -561,12 +549,6 @@ class SpatialSpanMemoryResultTableViewProvider: ResultTableViewProvider {
         return "Game Records"
     }
     
-    // MARK: UITableViewDelegate
-    
-    func tableView(tableView: UITableView, shouldHighlightRowAtIndexPath indexPath: NSIndexPath) -> Bool {
-        return false
-    }
-    
     // MARK: ResultTableViewProvider
     
     override func resultRowsForSection(section: Int) -> [ResultRow] {
@@ -589,13 +571,15 @@ class SpatialSpanMemoryResultTableViewProvider: ResultTableViewProvider {
         
         return rows + questionResult.gameRecords!.map { gameRecord in
             // Note `gameRecord` is of type `ORKSpatialSpanMemoryGameRecord`.
-            return ResultRow(text: "game", detail: gameRecord.score, selectable: true)
+            return ResultRow(text: "game", detail: gameRecord.score)
         }
     }
 }
 
+/// Table view provider specific to an `ORKDeviceMotionReactionTimeResult` instance.
 class DeviceMotionReactionTimeViewProvider: ResultTableViewProvider {
-    
+    // MARK: UITableViewDataSource
+
     override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
         return 2
     }
@@ -608,16 +592,18 @@ class DeviceMotionReactionTimeViewProvider: ResultTableViewProvider {
         return "File Results"
     }
     
+    // MARK: ResultTableViewProvider
+
     override func resultRowsForSection(section: Int) -> [ResultRow] {
         let reactionTimeResult = result as! ORKDeviceMotionReactionTimeResult
         
         let rows = super.resultRowsForSection(section)
         
         if section == 0 {
-            return rows + [ ResultRow(text: "timestamp", detail: reactionTimeResult.timestamp, selectable: true) ]
+            return rows + [ ResultRow(text: "timestamp", detail: reactionTimeResult.timestamp) ]
         }
         
-        return rows + [ ResultRow(text: "File Result", detail: reactionTimeResult.fileResult.fileURL!.absoluteString, selectable: false) ]
+        return rows + [ ResultRow(text: "File Result", detail: reactionTimeResult.fileResult.fileURL!.absoluteString) ]
     }
 }
 


### PR DESCRIPTION
This PR fixes three issues:

- *[Regression]* Failure animation was not showing if you shook the device before the blue dot appeared.
- Failure animation could be triggered a second time if you shook the device while the timeout failure animation was being shown.
- Reaction time result could cause a crash in `ORKCatalog` because the `timestamp` row was selectable.