### PR TITLE
Fix tests serializing NSURL

### DIFF
--- a/ResearchKit/Common/ORKHelpers.h
+++ b/ResearchKit/Common/ORKHelpers.h
@@ -175,6 +175,11 @@ ORKEqualObjects(id o1, id o2) {
     return (o1 == o2) || (o1 && o2 && [o1 isEqual:o2]);
 }
 
+ORK_INLINE BOOL
+ORKEqualURLs(NSURL *url1, NSURL *url2) {
+    return ORKEqualObjects(url1, url2) || ([url1 isFileURL] && [url2 isFileURL] && [[url1 absoluteString] isEqualToString:[url2 absoluteString]]);
+}
+
 ORK_INLINE NSArray *
 ORKArrayCopyObjects(NSArray *a) {
     if (!a) {

--- a/ResearchKit/Common/ORKResult.m
+++ b/ResearchKit/Common/ORKResult.m
@@ -540,7 +540,7 @@
     
     __typeof(self) castObject = object;
     return (isParentSame &&
-            ORKEqualObjects(self.fileURL, castObject.fileURL) &&
+            ORKEqualURLs(self.fileURL, castObject.fileURL) &&
             ORKEqualObjects(self.contentType, castObject.contentType));
 }
 
@@ -1371,7 +1371,7 @@
     __typeof(self) castObject = object;
     return (isParentSame &&
             ORKEqualObjects(self.taskRunUUID, castObject.taskRunUUID) &&
-            ORKEqualObjects(self.outputDirectory, castObject.outputDirectory));
+            ORKEqualURLs(self.outputDirectory, castObject.outputDirectory));
 }
 
 - (NSUInteger)hash {

--- a/ResearchKitTests/ORKResultTests.m
+++ b/ResearchKitTests/ORKResultTests.m
@@ -68,7 +68,7 @@
 - (void)compareTaskResult1:(ORKTaskResult *)taskResult1 andTaskResult2:(ORKTaskResult *)taskResult2 {
     // Compare
     XCTAssert([taskResult1.taskRunUUID isEqual:taskResult2.taskRunUUID], @"");
-    XCTAssert([taskResult1.outputDirectory isEqual:taskResult2.outputDirectory], @"");
+    XCTAssert([taskResult1.outputDirectory.absoluteString isEqual:taskResult2.outputDirectory.absoluteString], @"");
     XCTAssert([taskResult1.identifier isEqualToString:taskResult2.identifier], @"");
     
     XCTAssert(taskResult1!=taskResult2, @"");
@@ -107,7 +107,7 @@
                 ORKFileResult *f1 = (ORKFileResult *)result1;
                 ORKFileResult *f2 = (ORKFileResult *)result2;
                 
-                XCTAssert( [f1.fileURL isEqual:f2.fileURL], @"");
+                XCTAssert( [f1.fileURL.absoluteString isEqual:f2.fileURL.absoluteString], @"");
                 XCTAssert( [f1.contentType isEqualToString:f2.contentType], @"");
             } else if ([result1 isKindOfClass:[ORKConsentSignatureResult class]]) {
                 ORKConsentSignatureResult *c1 = (ORKConsentSignatureResult *)result1;


### PR DESCRIPTION
Fixes test failure introduced in #252, by comparing file URLs by
their absoluteString rather than a direct equality check.