### PR TITLE
Speech rate should use default speech rate

### DIFF
--- a/ResearchKit/ActiveTasks/ORKVoiceEngine.m
+++ b/ResearchKit/ActiveTasks/ORKVoiceEngine.m
@@ -71,7 +71,7 @@
     }
     
     AVSpeechUtterance *utterance = [[AVSpeechUtterance alloc] initWithString:text];
-    utterance.rate = AVSpeechUtteranceMaximumSpeechRate / 7;
+    utterance.rate = AVSpeechUtteranceDefaultSpeechRate;
 
     [self.speechSynthesizer speakUtterance:utterance];
 }


### PR DESCRIPTION
Using a speech rate relative to the maximum speech rate is error
prone.