### PR TITLE
ORKHTMLPDFWriter generates an extra empty page when useMetric is true

### DIFF
--- a/ResearchKit/Common/ORKHTMLPDFWriter.m
+++ b/ResearchKit/Common/ORKHTMLPDFWriter.m
@@ -37,8 +37,8 @@
 #define PPI 72
 #define ORKSizeMakeWithPPI(width, height) CGSizeMake(width * PPI, height * PPI)
 
-static const CGFloat A4Width = 8.26666667;
-static const CGFloat A4Height = 11.6916667;
+static const CGFloat A4Width = 8.27;
+static const CGFloat A4Height = 11.69;
 static const CGFloat LetterWidth = 8.5f;
 static const CGFloat LetterHeight = 11.0f;
 


### PR DESCRIPTION
When useMetric is true, ORKHTMLPDFWriter is going to generate an extra
empty page before the signature page. Gaining little more pixels can
omit this extra empty page.

I also upload two output pdf files for quick references. The files are generated via ORKCatalog. Please note the page 3 of 4 is empty in A4 size while useMetric is true.

Example Consent.pdf in letter size
https://db.tt/EAHt9dMT

Example Consent.pdf in A4 size
https://db.tt/WV7LuDmS