### PR TITLE
Alternate fix for Tower of Hanoi iOS 9 constraint crash

### DIFF
--- a/ResearchKit/ActiveTasks/ORKTowerOfHanoiTowerView.m
+++ b/ResearchKit/ActiveTasks/ORKTowerOfHanoiTowerView.m
@@ -33,17 +33,19 @@
 #import "ORKActiveStepView.h"
 #import "ORKSkin.h"
 #import "ORKAccessibility.h"
+#import "ORKHelpers.h"
 
-static const CGFloat kDiskHeight = 10;
-static const CGFloat kDiskSpacing = 8;
-static const CGFloat kBaseSpacing = 10;
+
+static const CGFloat DiskHeight = 10;
+static const CGFloat DiskSpacing = 8;
+static const CGFloat BaseSpacing = 10;
 
 @implementation ORKTowerOfHanoiTowerView {
     NSInteger _maximumNumberOfDisks;
     UIView *_base;
     NSMutableArray *_diskViews;
     NSMutableArray *_diskSizes;
-    NSArray *_currentConstraints;
+    NSMutableArray *_variableConstraints;
 }
 
 #pragma mark - Init
@@ -57,6 +59,8 @@ static const CGFloat kBaseSpacing = 10;
         [_base setTranslatesAutoresizingMaskIntoConstraints:NO];
         _base.layer.cornerRadius = 2.5;
         _base.layer.masksToBounds = YES;
+        _diskViews = [NSMutableArray new];
+        _diskSizes = [NSMutableArray new];
         [self addSubview:_base];
         [self addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(userDidTapTower)]];
     }
@@ -66,52 +70,54 @@ static const CGFloat kBaseSpacing = 10;
 #pragma mark - UIView
 
 - (void)updateConstraints {
-    if (_currentConstraints != nil) {
-        [self removeConstraints:_currentConstraints];
-        _currentConstraints = nil;
+    [NSLayoutConstraint deactivateConstraints:_variableConstraints];
+    [_variableConstraints removeAllObjects];
+    
+    if (!_variableConstraints) {
+        _variableConstraints = [NSMutableArray new];
     }
-    NSMutableArray *newConstraints = [NSMutableArray new];
-    CGFloat height = (kDiskHeight * _maximumNumberOfDisks) + (kDiskSpacing * _maximumNumberOfDisks);
     
-    [newConstraints addObject:[NSLayoutConstraint constraintWithItem:self
-                                                           attribute:NSLayoutAttributeHeight
-                                                           relatedBy:NSLayoutRelationGreaterThanOrEqual
-                                                              toItem:nil
-                                                           attribute:NSLayoutAttributeNotAnAttribute
-                                                          multiplier:1
-                                                            constant:height + kBaseSpacing]];
+    CGFloat height = (DiskHeight * _maximumNumberOfDisks) + (DiskSpacing * _maximumNumberOfDisks);
     
-    [newConstraints addObject:[NSLayoutConstraint constraintWithItem:_base
-                                                           attribute:NSLayoutAttributeWidth
-                                                           relatedBy:NSLayoutRelationEqual
-                                                              toItem:self
-                                                           attribute:NSLayoutAttributeWidth
-                                                          multiplier:1
-                                                            constant:0]];
+    [_variableConstraints addObject:[NSLayoutConstraint constraintWithItem:self
+                                                                 attribute:NSLayoutAttributeHeight
+                                                                 relatedBy:NSLayoutRelationGreaterThanOrEqual
+                                                                    toItem:nil
+                                                                 attribute:NSLayoutAttributeNotAnAttribute
+                                                                multiplier:1.0
+                                                                  constant:height + BaseSpacing]];
     
-    [newConstraints addObject:[NSLayoutConstraint constraintWithItem:_base
-                                                           attribute:NSLayoutAttributeHeight
-                                                           relatedBy:NSLayoutRelationEqual
-                                                              toItem:nil
-                                                           attribute:NSLayoutAttributeNotAnAttribute
-                                                          multiplier:1
-                                                            constant:2]];
+    [_variableConstraints addObject:[NSLayoutConstraint constraintWithItem:_base
+                                                                 attribute:NSLayoutAttributeWidth
+                                                                 relatedBy:NSLayoutRelationEqual
+                                                                    toItem:self
+                                                                 attribute:NSLayoutAttributeWidth
+                                                                multiplier:1.0
+                                                                  constant:0.0]];
     
-    [newConstraints addObject:[NSLayoutConstraint constraintWithItem:_base
-                                                           attribute:NSLayoutAttributeCenterX
-                                                           relatedBy:NSLayoutRelationEqual
-                                                              toItem:self
-                                                           attribute:NSLayoutAttributeCenterX
-                                                          multiplier:1
-                                                            constant:0]];
+    [_variableConstraints addObject:[NSLayoutConstraint constraintWithItem:_base
+                                                                 attribute:NSLayoutAttributeHeight
+                                                                 relatedBy:NSLayoutRelationEqual
+                                                                    toItem:nil
+                                                                 attribute:NSLayoutAttributeNotAnAttribute
+                                                                multiplier:1.0
+                                                                  constant:2]];
     
-    [newConstraints addObject:[NSLayoutConstraint constraintWithItem:_base
-                                                           attribute:NSLayoutAttributeBottom
-                                                           relatedBy:NSLayoutRelationEqual
-                                                              toItem:self
-                                                           attribute:NSLayoutAttributeCenterY
-                                                          multiplier:1
-                                                            constant:(height * 0.5) + kBaseSpacing]];
+    [_variableConstraints addObject:[NSLayoutConstraint constraintWithItem:_base
+                                                                 attribute:NSLayoutAttributeCenterX
+                                                                 relatedBy:NSLayoutRelationEqual
+                                                                    toItem:self
+                                                                 attribute:NSLayoutAttributeCenterX
+                                                                multiplier:1.0
+                                                                  constant:0.0]];
+    
+    [_variableConstraints addObject:[NSLayoutConstraint constraintWithItem:_base
+                                                                 attribute:NSLayoutAttributeBottom
+                                                                 relatedBy:NSLayoutRelationEqual
+                                                                    toItem:self
+                                                                 attribute:NSLayoutAttributeCenterY
+                                                                multiplier:1.0
+                                                                  constant:(height * 0.5) + BaseSpacing]];
     
     UIView *topDisk;
     for (NSInteger index = 0 ; index < _diskSizes.count ; index++) {
@@ -119,53 +125,52 @@ static const CGFloat kBaseSpacing = 10;
         CGFloat divide = 1.0 / _maximumNumberOfDisks;
         CGFloat multiply = [(NSNumber *)_diskSizes[index] floatValue] * divide;
         
-        [newConstraints addObject:[NSLayoutConstraint constraintWithItem:disk
-                                                               attribute:NSLayoutAttributeCenterX
-                                                               relatedBy:NSLayoutRelationEqual
-                                                                  toItem:self
-                                                               attribute:NSLayoutAttributeCenterX
-                                                              multiplier:1
-                                                                constant:0]];
+        [_variableConstraints addObject:[NSLayoutConstraint constraintWithItem:disk
+                                                                     attribute:NSLayoutAttributeCenterX
+                                                                     relatedBy:NSLayoutRelationEqual
+                                                                        toItem:self
+                                                                     attribute:NSLayoutAttributeCenterX
+                                                                    multiplier:1.0
+                                                                      constant:0.0]];
         
         
         
-        [newConstraints addObject:[NSLayoutConstraint constraintWithItem:disk
-                                                               attribute:NSLayoutAttributeWidth
-                                                               relatedBy:NSLayoutRelationEqual
-                                                                  toItem:_base
-                                                               attribute:NSLayoutAttributeWidth
-                                                              multiplier:multiply
-                                                                constant:0]];
+        [_variableConstraints addObject:[NSLayoutConstraint constraintWithItem:disk
+                                                                     attribute:NSLayoutAttributeWidth
+                                                                     relatedBy:NSLayoutRelationEqual
+                                                                        toItem:_base
+                                                                     attribute:NSLayoutAttributeWidth
+                                                                    multiplier:multiply
+                                                                      constant:0.0]];
         
-        [newConstraints addObject:[NSLayoutConstraint constraintWithItem:disk
-                                                               attribute:NSLayoutAttributeHeight
-                                                               relatedBy:NSLayoutRelationEqual
-                                                                  toItem:nil
-                                                               attribute:NSLayoutAttributeNotAnAttribute
-                                                              multiplier:1
-                                                                constant:kDiskHeight]];
+        [_variableConstraints addObject:[NSLayoutConstraint constraintWithItem:disk
+                                                                     attribute:NSLayoutAttributeHeight
+                                                                     relatedBy:NSLayoutRelationEqual
+                                                                        toItem:nil
+                                                                     attribute:NSLayoutAttributeNotAnAttribute
+                                                                    multiplier:1.0
+                                                                      constant:DiskHeight]];
         
         if (index == 0) {
-            [newConstraints addObject:[NSLayoutConstraint constraintWithItem:disk
-                                                                   attribute:NSLayoutAttributeBottom
-                                                                   relatedBy:NSLayoutRelationEqual
-                                                                      toItem:self
-                                                                   attribute:NSLayoutAttributeCenterY
-                                                                  multiplier:1
-                                                                    constant:height * 0.5]];
+            [_variableConstraints addObject:[NSLayoutConstraint constraintWithItem:disk
+                                                                         attribute:NSLayoutAttributeBottom
+                                                                         relatedBy:NSLayoutRelationEqual
+                                                                            toItem:self
+                                                                         attribute:NSLayoutAttributeCenterY
+                                                                        multiplier:1.0
+                                                                          constant:height * 0.5]];
         } else {
-            [newConstraints addObject:[NSLayoutConstraint constraintWithItem:disk
-                                                                   attribute:NSLayoutAttributeBottom
-                                                                   relatedBy:NSLayoutRelationEqual
-                                                                      toItem:topDisk
-                                                                   attribute:NSLayoutAttributeTop
-                                                                  multiplier:1
-                                                                    constant:-kDiskSpacing]];
+            [_variableConstraints addObject:[NSLayoutConstraint constraintWithItem:disk
+                                                                         attribute:NSLayoutAttributeBottom
+                                                                         relatedBy:NSLayoutRelationEqual
+                                                                            toItem:topDisk
+                                                                         attribute:NSLayoutAttributeTop
+                                                                        multiplier:1.0
+                                                                          constant:-DiskSpacing]];
         }
         topDisk = disk;
     }
-    _currentConstraints = newConstraints;
-    [NSLayoutConstraint activateConstraints:newConstraints];
+    [NSLayoutConstraint activateConstraints:_variableConstraints];
     [super updateConstraints];
 }
 
@@ -176,8 +181,7 @@ static const CGFloat kBaseSpacing = 10;
 #pragma mark - Public
 
 - (void)reloadData {
-    [_diskViews makeObjectsPerformSelector:@selector(removeFromSuperview)];
-    [self addDisks];
+    [self updateDisks];
     [self highlightIfNeeded];
     [self indicateTargetIfNeeded];
     [self setNeedsUpdateConstraints];
@@ -189,23 +193,25 @@ static const CGFloat kBaseSpacing = 10;
     [self.delegate towerOfHanoiTowerViewWasSelected:self];
 }
 
-- (void)addDisks {
+- (void)updateDisks {
+    [_diskViews makeObjectsPerformSelector:@selector(removeFromSuperview)];
+    ORKRemoveConstraintsForRemovedViews(_variableConstraints, _diskViews);
+
+    [_diskViews removeAllObjects];
+    [_diskSizes removeAllObjects];
+
     NSInteger numberOfDisks = [self.dataSource numberOfDisksInTowerOfHanoiView:self];
-    NSMutableArray *diskViews = [NSMutableArray new];
-    NSMutableArray *diskSizes = [NSMutableArray new];
     for (NSInteger index = 0 ; index < numberOfDisks ; index++) {
         NSNumber *diskSize = [self.dataSource towerOfHanoiView:self diskAtIndex:index];
-        [diskSizes addObject:diskSize];
-        UIView *v = [[UIView alloc] initWithFrame:CGRectZero];
-        v.backgroundColor = [self tintColor];
-        v.translatesAutoresizingMaskIntoConstraints = NO;
-        v.layer.cornerRadius = kDiskHeight * 0.5;
-        v.clipsToBounds = YES;
-        [self addSubview:v];
-        [diskViews addObject:v];
+        [_diskSizes addObject:diskSize];
+        UIView *diskView = [[UIView alloc] initWithFrame:CGRectZero];
+        diskView.backgroundColor = [self tintColor];
+        diskView.translatesAutoresizingMaskIntoConstraints = NO;
+        diskView.layer.cornerRadius = DiskHeight * 0.5;
+        diskView.clipsToBounds = YES;
+        [self addSubview:diskView];
+        [_diskViews addObject:diskView];
     }
-    _diskSizes = diskSizes;
-    _diskViews = diskViews;
 }
 
 - (void)highlightIfNeeded {

--- a/ResearchKit/Common/ORKHelpers.h
+++ b/ResearchKit/Common/ORKHelpers.h
@@ -254,3 +254,5 @@ ORKCGFloatNearlyEqualToFloat(CGFloat f1, CGFloat f2) {
 #define ORKThrowInvalidArgumentExceptionIfNil(argument)  if (!argument) { @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@#argument" can not be nil." userInfo:nil]; }
 
 void ORKValidateArrayForObjectsOfClass(NSArray *array, Class expectedObjectClass, NSString *exceptionReason);
+
+void ORKRemoveConstraintsForRemovedViews(NSMutableArray *constraints, NSMutableArray *removedViews);

--- a/ResearchKit/Common/ORKHelpers.m
+++ b/ResearchKit/Common/ORKHelpers.m
@@ -510,3 +510,12 @@ void ORKValidateArrayForObjectsOfClass(NSArray *array, Class expectedObjectClass
     }
 }
 
+void ORKRemoveConstraintsForRemovedViews(NSMutableArray *constraints, NSMutableArray *removedViews) {
+    for (NSLayoutConstraint *constraint in [constraints copy]) {
+        for (UIView *view in removedViews) {
+            if (constraint.firstItem == view || constraint.secondItem == view) {
+                [constraints removeObject:constraint];
+            }
+        }
+    }
+}


### PR DESCRIPTION
I figured an alternate fix for the *iOS 9* crash when you call `NSLayoutConstraint deactivateConstraints:` on constraints that reference removed views.

It adds the `void ORKRemoveConstraintsForRemovedViews(NSMutableArray *constraints, NSMutableArray *removedViews)` function to `ORKHelpers`. You have to call this whenever you remove subviews on a view that has a managed `_variableConstraints` mutable array.

Benefits of this fix:
- It allows to continue using the recommended `[NSLayoutConstraint deactivateConstraints:]`.
- It is easily compatible with my *constraint refactor* [pull request](https://github.com/ResearchKit/ResearchKit/pull/343), without having to switch back and forward between `[NSLayoutConstraint deactiveConstraints:]` and `[view removeConstraints:]`.
- When the bug is fixed, it'll be very easy to remove the fix by removing the new function and all of its calls, and the code will remain clean and in working order.

If, in the future, you merge the aforementioned *constraint refactor* PR before the bug is fixed at the iOS level, I can check it add calls to this function everywhere is needed.