### PR TITLE
Image Capture Step optional support

### DIFF
--- a/ResearchKit/Common/ORKImageCaptureStep.m
+++ b/ResearchKit/Common/ORKImageCaptureStep.m
@@ -41,6 +41,14 @@
     return [ORKImageCaptureStepViewController class];
 }
 
+- (instancetype)initWithIdentifier:(NSString *)identifier {
+    self = [super initWithIdentifier:identifier];
+    if (self) {
+        self.optional = YES;
+    }
+    return self;
+}
+
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {

--- a/ResearchKit/Common/ORKImageCaptureStepViewController.m
+++ b/ResearchKit/Common/ORKImageCaptureStepViewController.m
@@ -89,6 +89,11 @@
     _imageCaptureView.continueButtonItem = continueButtonItem;
 }
 
+- (void)setSkipButtonItem:(UIBarButtonItem *)skipButtonItem {
+    [super setSkipButtonItem:skipButtonItem];
+    _imageCaptureView.skipButtonItem = skipButtonItem;
+}
+
 - (void)retakePressed:(void (^ __nullable)())handler {
     // Start the capture session, and reset the captured image to nil
     dispatch_async(self.sessionQueue, ^{

--- a/ResearchKit/Common/ORKImageCaptureView.h
+++ b/ResearchKit/Common/ORKImageCaptureView.h
@@ -51,6 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, nullable) id<ORKImageCaptureViewDelegate> delegate;
 @property (nonatomic, weak, nullable) AVCaptureSession *session;
 @property (nonatomic, strong, nullable) UIBarButtonItem *continueButtonItem;
+@property (nonatomic, strong, nullable) UIBarButtonItem *skipButtonItem;
 @property (nonatomic, strong, nullable) UIImage *capturedImage;
 @property (nonatomic, strong, nullable) NSError *error;
 

--- a/ResearchKit/Common/ORKImageCaptureView.m
+++ b/ResearchKit/Common/ORKImageCaptureView.m
@@ -232,6 +232,15 @@ const CGFloat CONTINUE_ALPHA_OPAQUE = 0;
     }
 }
 
+- (void)setContinueButtonItem:(UIBarButtonItem *)continueButtonItem {
+    _continueButtonItem = continueButtonItem;
+    
+    // If the capture button is not currently being used as the continue button, then use this new button
+    if (_continueSkipContainer.continueButtonItem != _captureButtonItem) {
+        _continueSkipContainer.continueButtonItem = continueButtonItem;
+    }
+}
+
 - (void)capturePressed {
     // If we are still waiting for the delegate to complete, ignore futher presses
     if (_capturePressesIgnored)

--- a/ResearchKit/Common/ORKImageCaptureView.m
+++ b/ResearchKit/Common/ORKImageCaptureView.m
@@ -236,7 +236,7 @@ const CGFloat CONTINUE_ALPHA_OPAQUE = 0;
     _continueButtonItem = continueButtonItem;
     
     // If the capture button is not currently being used as the continue button, then use this new button
-    if (_continueSkipContainer.continueButtonItem != _captureButtonItem) {
+    if (!self.error && _continueSkipContainer.continueButtonItem != _captureButtonItem) {
         _continueSkipContainer.continueButtonItem = continueButtonItem;
     }
 }

--- a/ResearchKit/Common/ORKImageCaptureView.m
+++ b/ResearchKit/Common/ORKImageCaptureView.m
@@ -246,20 +246,14 @@ const CGFloat CONTINUE_ALPHA_OPAQUE = 0;
     if (_capturePressesIgnored)
         return;
     
-    // If we don't have an error to show, and we have not yet captured an image, then do so
-    if (!self.capturedImage && !self.error) {
-        // Ignore futher presses until the delegate completes
-        _capturePressesIgnored = YES;
+    // Ignore futher presses until the delegate completes
+    _capturePressesIgnored = YES;
         
-        // Capture the image via the delegate
-        [self.delegate capturePressed:^(BOOL captureSuccess){
-            // Stop ignoring presses
-            _capturePressesIgnored = NO;
-        }];
-    } else {
-        // Perform the action of the saved Continue button
-        [_continueButtonItem.target performSelector:_continueButtonItem.action withObject:_continueButtonItem afterDelay:0];
-    }
+    // Capture the image via the delegate
+    [self.delegate capturePressed:^(BOOL captureSuccess){
+        // Stop ignoring presses
+        _capturePressesIgnored = NO;
+    }];
 }
 
 - (void)retakePressed {

--- a/samples/ORKCatalog/ORKCatalog/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/TaskListRow.swift
@@ -631,6 +631,7 @@ enum TaskListRow: Int, Printable {
         steps += [instructionStep]
         
         let imageCaptureStep = ORKImageCaptureStep(identifier: Identifier.ImageCaptureStep.rawValue)
+        imageCaptureStep.optional = false
         
         imageCaptureStep.templateImage = UIImage(named: "hand_outline_big")!
         


### PR DESCRIPTION
This is a continuation of PR #263 taking into account @YuanZhu-apple 's PR #269.

Added support for optional to Image Capture Step.
Simplified the saving and using of continue and skip buttons.
Made the ORKCatalog use of Image Capture Step non-optional.

From PR #263:
Experiencing an error will now completely shut down the image capture step, including removing the continue and skip buttons, and resulting in only error text shown in the view.