### PR TITLE
Fixed bug in ORKNumericAnswerFormat so the value shown is the full decimal

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1169,6 +1169,7 @@ static NSArray *ork_processTextChoices(NSArray *textChoices) {
 - (NSNumberFormatter *)makeNumberFormatter {
     NSNumberFormatter *numberFormatter = [NSNumberFormatter new];
     numberFormatter.numberStyle = NSNumberFormatterDecimalStyle;
+    numberFormatter.maximumFractionDigits = NSDecimalNoScale;
     numberFormatter.usesGroupingSeparator = NO;
     return numberFormatter;
 }


### PR DESCRIPTION
**Fixed this bug for Decimal Number:**
1. Input: "20.000123"
2. Tap next, then go back
3. Then saved answer is 20 instead of 20.000123