### PR TITLE
Enhance argument validation for Predicate Step Navigation Rule

### DIFF
--- a/ResearchKit/Common/ORKHelpers.h
+++ b/ResearchKit/Common/ORKHelpers.h
@@ -251,3 +251,5 @@ ORKCGFloatNearlyEqualToFloat(CGFloat f1, CGFloat f2) {
 #define ORKDefineStringKey(x) static NSString *const x = @STRINGIFY(x)
 
 #define ORKThrowInvalidArgumentExceptionIfNil(argument)  if (!argument) { @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@#argument" can not be nil." userInfo:nil]; }
+
+void ORKValidateArrayForObjectsOfClass(NSArray *array, Class expectedObjectClass, NSString *exceptionReason);

--- a/ResearchKit/Common/ORKHelpers.m
+++ b/ResearchKit/Common/ORKHelpers.m
@@ -497,3 +497,16 @@ id ORKDynamicCast_(id x, Class objClass) {
 }
 
 const CGFloat ORKScrollToTopAnimationDuration = 0.2;
+
+void ORKValidateArrayForObjectsOfClass(NSArray *array, Class expectedObjectClass, NSString *exceptionReason) {
+    NSCParameterAssert(array);
+    NSCParameterAssert(expectedObjectClass);
+    NSCParameterAssert(exceptionReason);
+
+    for (id object in array) {
+        if (![object isKindOfClass:expectedObjectClass]) {
+            @throw [NSException exceptionWithName:NSGenericException reason:exceptionReason userInfo:nil];
+        }
+    }
+}
+

--- a/ResearchKit/Common/ORKStepNavigationRule.m
+++ b/ResearchKit/Common/ORKStepNavigationRule.m
@@ -107,6 +107,11 @@ NSString *const ORKNullStepIdentifier = @"org.researchkit.step.null";
         if (resultPredicatesCount != destinationStepIdentifiersCount) {
             @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"Each predicate in resultPredicates must have a destination step identifier in destinationStepIdentifiers" userInfo:nil];
         }
+        ORKValidateArrayForObjectsOfClass(resultPredicates, [NSPredicate class], @"resultPredicates objects must be of a NSPredicate class kind");
+        ORKValidateArrayForObjectsOfClass(destinationStepIdentifiers, [NSString class], @"destinationStepIdentifiers objects must be of a NSString class kind");
+        if (defaultStepIdentifier != nil && ![defaultStepIdentifier isKindOfClass:[NSString class]]) {
+            @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"defaultStepIdentifier must be of a NSString class kind or nil" userInfo:nil];
+        }
     }
     self = [super init_ork];
     if (self) {


### PR DESCRIPTION
A user was having trouble using `ORKPredicateStepNavigationRule` because she was passing an array of *steps* (instead of *step identifiers*) to the `destinationStepIdentifiers` argument. I added argument checking to make sure the objects in the arrays are of the correct class. Throws an exception if they aren't.

This PR also slightly rewrites `ORKTest`'s `ORKNavigableOrderedTask` example so it's easier to read.