### PR TITLE
Fix: Initializing from a metatype must reference 'init' explicitly

### DIFF
--- a/samples/ORKCatalog/ORKCatalog/ResultTableViewProviders.swift
+++ b/samples/ORKCatalog/ORKCatalog/ResultTableViewProviders.swift
@@ -125,7 +125,7 @@ func resultTableViewProviderForResult(result: ORKResult?) -> protocol<UITableVie
     }
     
     // Return a new instance of the specific `ResultTableViewProvider`.
-    return providerType(result: result)
+    return providerType.init(result: result)
 }
 
 /**


### PR DESCRIPTION
Okay this one is finally a correct PR ;3

Fixes:
![swift](https://cloud.githubusercontent.com/assets/830748/8588929/76976694-2653-11e5-88f2-d00a6a02c4ab.png)
