### PR TITLE
Keyboard does not hide when tapping on margins on iPad

### DIFF
--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -427,6 +427,7 @@
         _tableContainer = [[ORKTableContainerView alloc] initWithFrame:self.view.bounds];
         _tableContainer.delegate = self;
         [self.view addSubview:_tableContainer];
+        _tableContainer.tapOffView = self.view;
         
         _tableView = _tableContainer.tableView;
         _tableView.delegate = self;

--- a/ResearchKit/Common/ORKQuestionStepViewController.m
+++ b/ResearchKit/Common/ORKQuestionStepViewController.m
@@ -161,6 +161,7 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
             _tableView.clipsToBounds = YES;
             
             [self.view addSubview:_tableContainer];
+            _tableContainer.tapOffView = self.view;
             
             _headerView = _tableContainer.stepHeaderView;
             _headerView.captionLabel.useSurveyMode = self.step.useSurveyMode;

--- a/ResearchKit/Common/ORKTableContainerView.h
+++ b/ResearchKit/Common/ORKTableContainerView.h
@@ -56,6 +56,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) ORKStepHeaderView *stepHeaderView;
 @property (nonatomic, strong, readonly) ORKNavigationContainerView *continueSkipContainerView;
 
+/*
+ If tap off events should be accepted from outside this view's bounds, provide
+ the parent view where the tap off gesture recognizer should be attached.
+ */
+@property (nonatomic, weak, nullable) UIView *tapOffView;
+
 - (void)scrollCellVisible:(UITableViewCell *)cell animated:(BOOL)animated;
 
 @end

--- a/ResearchKit/Common/ORKTableContainerView.m
+++ b/ResearchKit/Common/ORKTableContainerView.m
@@ -56,6 +56,8 @@
     BOOL _keyboardIsUp;
     
     UIScrollView *_scrollView;
+    
+    UITapGestureRecognizer *_tapOffGestureRecognizer;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
@@ -98,11 +100,21 @@
         
         [self setNeedsUpdateConstraints];
         
-        UITapGestureRecognizer *tapOffRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tapOffAction:)];
-        tapOffRecognizer.delegate = self;
-        [_tableView addGestureRecognizer:tapOffRecognizer];
+        _tapOffGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tapOffAction:)];
+        _tapOffGestureRecognizer.delegate = self;
+        [_tableView addGestureRecognizer:_tapOffGestureRecognizer];
     }
     return self;
+}
+
+- (void)setTapOffView:(UIView * __nullable)tapOffView {
+    _tapOffView = tapOffView;
+    
+    [_tapOffGestureRecognizer.view removeGestureRecognizer:_tapOffGestureRecognizer];
+    
+    _tapOffGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tapOffAction:)];
+    _tapOffGestureRecognizer.delegate = self;
+    [(tapOffView ? : _tableView) addGestureRecognizer:_tapOffGestureRecognizer];
 }
 
 - (void)layoutSubviews {
@@ -193,7 +205,6 @@
     while (subview) {
         // Ignore table view cells, since first responder will be manually managed for taps on them
         if ([subview isFirstResponder] || [subview isKindOfClass:[UITableViewCell class]]) {
-            ORK_Log_Debug(@"v=%@",subview);
             viewIsChildOfFirstResponder = YES;
             break;
         }


### PR DESCRIPTION
Steps to reproduce:
- Build and deploy ORKTest to iPad sim
- Miniform -> Weight
- Tap on weight, Keyboard appears
- Tap on side of screen

Actual result:
- Keyboard does not hide

Expected result:
- Keyboard should hide.

Fix: allow parent view to specify a different tap off scope for the tap off
gesture recognizer by exposing a tapOffView property on ORKTableContainerView.

This has no API impact, since ORKTableContainerView is internal to the framework.