### PR TITLE
Generic ORKSide constants.

### DIFF
--- a/ResearchKit/ActiveTasks/ORKAudioGenerator.h
+++ b/ResearchKit/ActiveTasks/ORKAudioGenerator.h
@@ -80,7 +80,7 @@ ORK_CLASS_AVAILABLE
  @param duration The fade-in duration.
  */
 - (void)playSoundAtFrequency:(double)frequency
-                   onChannel:(ORKAudioChannel)channel
+                   onChannel:(ORKSide)channel
               fadeInDuration:(NSTimeInterval)duration;
 
 /**

--- a/ResearchKit/ActiveTasks/ORKAudioGenerator.m
+++ b/ResearchKit/ActiveTasks/ORKAudioGenerator.m
@@ -60,7 +60,7 @@
 @public
     double _frequency;
     double _theta;
-    ORKAudioChannel _activeChannel;
+    ORKSide _activeChannel;
     BOOL _playsStereo;
     double _fadeInFactor;
     NSTimeInterval _fadeInDuration;
@@ -179,7 +179,7 @@ OSStatus ORKAudioGeneratorRenderTone(void *inRefCon,
 }
 
 - (void)playSoundAtFrequency:(double)playFrequency
-                   onChannel:(ORKAudioChannel)playChannel
+                   onChannel:(ORKSide)playChannel
               fadeInDuration:(NSTimeInterval)duration {
     _frequency = playFrequency;
     _activeChannel = playChannel;

--- a/ResearchKit/ActiveTasks/ORKToneAudiometryStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKToneAudiometryStepViewController.m
@@ -160,7 +160,7 @@
     NSUInteger frequencyIndex = (self.currentTestIndex / 2);
     NSNumber *frequency = self.testingFrequencies[frequencyIndex];
     sample.frequency = frequency;
-    sample.channel = ((self.currentTestIndex % 2) == 0) ? ORKAudioChannelLeft : ORKAudioChannelRight;
+    sample.channel = ((self.currentTestIndex % 2) == 0) ? ORKSideLeft : ORKSideRight;
     sample.amplitude = @(self.audioGenerator.volumeAmplitude);
 
     [self.samples addObject:sample];
@@ -198,11 +198,11 @@
     NSAssert(frequencyIndex < self.testingFrequencies.count, nil);
 
     NSNumber *frequency = self.testingFrequencies[frequencyIndex];
-    ORKAudioChannel channel = ((testIndex % 2) == 0) ? ORKAudioChannelLeft : ORKAudioChannelRight;
+    ORKSide channel = ((testIndex % 2) == 0) ? ORKSideLeft : ORKSideRight;
 
     CGFloat progress = 0.001 + (CGFloat)testIndex / (self.testingFrequencies.count * 2);
     [self.toneAudiometryContentView setProgress:progress
-                                        caption:(channel == ORKAudioChannelLeft) ? [NSString stringWithFormat:ORKLocalizedString(@"TONE_LABEL_%@_LEFT", nil), ORKLocalizedStringFromNumber(frequency)] : [NSString stringWithFormat:ORKLocalizedString(@"TONE_LABEL_%@_RIGHT", nil), ORKLocalizedStringFromNumber(frequency)]
+                                        caption:(channel == ORKSideLeft) ? [NSString stringWithFormat:ORKLocalizedString(@"TONE_LABEL_%@_LEFT", nil), ORKLocalizedStringFromNumber(frequency)] : [NSString stringWithFormat:ORKLocalizedString(@"TONE_LABEL_%@_RIGHT", nil), ORKLocalizedStringFromNumber(frequency)]
                                        animated:YES];
 
     [self.audioGenerator playSoundAtFrequency:frequency.doubleValue

--- a/ResearchKit/Common/ORKDefines.h
+++ b/ResearchKit/Common/ORKDefines.h
@@ -93,13 +93,13 @@ typedef NS_ENUM(NSInteger, ORKFileProtectionMode) {
 
 
 /**
- Audio channel constants.
+ Body side constants.
  */
-typedef NS_ENUM(NSInteger, ORKAudioChannel) {
-    /// The left audio channel.
-    ORKAudioChannelLeft,
+typedef NS_ENUM(NSInteger, ORKSide) {
+    /// The left side.
+    ORKSideLeft,
     
-    /// The right audio channel.
-    ORKAudioChannelRight
+    /// The right side.
+    ORKSideRight
 } ORK_ENUM_AVAILABLE;
 

--- a/ResearchKit/Common/ORKResult.h
+++ b/ResearchKit/Common/ORKResult.h
@@ -363,7 +363,7 @@ ORK_CLASS_AVAILABLE
 
  The channel, either left or right, for the tone associated to this sample.
  */
-@property (nonatomic, assign) ORKAudioChannel channel;
+@property (nonatomic, assign) ORKSide channel;
 
 /**
  The audio signal amplitude.

--- a/samples/ORKCatalog/ORKCatalog/ResultTableViewProviders.swift
+++ b/samples/ORKCatalog/ORKCatalog/ResultTableViewProviders.swift
@@ -556,7 +556,7 @@ class ToneAudiometryResultTableViewProvider: ResultTableViewProvider {
 
             if let frequency = toneSample.frequency,
                 amplitude = toneSample.amplitude {
-                    let channelName = toneSample.channel == ORKAudioChannel.Left ? "Left" : "Right"
+                    let channelName = toneSample.channel == ORKSide.Left ? "Left" : "Right"
 
                     text = "\(frequency) \(channelName)"
                     detail = "\(amplitude)"


### PR DESCRIPTION
The Audiometry task uses ORKAudioChannel constants (Left/Right).
I moved to more generic values ORKSide.
Unfortunately, HealthKit does not provide such constants yet.