### PR TITLE
Exception when saving and restoring image capture step.

### DIFF
--- a/ResearchKit/Common/ORKHelpers.h
+++ b/ResearchKit/Common/ORKHelpers.h
@@ -56,6 +56,8 @@
 
 #define ORK_DECODE_OBJ(d,x)  _ ## x = [d decodeObjectForKey:@STRINGIFY(x)]
 #define ORK_ENCODE_OBJ(c,x)  [c encodeObject:_ ## x forKey:@STRINGIFY(x)]
+#define ORK_ENCODE_URL(c,x)  [c encodeObject:ORKRelativePathForURL(_ ## x) forKey:@STRINGIFY(x)]
+#define ORK_ENCODE_URL_BOOKMARK(c, x) [c encodeObject:ORKBookmarkDataFromURL(_ ## x) forKey:@STRINGIFY(x)]
 
 #define ORK_DECODE_OBJ_CLASS(d,x,cl)  _ ## x = (cl *)[d decodeObjectOfClass:[cl class] forKey:@STRINGIFY(x)]
 #define ORK_DECODE_OBJ_ARRAY(d,x,cl)  _ ## x = (NSArray *)[d decodeObjectOfClasses:[NSSet setWithObjects:[NSArray class],[cl class],nil] forKey:@STRINGIFY(x)]
@@ -67,7 +69,8 @@
 #define ORK_DECODE_IMAGE(d,x)  _ ## x = (UIImage *)[d decodeObjectOfClass:[UIImage class] forKey:@STRINGIFY(x)]
 #define ORK_ENCODE_IMAGE(c,x)  { if (_ ## x) { UIImage * __ ## x = [UIImage imageWithCGImage:[_ ## x CGImage] scale:[_ ## x scale] orientation:[_ ## x imageOrientation]]; [c encodeObject:__ ## x forKey:@STRINGIFY(x)]; } }
 
-#define ORK_DECODE_URL(d,x) _ ## x = (NSURL *)[d decodeObjectOfClass:[NSURL class] forKey:@STRINGIFY(x)]
+#define ORK_DECODE_URL(d,x) _ ## x = ORKURLForRelativePath((NSString *)[d decodeObjectOfClass:[NSString class] forKey:@STRINGIFY(x)])
+#define ORK_DECODE_URL_BOOKMARK(d,x)  _ ## x = ORKURLFromBookmarkData((NSData *)[d decodeObjectOfClass:[NSData class] forKey:@STRINGIFY(x)])
 
 #define ORK_DECODE_BOOL(d,x)  _ ## x = [d decodeBoolForKey:@STRINGIFY(x)]
 #define ORK_ENCODE_BOOL(c,x)  [c encodeBool:_ ## x forKey:@STRINGIFY(x)]
@@ -219,6 +222,13 @@ _Pragma("clang diagnostic pop") \
 UIFont *ORKThinFontWithSize(CGFloat size);
 UIFont *ORKLightFontWithSize(CGFloat size);
 UIFont *ORKMediumFontWithSize(CGFloat size);
+
+NSURL *ORKURLFromBookmarkData(NSData *data);
+NSData *ORKBookmarkDataFromURL(NSURL *url);
+
+NSString *ORKPathRelativeToURL(NSURL *url, NSURL *baseURL);
+NSURL *ORKURLForRelativePath(NSString *relativePath);
+NSString *ORKRelativePathForURL(NSURL *url);
 
 id ORKDynamicCast_(id x, Class objClass);
 

--- a/ResearchKit/Common/ORKResult.m
+++ b/ResearchKit/Common/ORKResult.m
@@ -518,14 +518,14 @@
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
     [super encodeWithCoder:aCoder];
-    ORK_ENCODE_OBJ(aCoder, fileURL);
+    ORK_ENCODE_URL(aCoder, fileURL);
     ORK_ENCODE_OBJ(aCoder, contentType);
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
-        ORK_DECODE_OBJ_CLASS(aDecoder, fileURL, NSURL);
+        ORK_DECODE_URL(aDecoder, fileURL);
         ORK_DECODE_OBJ_CLASS(aDecoder, contentType, NSString);
     }
     return self;
@@ -1345,14 +1345,14 @@
 - (void)encodeWithCoder:(NSCoder *)aCoder {
     [super encodeWithCoder:aCoder];
     ORK_ENCODE_OBJ(aCoder, taskRunUUID);
-    ORK_ENCODE_OBJ(aCoder, outputDirectory);
+    ORK_ENCODE_URL(aCoder, outputDirectory);
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
         ORK_DECODE_OBJ_CLASS(aDecoder, taskRunUUID, NSUUID);
-        ORK_DECODE_OBJ_CLASS(aDecoder, outputDirectory, NSURL);
+        ORK_DECODE_URL(aDecoder, outputDirectory);
     }
     return self;
 }

--- a/ResearchKit/Common/ORKStepViewController.m
+++ b/ResearchKit/Common/ORKStepViewController.m
@@ -347,13 +347,13 @@ static NSString *const _ORKOutputDirectoryKey = @"outputDirectory";
     
     [coder encodeObject:_step.identifier forKey:_ORKStepIdentifierRestoreKey];
     [coder encodeObject:_presentedDate forKey:_ORKPresentedDateRestoreKey];
-    [coder encodeObject:_outputDirectory forKey:_ORKOutputDirectoryKey];
+    [coder encodeObject:ORKBookmarkDataFromURL(_outputDirectory) forKey:_ORKOutputDirectoryKey];
 }
 
 - (void)decodeRestorableStateWithCoder:(NSCoder *)coder {
     [super decodeRestorableStateWithCoder:coder];
     
-    self.outputDirectory = [coder decodeObjectOfClass:[NSURL class] forKey:_ORKOutputDirectoryKey];
+    self.outputDirectory = ORKURLFromBookmarkData([coder decodeObjectOfClass:[NSData class] forKey:_ORKOutputDirectoryKey]);
     
     if (! self.step) {
         // Just logging to the console in this case, since this can happen during a taskVC restoration of a dynamic task.

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -746,11 +746,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     return [data copy];
 }
 
-- (void)setOutputDirectory:(NSURL *)outputDirectory {
-    if (_hasBeenPresented) {
-        @throw [NSException exceptionWithName:NSGenericException reason:@"Cannot change outputDirectory after presenting task controller" userInfo:nil];
-    }
-    
+- (void)ensureDirectoryExists:(NSURL *)outputDirectory {
     // Only verify existence if the output directory is non-nil.
     // But, even if the output directory is nil, we still set it and forward to the step VC.
     if (outputDirectory != nil) {
@@ -767,6 +763,13 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
             @throw [NSException exceptionWithName:NSGenericException reason:@"Desired outputDirectory is not a directory or could not be created." userInfo:nil];
         }
     }
+}
+
+- (void)setOutputDirectory:(NSURL *)outputDirectory {
+    if (_hasBeenPresented) {
+        @throw [NSException exceptionWithName:NSGenericException reason:@"Cannot change outputDirectory after presenting task controller" userInfo:nil];
+    }
+    [self ensureDirectoryExists:outputDirectory];
     
     _outputDirectory = [outputDirectory copy];
     
@@ -1281,6 +1284,7 @@ static NSString *const _ORKPresentedDate = @"presentedDate";
     self.showsProgressInNavigationBar = [coder decodeBoolForKey:_ORKShowsProgressInNavigationBarRestoreKey];
     
     _outputDirectory = ORKURLFromBookmarkData([coder decodeObjectOfClass:[NSData class] forKey:_ORKOutputDirectoryRestoreKey]);
+    [self ensureDirectoryExists:_outputDirectory];
     
     // Must have a task object already provided by this point in the restoration, in order to restore any other state.
     if (_task) {

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1260,7 +1260,8 @@ static NSString *const _ORKPresentedDate = @"presentedDate";
     [coder encodeObject:_requestedHealthTypesForRead forKey:_ORKRequestedHealthTypesForReadRestoreKey];
     [coder encodeObject:_requestedHealthTypesForWrite forKey:_ORKRequestedHealthTypesForWriteRestoreKey];
     [coder encodeObject:_presentedDate forKey:_ORKPresentedDate];
-    [coder encodeObject:_outputDirectory forKey:_ORKOutputDirectoryRestoreKey];
+    
+    [coder encodeObject:ORKBookmarkDataFromURL(_outputDirectory) forKey:_ORKOutputDirectoryRestoreKey];
     [coder encodeObject:_lastBeginningInstructionStepIdentifier forKey:_ORKLastBeginningInstructionStepIdentifierKey];
     
     [coder encodeObject:_task.identifier forKey:_ORKTaskIdentifierRestoreKey];
@@ -1279,7 +1280,7 @@ static NSString *const _ORKPresentedDate = @"presentedDate";
     _taskRunUUID = [coder decodeObjectOfClass:[NSUUID class] forKey:_ORKTaskRunUUIDRestoreKey];
     self.showsProgressInNavigationBar = [coder decodeBoolForKey:_ORKShowsProgressInNavigationBarRestoreKey];
     
-    _outputDirectory = [coder decodeObjectOfClass:[NSURL class] forKey:_ORKOutputDirectoryRestoreKey];
+    _outputDirectory = ORKURLFromBookmarkData([coder decodeObjectOfClass:[NSData class] forKey:_ORKOutputDirectoryRestoreKey]);
     
     // Must have a task object already provided by this point in the restoration, in order to restore any other state.
     if (_task) {

--- a/ResearchKit/Consent/ORKConsentSection.m
+++ b/ResearchKit/Consent/ORKConsentSection.m
@@ -208,7 +208,7 @@ static NSString *localizedTitleForConsentSectionType(ORKConsentSectionType secti
         ORK_DECODE_OBJ_CLASS(aDecoder, htmlContent, NSString);
         ORK_DECODE_OBJ_CLASS(aDecoder, formalTitle, NSString);
         ORK_DECODE_IMAGE(aDecoder, customImage);
-        ORK_DECODE_URL(aDecoder, customAnimationURL);
+        ORK_DECODE_URL_BOOKMARK(aDecoder, customAnimationURL);
         ORK_DECODE_OBJ_CLASS(aDecoder, customLearnMoreButtonTitle, NSString);
     }
     return self;
@@ -222,7 +222,7 @@ static NSString *localizedTitleForConsentSectionType(ORKConsentSectionType secti
     ORK_ENCODE_OBJ(aCoder, content);
     ORK_ENCODE_OBJ(aCoder, htmlContent);
     ORK_ENCODE_IMAGE(aCoder, customImage);
-    ORK_ENCODE_OBJ(aCoder, customAnimationURL);
+    ORK_ENCODE_URL_BOOKMARK(aCoder, customAnimationURL);
     ORK_ENCODE_OBJ(aCoder, customLearnMoreButtonTitle);
 }
 

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -474,7 +474,7 @@ static NSString * const StepNavigationTaskIdentifier = @"step_navigation";
     
     if (_taskViewController.outputDirectory == nil) {
         // Sets an output directory in Documents, using the `taskRunUUID` in the path.
-        NSURL *documents = [NSURL fileURLWithPath:[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) lastObject]];
+        NSURL *documents =  [[NSFileManager defaultManager] URLForDirectory:NSDocumentDirectory inDomain:NSUserDomainMask appropriateForURL:nil create:NO error:nil];
         NSURL *outputDir = [documents URLByAppendingPathComponent:[self.taskViewController.taskRunUUID UUIDString]];
         [[NSFileManager defaultManager] createDirectoryAtURL:outputDir withIntermediateDirectories:YES attributes:nil error:nil];
         self.taskViewController.outputDirectory = outputDir;


### PR DESCRIPTION
If the app is terminated while on an image capture step, and restarted
by build and run from Xcode, an exception would occur while restoring.

This is a symptom of serializing NSURL's directly, rather than serializing
either a relative path or bookmark data. This matters because the path can
change after a reinstall or restore from backup.

Here we make two changes. First, the output directory in task and step
view controller is serialized as bookmark data rather than directly as a URL.
Secondly, for results serialization, NSURL references are stored as paths
relative to the NSHomeDirectory (i.e. the root of the writable sandbox).