### PR TITLE
Add explicit consent review indication

### DIFF
--- a/ResearchKit/Common/ORKResult.h
+++ b/ResearchKit/Common/ORKResult.h
@@ -761,9 +761,20 @@ ORK_CLASS_AVAILABLE
 @property (nonatomic, copy, nullable) ORKConsentSignature *signature;
 
 /**
+ A boolean value indicating whether the participant consented.
+ 
+ `YES` if the user confirmed consent to the contents of the consent review. Note
+ that the signature could still be invalid if the name or signature image is
+ empty; this indicates only that the user gave a positive acknowledgement of the
+ document.
+ */
+@property (nonatomic, assign) BOOL consented;
+
+/**
  Applies the signature to the consent document.
  
- This method uses the identifier to look up the matching signature placeholder in the consent document and replaces it with this signature. It may throw an exception if
+ This method uses the identifier to look up the matching signature placeholder
+ in the consent document and replaces it with this signature. It may throw an exception if
  the document does not contain a signature with a matching identifier.
  
  @param document     The document to which to apply the signature.

--- a/ResearchKit/Common/ORKResult.m
+++ b/ResearchKit/Common/ORKResult.m
@@ -668,12 +668,14 @@
 - (void)encodeWithCoder:(NSCoder *)aCoder {
     [super encodeWithCoder:aCoder];
     ORK_ENCODE_OBJ(aCoder, signature);
+    ORK_ENCODE_BOOL(aCoder, consented);
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
         ORK_DECODE_OBJ_CLASS(aDecoder, signature, ORKConsentSignature);
+        ORK_DECODE_BOOL(aDecoder, consented);
     }
     return self;
 }
@@ -685,6 +687,7 @@
 - (instancetype)copyWithZone:(NSZone *)zone {
     ORKConsentSignatureResult *result = [super copyWithZone:zone];
     result.signature = _signature;
+    result.consented = _consented;
     return result;
 }
 
@@ -693,7 +696,8 @@
     
     __typeof(self) castObject = object;
     return (isParentSame &&
-            ORKEqualObjects(self.signature, castObject.signature));
+            ORKEqualObjects(self.signature, castObject.signature) &&
+            (self.consented == castObject.consented));
 }
 
 - (NSUInteger)hash {

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -309,6 +309,7 @@ static NSString *const _FamilyNameIdentifier = @"family";
     ORKConsentSignatureResult *result = [[ORKConsentSignatureResult alloc] init];
     result.signature = _currentSignature;
     result.identifier = _currentSignature.identifier;
+    result.consented = _documentReviewed;
     result.startDate = parentResult.startDate;
     result.endDate = parentResult.endDate;
     parentResult.results = @[result];

--- a/Testing/ORKTest/ORKTest/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTest/ORKESerialization.m
@@ -892,8 +892,8 @@ ret =
    ENTRY(ORKConsentSignatureResult,
          nil,
          (@{
-            PROPERTY(signature, ORKConsentSignature, NSObject, NO, nil, nil),
-            PROPERTY(consented, NSNumber, NSObject, NO, nil, nil),
+            PROPERTY(signature, ORKConsentSignature, NSObject, YES, nil, nil),
+            PROPERTY(consented, NSNumber, NSObject, YES, nil, nil),
             })),
    ENTRY(ORKCollectionResult,
          nil,

--- a/Testing/ORKTest/ORKTest/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTest/ORKESerialization.m
@@ -892,7 +892,8 @@ ret =
    ENTRY(ORKConsentSignatureResult,
          nil,
          (@{
-            PROPERTY(signature, ORKConsentSignature, NSObject, NO, nil, nil)
+            PROPERTY(signature, ORKConsentSignature, NSObject, NO, nil, nil),
+            PROPERTY(consented, NSNumber, NSObject, NO, nil, nil),
             })),
    ENTRY(ORKCollectionResult,
          nil,


### PR DESCRIPTION
Adds a `consented` property to ORKConsentSignatureResult. This property
is true if the consent has been explicitly agreed by the user, and false
otherwise.

Added ORKESerializer support and verified unit tests pass.