### PR TITLE
Improve Image Capture Step error handling (Fix for #242) based on PR #263

### DIFF
--- a/ResearchKit/Common/ORKImageCaptureStepViewController.m
+++ b/ResearchKit/Common/ORKImageCaptureStepViewController.m
@@ -207,12 +207,23 @@
 }
 
 - (void)handleError:(NSError *)error {
-    // Tell the task view controller that we have failed so that it removes our result
-    STRONGTYPE(self.delegate) strongDelegate = self.delegate;
-    [strongDelegate stepViewControllerDidFail:self withError:error];
+    // Set the captured image data to nil before calling the delegate, as the call may result
+    // in an attempt to create a new result, which will in turn check the captured image data.
+    _capturedImageData = nil;
+    
+    // Shut everything down
+    [_captureSession stopRunning];
+    _captureSession = nil;
+    _stillImageOutput = nil;
+    _imageCaptureView.session = nil;
+    _imageCaptureView.capturedImage = nil;
     
     // Show the error in the image capture view
     _imageCaptureView.error = error;
+    
+    // Tell the task view controller that we have failed so that it removes our result
+    STRONGTYPE(self.delegate) strongDelegate = self.delegate;
+    [strongDelegate stepViewControllerDidFail:self withError:error];
 }
 
 - (void)setCapturedImageData:(NSData *)capturedImageData {


### PR DESCRIPTION
Thanks @brucehappy, this PR is mostly based his PR #263 

With a few changes to address review comments in PR #263:
1. Recover button states when the error is cleared.
2. Improved error handling in (setContinueButtonItem:)
3. Fixed a bug in layout code

If current step is not optional, next button will be shown but disabled. Please a screenshot below.
![img_0258](https://cloud.githubusercontent.com/assets/11466704/8001530/790fce00-0b1b-11e5-989f-bafde604a692.PNG)
