### PR TITLE
Image Capture Step handling of file write error (Fix for #242)

### DIFF
--- a/ResearchKit/Common/ORKImageCaptureStepViewController.m
+++ b/ResearchKit/Common/ORKImageCaptureStepViewController.m
@@ -207,12 +207,23 @@
 }
 
 - (void)handleError:(NSError *)error {
-    // Tell the task view controller that we have failed so that it removes our result
-    STRONGTYPE(self.delegate) strongDelegate = self.delegate;
-    [strongDelegate stepViewControllerDidFail:self withError:error];
+    // Set the captured image data to nil before calling the delegate, as the call may result
+    // in an attempt to create a new result, which will in turn check the captured image data.
+    _capturedImageData = nil;
+    
+    // Shut everything down
+    [_captureSession stopRunning];
+    _captureSession = nil;
+    _stillImageOutput = nil;
+    _imageCaptureView.session = nil;
+    _imageCaptureView.capturedImage = nil;
     
     // Show the error in the image capture view
     _imageCaptureView.error = error;
+    
+    // Tell the task view controller that we have failed so that it removes our result
+    STRONGTYPE(self.delegate) strongDelegate = self.delegate;
+    [strongDelegate stepViewControllerDidFail:self withError:error];
 }
 
 - (void)setCapturedImageData:(NSData *)capturedImageData {


### PR DESCRIPTION
Experiencing an error will now completely shut down the image capture step, including removing the continue and skip buttons, and resulting in only error text shown in the view.

#242 