### PR TITLE
Fix small Tower of Hanoi issues

### DIFF
--- a/ResearchKit/ActiveTasks/ORKTowerOfHanoiTowerView.m
+++ b/ResearchKit/ActiveTasks/ORKTowerOfHanoiTowerView.m
@@ -167,6 +167,10 @@ static const CGFloat kBaseSpacing = 10;
     [super updateConstraints];
 }
 
+- (void)tintColorDidChange {
+    [self reloadData];
+}
+
 #pragma Mark -- Public
 
 - (void)reloadData {

--- a/ResearchKit/Common/ORKResult.m
+++ b/ResearchKit/Common/ORKResult.m
@@ -185,7 +185,7 @@
 - (id)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
-        ORK_DECODE_OBJ(aDecoder, moves);
+        ORK_DECODE_OBJ_ARRAY(aDecoder, moves, ORKTowerOfHanoiMove);
         ORK_DECODE_BOOL(aDecoder, puzzleWasSolved);
     }
     return self;


### PR DESCRIPTION
This fixes two small Tower of Hanoi issues:
- ORKTest serialization unit test was failing due improper `NSArray` unarchiving.
- The discs were not honoring the `tintColor` on first display ([Issue #349](https://github.com/ResearchKit/ResearchKit/issues/349)).