### PR TITLE
Fix small typos (deleagte -> delegate)

### DIFF
--- a/ResearchKit/ActiveTasks/ORKTouchRecorder.m
+++ b/ResearchKit/ActiveTasks/ORKTouchRecorder.m
@@ -80,7 +80,7 @@
 
 @interface ORKTouchRecordingView : UIView
 
-@property (nonatomic, weak) id<ORKTouchRecordingDelegate> deleagte;
+@property (nonatomic, weak) id<ORKTouchRecordingDelegate> delegate;
 
 @end
 

--- a/ResearchKit/Common/ORKTaskViewController.h
+++ b/ResearchKit/Common/ORKTaskViewController.h
@@ -303,7 +303,7 @@ ORK_CLASS_AVAILABLE
  @param task        The task to be presented.
  @param data        Data obtained from the `restorationData` property of a previous
                     task view controller instance.
- @param delegate    The deleagte for the task view controller.
+ @param delegate    The delegate for the task view controller.
  
  @return A new task view controller.
  */


### PR DESCRIPTION
Fixes two small typos (`deleagte` -> `delegate`).