### PR TITLE
In FormItemCell, lower a heightConstraint's priority 

### DIFF
--- a/ResearchKit/Common/ORKFormItemCell.m
+++ b/ResearchKit/Common/ORKFormItemCell.m
@@ -305,19 +305,19 @@ static const CGFloat kHMargin = 15.0;
     }
     
     CGFloat height = ORKGetMetricForScreenType(ORKScreenMetricTableCellDefaultHeight, self.screenType);
-        
-    [self.myConstraints addObject:[NSLayoutConstraint constraintWithItem:self.contentView
-                                                               attribute:NSLayoutAttributeHeight
-                                                               relatedBy:NSLayoutRelationGreaterThanOrEqual
-                                                                  toItem:nil
-                                                               attribute:NSLayoutAttributeNotAnAttribute
-                                                              multiplier:1 constant:height]];
     
-    
-    
+    NSLayoutConstraint* heightConstraint = [NSLayoutConstraint constraintWithItem:self.contentView
+                                                                         attribute:NSLayoutAttributeHeight
+                                                                         relatedBy:NSLayoutRelationGreaterThanOrEqual
+                                                                            toItem:nil
+                                                                         attribute:NSLayoutAttributeNotAnAttribute
+                                                                        multiplier:1
+                                                                          constant:height];
+    // Lower the priority to avoid conflicts with system supplied UIView-Encapsulated-Layout-Height constraint.
+    heightConstraint.priority = 999;
+    [self.myConstraints addObject:heightConstraint];
     
     [self.contentView addConstraints:self.myConstraints];
-    
     [super updateConstraints];
 }
 


### PR DESCRIPTION
 To avoid conflicts with system supplied UIView-Encapsulated-Layout-Height constraint.