### PR TITLE
Reduce continue button height on compact vertical size classes

### DIFF
--- a/ResearchKit/Common/ORKContinueButton.m
+++ b/ResearchKit/Common/ORKContinueButton.m
@@ -45,7 +45,7 @@ static const CGFloat kContinueButtonTouchMargin = 10;
     if (self) {
         [self setTitle:title forState:UIControlStateNormal];
         self.isDoneButton = isDoneButton;
-        self.contentEdgeInsets = (UIEdgeInsets){.left=6,.right=6};
+        self.contentEdgeInsets = (UIEdgeInsets){.left=6, .right=6};
         
         [self setNeedsUpdateConstraints];
     }
@@ -73,30 +73,27 @@ static const CGFloat kContinueButtonTouchMargin = 10;
 }
 
 - (void)updateConstraints {
-    if (! _heightConstraint) {
+    if (!_heightConstraint) {
         _heightConstraint = [NSLayoutConstraint constraintWithItem:self
                                                          attribute:NSLayoutAttributeHeight
                                                          relatedBy:NSLayoutRelationEqual
                                                             toItem:nil
                                                          attribute:NSLayoutAttributeNotAnAttribute
                                                         multiplier:1.0
-                                                          constant:0.0];
+                                                          constant:0.0]; // constant will be set in updateConstraintConstants
         _heightConstraint.active = YES;
     }
-    if (! _widthConstraint) {
+    if (!_widthConstraint) {
         _widthConstraint = [NSLayoutConstraint constraintWithItem:self
                                                         attribute:NSLayoutAttributeWidth
                                                         relatedBy:NSLayoutRelationGreaterThanOrEqual
                                                            toItem:nil
                                                         attribute:NSLayoutAttributeNotAnAttribute
                                                        multiplier:1.0
-                                                         constant:0.0];
+                                                         constant:0.0]; // constant will be set in updateConstraintConstants
+        _widthConstraint.active = YES;
     }
     [self updateConstraintConstants];
-    
-    _heightConstraint.active = YES;
-    _widthConstraint.active = YES;
-    
     [super updateConstraints];
 }
 

--- a/ResearchKit/Common/ORKContinueButton.m
+++ b/ResearchKit/Common/ORKContinueButton.m
@@ -56,10 +56,19 @@ static const CGFloat kContinueButtonTouchMargin = 10;
     [self updateConstraintConstants];
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+    [super traitCollectionDidChange: previousTraitCollection];
+    if (self.traitCollection.verticalSizeClass != previousTraitCollection.verticalSizeClass) {
+        [self updateConstraintConstants];
+    }
+}
+
 - (void)updateConstraintConstants {
-    
-    UIWindow *window = [self window];
-    ORKScreenType screenType = ORKGetScreenTypeForWindow(window);
+    ORKScreenType screenType = ORKGetScreenTypeForWindow(self.window);
+    CGFloat height = (self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassCompact) ?
+        ORKGetMetricForScreenType(ORKScreenMetricContinueButtonHeightCompact, screenType) :
+        ORKGetMetricForScreenType(ORKScreenMetricContinueButtonHeightRegular, screenType);
+    _heightConstraint.constant = height;
     _widthConstraint.constant = ORKGetMetricForScreenType(ORKScreenMetricContinueButtonWidth, screenType);
 }
 
@@ -70,21 +79,21 @@ static const CGFloat kContinueButtonTouchMargin = 10;
                                                          relatedBy:NSLayoutRelationEqual
                                                             toItem:nil
                                                          attribute:NSLayoutAttributeNotAnAttribute
-                                                        multiplier:1
-                                                          constant:44];
+                                                        multiplier:1.0
+                                                          constant:0.0];
         _heightConstraint.active = YES;
     }
     if (! _widthConstraint) {
-        UIWindow *window = [self window];
-        ORKScreenType screenType = ORKGetScreenTypeForWindow(window);
         _widthConstraint = [NSLayoutConstraint constraintWithItem:self
                                                         attribute:NSLayoutAttributeWidth
                                                         relatedBy:NSLayoutRelationGreaterThanOrEqual
                                                            toItem:nil
                                                         attribute:NSLayoutAttributeNotAnAttribute
-                                                       multiplier:1
-                                                         constant:ORKGetMetricForScreenType(ORKScreenMetricContinueButtonWidth, screenType)];
+                                                       multiplier:1.0
+                                                         constant:0.0];
     }
+    [self updateConstraintConstants];
+    
     _heightConstraint.active = YES;
     _widthConstraint.active = YES;
     

--- a/ResearchKit/Common/ORKSkin.h
+++ b/ResearchKit/Common/ORKSkin.h
@@ -93,6 +93,8 @@ typedef NS_ENUM(NSInteger, ORKScreenMetric) {
     ORKScreenMetricIllustrationToCaptionBaseline,
     ORKScreenMetricIllustrationHeight,
     ORKScreenMetricInstructionImageHeight,
+    ORKScreenMetricContinueButtonHeightRegular,
+    ORKScreenMetricContinueButtonHeightCompact,
     ORKScreenMetricContinueButtonWidth,
     ORKScreenMetricMinimumStepHeaderHeightForMemoryGame,
     ORKScreenMetricTableCellDefaultHeight,

--- a/ResearchKit/Common/ORKSkin.m
+++ b/ResearchKit/Common/ORKSkin.m
@@ -151,6 +151,8 @@ CGFloat ORKGetMetricForScreenType(ORKScreenMetric metric, ORKScreenType screenTy
         {         44,        44,        40,        40,        44},      // ORKScreenMetricIllustrationToCaptionBaseline
         {        198,       198,       194,       152,       297},      // ORKScreenMetricIllustrationHeight
         {        300,       300,       176,       152,       300},      // ORKScreenMetricInstructionImageHeight
+        {         44,        44,        44,        44,        44},      // ORKScreenMetricContinueButtonHeightRegular
+        {         44,        32,        32,        32,        44},      // ORKScreenMetricContinueButtonHeightCompact
         {        150,       150,       146,       146,       150},      // ORKScreenMetricContinueButtonWidth
         {        162,       162,       120,       116,       240},      // ORKScreenMetricMinimumStepHeaderHeightForMemoryGame
         {         60,        60,        60,        44,        60},      // ORKScreenMetricTableCellDefaultHeight


### PR DESCRIPTION
This reduces `ORKContinueButton`'s *height* from `44` to `32` points on the *compact vertical size class* on all *iPhone* devices except on the *iPhone 6 Plus* ([Issue #231](https://github.com/ResearchKit/ResearchKit/issues/231)).

This is the same behavior and metrics as `UINavigationBar`.