### PR TITLE
iOS9 iPad split view support

### DIFF
--- a/ResearchKit/ActiveTasks/ORKFitnessContentView.m
+++ b/ResearchKit/ActiveTasks/ORKFitnessContentView.m
@@ -139,7 +139,7 @@
 
 - (void)willMoveToWindow:(UIWindow *)newWindow {
     [super willMoveToWindow:newWindow];
-    _screenType = ORKGetScreenTypeForWindow(newWindow);
+    _screenType = ORKGetVerticalScreenTypeForWindow(newWindow);
     [self updateConstraintConstants];
 }
 

--- a/ResearchKit/ActiveTasks/ORKSpatialSpanMemoryContentView.m
+++ b/ResearchKit/ActiveTasks/ORKSpatialSpanMemoryContentView.m
@@ -260,7 +260,8 @@
 
 
 - (void)updateMargins {
-    self.layoutMargins = (UIEdgeInsets){.left=ORKStandardHorizMarginForView(self), .right=ORKStandardHorizMarginForView(self)};
+    CGFloat margin = ORKStandardHorizMarginForView(self);
+    self.layoutMargins = (UIEdgeInsets){.left = margin, .right = margin};
     _quantityPairView.layoutMargins = self.layoutMargins;
 }
 

--- a/ResearchKit/ActiveTasks/ORKTappingContentView.m
+++ b/ResearchKit/ActiveTasks/ORKTappingContentView.m
@@ -147,7 +147,7 @@
 
 - (void)willMoveToWindow:(UIWindow *)newWindow {
     [super willMoveToWindow:newWindow];
-    _screenType = ORKGetScreenTypeForWindow(newWindow);
+    _screenType = ORKGetVerticalScreenTypeForWindow(newWindow);
     [self setNeedsUpdateConstraints];
 }
 

--- a/ResearchKit/ActiveTasks/ORKToneAudiometryContentView.m
+++ b/ResearchKit/ActiveTasks/ORKToneAudiometryContentView.m
@@ -51,7 +51,7 @@
     self = [super init];
     if (self) {
 
-        _screenType = ORKGetScreenTypeForWindow(self.window);
+        _screenType = ORKGetVerticalScreenTypeForWindow(self.window);
         _captionLabel = [ORKUnitLabel new];
         _captionLabel.textAlignment = NSTextAlignmentCenter;
         _captionLabel.translatesAutoresizingMaskIntoConstraints = NO;

--- a/ResearchKit/ActiveTasks/ORKWalkingTaskStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKWalkingTaskStepViewController.m
@@ -198,7 +198,7 @@ static const CGFloat kProgressCircleSpacing = 4;
 
 - (void)willMoveToWindow:(UIWindow *)newWindow {
     [super willMoveToWindow:newWindow];
-    _screenType = ORKGetScreenTypeForWindow(newWindow);
+    _screenType = ORKGetVerticalScreenTypeForWindow(newWindow);
     [self updateConstraintConstants];
 }
 

--- a/ResearchKit/Common/ORKChoiceViewCell.m
+++ b/ResearchKit/Common/ORKChoiceViewCell.m
@@ -55,7 +55,7 @@ static const CGFloat kLabelRightMargin = 44.0;
 - (void)layoutSubviews {
     [super layoutSubviews];
     
-    ORKScreenType screenType = ORKGetScreenTypeForWindow(self.window);
+    ORKScreenType screenType = ORKGetVerticalScreenTypeForWindow(self.window);
     
     CGFloat firstBaselineOffsetFromTop = ORKGetMetricForScreenType(ORKScreenMetricChoiceCellFirstBaselineOffsetFromTop, screenType);
     CGFloat labelLastBaselineToLabelFirstBaseline = ORKGetMetricForScreenType(ORKScreenMetricChoiceCellLabelLastBaselineToLabelFirstBaseline, screenType);
@@ -153,7 +153,7 @@ static const CGFloat kLabelRightMargin = 44.0;
 + (CGFloat)suggestedCellHeightForShortText:(NSString *)shortText LongText:(NSString *)longText inTableView:(UITableView *)tableView {
     CGFloat height = 0;
     
-    ORKScreenType screenType = ORKGetScreenTypeForWindow(tableView.window);
+    ORKScreenType screenType = ORKGetVerticalScreenTypeForWindow(tableView.window);
     CGFloat firstBaselineOffsetFromTop = ORKGetMetricForScreenType(ORKScreenMetricChoiceCellFirstBaselineOffsetFromTop, screenType);
     CGFloat labelLastBaselineToLabelFirstBaseline = ORKGetMetricForScreenType(ORKScreenMetricChoiceCellLabelLastBaselineToLabelFirstBaseline, screenType);
     CGFloat lastBaselineToBottom = ORKGetMetricForScreenType(ORKScreenMetricChoiceCellLastBaselineToBottom, screenType);

--- a/ResearchKit/Common/ORKContinueButton.m
+++ b/ResearchKit/Common/ORKContinueButton.m
@@ -64,12 +64,13 @@ static const CGFloat kContinueButtonTouchMargin = 10;
 }
 
 - (void)updateConstraintConstants {
-    ORKScreenType screenType = ORKGetScreenTypeForWindow(self.window);
+    ORKScreenType verticalScreenType = ORKGetVerticalScreenTypeForWindow(self.window);
     CGFloat height = (self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassCompact) ?
-        ORKGetMetricForScreenType(ORKScreenMetricContinueButtonHeightCompact, screenType) :
-        ORKGetMetricForScreenType(ORKScreenMetricContinueButtonHeightRegular, screenType);
+        ORKGetMetricForScreenType(ORKScreenMetricContinueButtonHeightCompact, verticalScreenType) :
+        ORKGetMetricForScreenType(ORKScreenMetricContinueButtonHeightRegular, verticalScreenType);
     _heightConstraint.constant = height;
-    _widthConstraint.constant = ORKGetMetricForScreenType(ORKScreenMetricContinueButtonWidth, screenType);
+    
+    _widthConstraint.constant = ORKGetMetricForWindow(ORKScreenMetricContinueButtonWidth, self.window);
 }
 
 - (void)updateConstraints {

--- a/ResearchKit/Common/ORKFormItemCell.m
+++ b/ResearchKit/Common/ORKFormItemCell.m
@@ -275,7 +275,7 @@ static const CGFloat kHMargin = 15.0;
     
     self.myConstraints = [NSMutableArray new];
     
-    if ((labelMinWidth) >= 0.6*boundWidth) {
+    if ((labelMinWidth) >= 0.5*boundWidth) {
 
         [self.myConstraints addObjectsFromArray:
          [NSLayoutConstraint constraintsWithVisualFormat:@"H:|-hMargin-[labelLabel]-hMargin-|" options:NSLayoutFormatDirectionLeadingToTrailing metrics:metrics views:dictionary]];

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -434,7 +434,7 @@
         _tableView.dataSource = self;
         _tableView.rowHeight = UITableViewAutomaticDimension;
         _tableView.sectionHeaderHeight = UITableViewAutomaticDimension;
-        ORKScreenType screenType = ORKGetScreenTypeForWindow(self.view.window);
+        ORKScreenType screenType = ORKGetVerticalScreenTypeForWindow(self.view.window);
         _tableView.estimatedRowHeight = ORKGetMetricForScreenType(ORKScreenMetricTableCellDefaultHeight, screenType);
         _tableView.estimatedSectionHeaderHeight = 30.0;
         
@@ -742,7 +742,7 @@
                         NSAssert(NO, @"SHOULD NOT FALL IN HERE");
                     } else {
                         ORKFormItemCell *formCell = nil;
-                        formCell = [[class alloc] initWithReuseIdentifier:identifier formItem:formItem answer:answer maxLabelWidth:section.maxLabelWidth screenType:ORKGetScreenTypeForWindow(self.view.window)];
+                        formCell = [[class alloc] initWithReuseIdentifier:identifier formItem:formItem answer:answer maxLabelWidth:section.maxLabelWidth screenType:ORKGetVerticalScreenTypeForWindow(self.view.window)];
                         [_formItemCells addObject:formCell];
                         [formCell setExpectedLayoutWidth:self.tableView.bounds.size.width];
                         formCell.delegate  = self;
@@ -947,7 +947,6 @@ static NSString *const _ORKSavedSystemTimeZonesRestoreKey = @"savedSystemTimeZon
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
-    
     for (ORKFormItemCell *cell in _formItemCells) {
         [cell setExpectedLayoutWidth:size.width];
     }

--- a/ResearchKit/Common/ORKHeadlineLabel.m
+++ b/ResearchKit/Common/ORKHeadlineLabel.m
@@ -41,7 +41,7 @@
     const CGFloat defaultHeadlineSize = 17;
     
     UIWindow *window = [[[UIApplication sharedApplication] windows] firstObject];
-    ORKScreenType screenType = ORKGetScreenTypeForWindow(window);
+    ORKScreenType screenType = ORKGetVerticalScreenTypeForWindow(window);
     
     CGFloat fontSize = [[descriptor objectForKey: UIFontDescriptorSizeAttribute] doubleValue] - defaultHeadlineSize + ORKGetMetricForScreenType(surveyMode?ORKScreenMetricFontSizeSurveyHeadline: ORKScreenMetricFontSizeHeadline, screenType);
     CGFloat maxFontSize = ORKGetMetricForScreenType(surveyMode?ORKScreenMetricMaxFontSizeSurveyHeadline:ORKScreenMetricMaxFontSizeHeadline, screenType);

--- a/ResearchKit/Common/ORKInstructionStepView.m
+++ b/ResearchKit/Common/ORKInstructionStepView.m
@@ -133,7 +133,7 @@
 - (void)updateConstraintConstants {
     [super updateConstraintConstants];
     
-    ORKScreenType screenType = self.screenType;
+    ORKScreenType screenType = self.verticalScreenType;
     const CGFloat IllustrationHeight = ORKGetMetricForScreenType(ORKScreenMetricInstructionImageHeight, screenType);
     
     {

--- a/ResearchKit/Common/ORKSkin.h
+++ b/ResearchKit/Common/ORKSkin.h
@@ -120,7 +120,8 @@ typedef NS_ENUM(NSInteger, ORKScreenType) {
     ORKScreenType_COUNT
 };
 
-ORKScreenType ORKGetScreenTypeForWindow(UIWindow *__nullable window);
+ORKScreenType ORKGetVerticalScreenTypeForWindow(UIWindow *__nullable window);
+ORKScreenType ORKGetHorizontalScreenTypeForWindow(UIWindow *__nullable window);
 CGFloat ORKGetMetricForScreenType(ORKScreenMetric metric, ORKScreenType screenType);
 CGFloat ORKGetMetricForWindow(ORKScreenMetric metric, UIWindow *__nullable window);
 

--- a/ResearchKit/Common/ORKSkin.m
+++ b/ResearchKit/Common/ORKSkin.m
@@ -96,7 +96,7 @@ const CGSize ORKiPhone6ScreenSize = (CGSize){375, 667};
 const CGSize ORKiPhone6PlusScreenSize = (CGSize){414, 736};
 const CGSize ORKiPadScreenSize = (CGSize){768, 1024};
 
-ORKScreenType ORKGetScreenTypeForBounds(CGRect bounds) {
+ORKScreenType ORKGetVerticalScreenTypeForBounds(CGRect bounds) {
     ORKScreenType screenType = ORKScreenTypeiPhone6;
     CGFloat maximumDimension = MAX(bounds.size.width, bounds.size.height);
     if (maximumDimension < ORKiPhone4ScreenSize.height + 1) {
@@ -113,20 +113,47 @@ ORKScreenType ORKGetScreenTypeForBounds(CGRect bounds) {
     return screenType;
 }
 
-ORKScreenType ORKGetScreenTypeForWindow(UIWindow *window) {
+ORKScreenType ORKGetHorizontalScreenTypeForBounds(CGRect bounds) {
+    ORKScreenType screenType = ORKScreenTypeiPhone6;
+    CGFloat minimumDimension = MIN(bounds.size.width, bounds.size.height);
+    if (minimumDimension < ORKiPhone4ScreenSize.width + 1) {
+        screenType = ORKScreenTypeiPhone4;
+    } else if (minimumDimension < ORKiPhone5ScreenSize.width + 1) {
+        screenType = ORKScreenTypeiPhone5;
+    } else if (minimumDimension < ORKiPhone6ScreenSize.width + 1) {
+        screenType = ORKScreenTypeiPhone6;
+    } else if (minimumDimension < ORKiPhone6PlusScreenSize.width + 1) {
+        screenType = ORKScreenTypeiPhone6Plus;
+    } else {
+        screenType = ORKScreenTypeiPad;
+    }
+    return screenType;
+}
+
+ORKScreenType ORKGetVerticalScreenTypeForWindow(UIWindow *window) {
     if (!window) {
         window = [[[UIApplication sharedApplication] windows] firstObject];
     }
-    return ORKGetScreenTypeForBounds([window bounds]);
+    return ORKGetVerticalScreenTypeForBounds([window bounds]);
 }
+
+ORKScreenType ORKGetHorizontalScreenTypeForWindow(UIWindow *window) {
+    if (!window) {
+        window = [[[UIApplication sharedApplication] windows] firstObject];
+    }
+    return ORKGetHorizontalScreenTypeForBounds([window bounds]);
+}
+
 
 ORKScreenType ORKGetScreenTypeForScreen(UIScreen *screen) {
     ORKScreenType screenType = ORKScreenTypeiPhone6;
     if (screen == [UIScreen mainScreen]) {
-        screenType = ORKGetScreenTypeForBounds([screen bounds]);
+        screenType = ORKGetVerticalScreenTypeForBounds([screen bounds]);
     }
     return screenType;
 }
+
+
 
 const CGFloat ORKScreenMetricMaxDimension = 10000.0;
 
@@ -171,7 +198,22 @@ CGFloat ORKGetMetricForScreenType(ORKScreenMetric metric, ORKScreenType screenTy
 }
 
 CGFloat ORKGetMetricForWindow(ORKScreenMetric metric, UIWindow *window) {
-    return ORKGetMetricForScreenType(metric, ORKGetScreenTypeForWindow(window));
+    
+    CGFloat ret = 0;
+    switch (metric) {
+        case ORKScreenMetricContinueButtonWidth:
+        case ORKScreenMetricHeadlineSideMargin:
+        case ORKScreenMetricLearnMoreButtonSideMargin:
+        case ORKScreenMetricTopToIllustration:
+            ret = ORKGetMetricForScreenType(metric, ORKGetHorizontalScreenTypeForWindow(window));
+            break;
+            
+        default:
+            ret = ORKGetMetricForScreenType(metric, ORKGetVerticalScreenTypeForWindow(window));
+            break;
+    }
+    
+    return ret;
 }
 
 const CGFloat ORKLayoutMarginWidthRegularBezel = 15.0;
@@ -180,7 +222,7 @@ const CGFloat ORKLayoutMarginWidthiPad = 115.0;
 
 CGFloat ORKStandardLeftMarginForTableViewCell(UITableViewCell *cell) {
     CGFloat margin = 0;
-    switch (ORKGetScreenTypeForWindow(cell.window)) {
+    switch (ORKGetHorizontalScreenTypeForWindow(cell.window)) {
         case ORKScreenTypeiPhone4:
         case ORKScreenTypeiPhone5:
         case ORKScreenTypeiPhone6:
@@ -197,7 +239,7 @@ CGFloat ORKStandardLeftMarginForTableViewCell(UITableViewCell *cell) {
 
 CGFloat ORKStandardHorizMarginForView(UIView *view) {
     CGFloat margin = 0;
-    switch (ORKGetScreenTypeForWindow(view.window)) {
+    switch (ORKGetHorizontalScreenTypeForWindow(view.window)) {
         case ORKScreenTypeiPhone4:
         case ORKScreenTypeiPhone5:
         case ORKScreenTypeiPhone6:
@@ -205,10 +247,17 @@ CGFloat ORKStandardHorizMarginForView(UIView *view) {
         default:
             margin = ORKStandardLeftMarginForTableViewCell(view);
             break;
-        case ORKScreenTypeiPad:
-            margin = ORKLayoutMarginWidthiPad;
+        case ORKScreenTypeiPad:{
+            // Use adaptive side margin, if view is wider than iPhone6 Plus.
+            // Min Marign = ORKLayoutMarginWidthThinBezelRegular, Max Marign = ORKLayoutMarginWidthiPad
+            CGFloat ratio =  (view.bounds.size.width - ORKiPhone6PlusScreenSize.width)/(ORKiPadScreenSize.width - ORKiPhone6PlusScreenSize.width);
+            ratio = MIN(1.0, ratio);
+            ratio = MAX(0.0, ratio);
+            margin = ORKLayoutMarginWidthThinBezelRegular + (ORKLayoutMarginWidthiPad - ORKLayoutMarginWidthThinBezelRegular)*ratio;
             break;
+        }
     }
+    NSLog(@"margin = %@ [%@]", @(margin), @(view.bounds.size.width));
     return margin;
 }
 
@@ -221,18 +270,20 @@ UIEdgeInsets ORKStandardLayoutMarginsForTableViewCell(UITableViewCell *cell) {
 
 UIEdgeInsets ORKStandardFullScreenLayoutMarginsForView(UIView *view) {
     UIEdgeInsets layoutMargins = UIEdgeInsetsZero;
-    ORKScreenType screenType = ORKGetScreenTypeForWindow(view.window);
+    ORKScreenType screenType = ORKGetHorizontalScreenTypeForWindow(view.window);
     if (screenType == ORKScreenTypeiPad) {
-        layoutMargins = (UIEdgeInsets){.left=ORKStandardHorizMarginForView(view), .right=ORKStandardHorizMarginForView(view)};
+        CGFloat margin = ORKStandardHorizMarginForView(view);
+        layoutMargins = (UIEdgeInsets){.left = margin, .right = margin };
     }
     return layoutMargins;
 }
 
 UIEdgeInsets ORKScrollIndicatorInsetsForScrollView(UIView *view) {
     UIEdgeInsets scrollIndicatorInsets = UIEdgeInsetsZero;
-    ORKScreenType screenType = ORKGetScreenTypeForWindow(view.window);
+    ORKScreenType screenType = ORKGetHorizontalScreenTypeForWindow(view.window);
     if (screenType == ORKScreenTypeiPad) {
-        scrollIndicatorInsets = (UIEdgeInsets){.left=-ORKStandardHorizMarginForView(view), .right=-ORKStandardHorizMarginForView(view)};
+        CGFloat margin = ORKStandardHorizMarginForView(view);
+        scrollIndicatorInsets = (UIEdgeInsets){.left = -margin, .right = -margin };
     }
     return scrollIndicatorInsets;
 }

--- a/ResearchKit/Common/ORKSkin.m
+++ b/ResearchKit/Common/ORKSkin.m
@@ -257,7 +257,7 @@ CGFloat ORKStandardHorizMarginForView(UIView *view) {
             break;
         }
     }
-    NSLog(@"margin = %@ [%@]", @(margin), @(view.bounds.size.width));
+
     return margin;
 }
 

--- a/ResearchKit/Common/ORKSkin.m
+++ b/ResearchKit/Common/ORKSkin.m
@@ -204,7 +204,6 @@ CGFloat ORKGetMetricForWindow(ORKScreenMetric metric, UIWindow *window) {
         case ORKScreenMetricContinueButtonWidth:
         case ORKScreenMetricHeadlineSideMargin:
         case ORKScreenMetricLearnMoreButtonSideMargin:
-        case ORKScreenMetricTopToIllustration:
             ret = ORKGetMetricForScreenType(metric, ORKGetHorizontalScreenTypeForWindow(window));
             break;
             

--- a/ResearchKit/Common/ORKStepHeaderView.m
+++ b/ResearchKit/Common/ORKStepHeaderView.m
@@ -85,7 +85,7 @@ static const CGFloat AssumedStatusBarHeight = 20;
 - (instancetype)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
-        _screenType = ORKGetScreenTypeForWindow(nil);
+        _screenType = ORKGetVerticalScreenTypeForWindow(nil);
         // Text Label
         {
             _captionLabel = [ORKHeadlineLabel new];
@@ -136,7 +136,7 @@ static const CGFloat AssumedStatusBarHeight = 20;
 
 - (void)willMoveToWindow:(UIWindow *)newWindow {
     [super willMoveToWindow:newWindow];
-    _screenType = ORKGetScreenTypeForWindow(newWindow);
+    _screenType = ORKGetVerticalScreenTypeForWindow(newWindow);
     [self updateConstraintConstants];
     [self updateCaptionLabelPreferredWidth];
 }
@@ -160,8 +160,7 @@ static const CGFloat AssumedStatusBarHeight = 20;
     CGRect bounds = self.bounds;
     CGRect insetBounds = UIEdgeInsetsInsetRect(bounds, self.layoutMargins);
     
-    ORKScreenType screenType = ORKGetScreenTypeForWindow(self.window);
-    CGFloat sideMargin = ORKGetMetricForScreenType(ORKScreenMetricLearnMoreButtonSideMargin, screenType);
+    CGFloat sideMargin = ORKGetMetricForWindow(ORKScreenMetricLearnMoreButtonSideMargin, self.window);
     _learnMoreButton.titleLabel.preferredMaxLayoutWidth = insetBounds.size.width - sideMargin*2;
 }
 

--- a/ResearchKit/Common/ORKSubheadlineLabel.m
+++ b/ResearchKit/Common/ORKSubheadlineLabel.m
@@ -37,7 +37,7 @@
 
 + (UIFont *)defaultFont {
     UIWindow *window = [[[UIApplication sharedApplication] windows] firstObject];
-    ORKScreenType screenType = ORKGetScreenTypeForWindow(window);
+    ORKScreenType screenType = ORKGetVerticalScreenTypeForWindow(window);
     UIFontDescriptor *descriptor = [UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleSubheadline];
     const CGFloat defaultSize = 15;
     return [UIFont systemFontOfSize:[[descriptor objectForKey: UIFontDescriptorSizeAttribute] doubleValue] - defaultSize + ORKGetMetricForScreenType(ORKScreenMetricFontSizeSubheadline, screenType)];

--- a/ResearchKit/Common/ORKSurveyAnswerCell.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCell.m
@@ -200,7 +200,7 @@
 }
 
 + (CGFloat)suggestedCellHeightForView:(UIView *)view {
-    ORKScreenType screenType = ORKGetScreenTypeForWindow(view.window);
+    ORKScreenType screenType = ORKGetVerticalScreenTypeForWindow(view.window);
     return ORKGetMetricForScreenType(ORKScreenMetricTableCellDefaultHeight, screenType);
 }
 

--- a/ResearchKit/Common/ORKTableContainerView.m
+++ b/ResearchKit/Common/ORKTableContainerView.m
@@ -254,7 +254,7 @@
 
 - (void)willMoveToWindow:(UIWindow *)newWindow {
     [super willMoveToWindow:newWindow];
-    ORKScreenType screenType = ORKGetScreenTypeForWindow(newWindow);
+    ORKScreenType screenType = ORKGetVerticalScreenTypeForWindow(newWindow);
     _continueSkipContainerView.topMargin = ORKGetMetricForScreenType(ORKScreenMetricContinueButtonTopMargin, screenType);
     if (newWindow) {
         [self registerForKeyboardNotifications:YES];
@@ -305,7 +305,7 @@
     }
     
     // If there's room, we'd like to leave space below so you can tap on the next cell
-    ORKScreenType screenType = ORKGetScreenTypeForWindow(self.window);
+    ORKScreenType screenType = ORKGetVerticalScreenTypeForWindow(self.window);
     // Only go 3/4 of a cell extra; otherwise user might think they tapped the wrong cell
     CGFloat desiredExtraSpace  = floor(ORKGetMetricForScreenType(ORKScreenMetricTextFieldCellHeight, screenType)*3/4);
     CGFloat visibleSpaceAboveDesiredRect = CGRectGetMinY(desiredRect) - offsetY;

--- a/ResearchKit/Common/ORKVerticalContainerView.m
+++ b/ResearchKit/Common/ORKVerticalContainerView.m
@@ -75,7 +75,6 @@ static const CGFloat AssumedStatusBarHeight = 20;
         UIEdgeInsets layoutMargins = (UIEdgeInsets){.left = margin, .right = margin};
         self.layoutMargins = layoutMargins;
         _verticalScreenType = ORKScreenTypeiPhone4;
-        _horizontalScreenType = ORKScreenTypeiPhone4;
         _scrollContainer = [UIView new];
         [self addSubview:_scrollContainer];
         _container = [UIView new];
@@ -188,7 +187,6 @@ static const CGFloat AssumedStatusBarHeight = 20;
 - (void)willMoveToWindow:(UIWindow *)newWindow {
     [super willMoveToWindow:newWindow];
     _verticalScreenType = ORKGetVerticalScreenTypeForWindow(newWindow);
-    _horizontalScreenType = ORKGetHorizontalScreenTypeForWindow(newWindow);
     [self updateConstraintConstants];
     if (newWindow) {
         [self registerForKeyboardNotifications:YES];
@@ -313,11 +311,9 @@ static const CGFloat AssumedStatusBarHeight = 20;
     UIWindow *window = self.window;
     if (window) {
         _verticalScreenType = ORKGetVerticalScreenTypeForWindow(window);
-        _horizontalScreenType = ORKGetHorizontalScreenTypeForWindow(window);
     }
     
     ORKScreenType verticalScreenType = _verticalScreenType;
-    ORKScreenType horizontalScreenType = _horizontalScreenType;
     
     const CGFloat StepViewBottomToContinueTop = ORKGetMetricForScreenType(ORKScreenMetricContinueButtonTopMargin, verticalScreenType);
     const CGFloat StepViewBottomToContinueTopForIntroStep = ORKGetMetricForScreenType(ORKScreenMetricContinueButtonTopMarginForIntroStep, verticalScreenType);
@@ -328,7 +324,7 @@ static const CGFloat AssumedStatusBarHeight = 20;
     
     {
         const CGFloat IllustrationHeight = ORKGetMetricForScreenType(ORKScreenMetricIllustrationHeight, verticalScreenType);
-        const CGFloat IllustrationTopMargin = ORKGetMetricForScreenType(ORKScreenMetricTopToIllustration, horizontalScreenType);
+        const CGFloat IllustrationTopMargin = ORKGetMetricForScreenType(ORKScreenMetricTopToIllustration, verticalScreenType);
 
         NSLayoutConstraint *constraint = _adjustableConstraints[_IllustrationHeightConstraintKey];
         constraint.constant = (_imageView.image ? IllustrationHeight : 0);

--- a/ResearchKit/Common/ORKVerticalContainerView_Internal.h
+++ b/ResearchKit/Common/ORKVerticalContainerView_Internal.h
@@ -37,7 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ORKVerticalContainerView ()
 
-@property (nonatomic, readonly) ORKScreenType screenType;
+@property (nonatomic, readonly) ORKScreenType verticalScreenType;
+@property (nonatomic, readonly) ORKScreenType horizontalScreenType;
 
 - (void)updateConstraintConstants;
 

--- a/ResearchKit/Common/ORKVerticalContainerView_Internal.h
+++ b/ResearchKit/Common/ORKVerticalContainerView_Internal.h
@@ -38,7 +38,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ORKVerticalContainerView ()
 
 @property (nonatomic, readonly) ORKScreenType verticalScreenType;
-@property (nonatomic, readonly) ORKScreenType horizontalScreenType;
 
 - (void)updateConstraintConstants;
 

--- a/ResearchKit/Consent/ORKConsentSignatureController.m
+++ b/ResearchKit/Consent/ORKConsentSignatureController.m
@@ -55,7 +55,7 @@
 
 - (void)willMoveToWindow:(UIWindow *)newWindow {
     [super willMoveToWindow:newWindow];
-    ORKScreenType screenType = ORKGetScreenTypeForWindow(newWindow);
+    ORKScreenType screenType = ORKGetVerticalScreenTypeForWindow(newWindow);
     _signatureView.layoutMargins = (UIEdgeInsets){.top=ORKGetMetricForScreenType(ORKScreenMetricLearnMoreBaselineToStepViewTopWithNoLearnMore, screenType)-ABS([[ORKTextButton defaultFont] descender])-1 };
     [self setNeedsLayout];
 }
@@ -84,7 +84,8 @@
             [self addSubview:_signatureView];
         }
         
-        self.layoutMargins = (UIEdgeInsets){.left=ORKStandardHorizMarginForView(self), .right=ORKStandardHorizMarginForView(self)};
+        CGFloat margin = ORKStandardHorizMarginForView(self);
+        self.layoutMargins = (UIEdgeInsets){.left = margin, .right = margin };
         
         [self setNeedsUpdateConstraints];
     }


### PR DESCRIPTION
Fixed layout problem on iPad with iOS 9. (Tested in simulator)

Changes:
- Determine screen type from two dimensions: `vertical` and `horizontal`  
Renamed `ORKGetScreenTypeForWindow` to `ORKGetVerticalScreenTypeForWindow`
And introduced `ORKGetHorizontalScreenTypeForWindow`

       Use horizontal screen type to determine a few metrics:
       ` ORKScreenMetricContinueButtonWidth`
       `ORKScreenMetricHeadlineSideMargin`
        `ORKScreenMetricLearnMoreButtonSideMargin`
        ~~`ORKScreenMetricTopToIllustration`~~


- Update `layoutMargin` in `ORKVerticalContainerView`'s `updateConstraintConstants`
