### PR TITLE
iPad: constraint and layoutMargin code fixes

### DIFF
--- a/ResearchKit/ActiveTasks/ORKSpatialSpanMemoryContentView.m
+++ b/ResearchKit/ActiveTasks/ORKSpatialSpanMemoryContentView.m
@@ -258,14 +258,19 @@
     [self updateFooterHidden];
 }
 
-
 - (void)updateMargins {
-    CGFloat margin = ORKStandardHorizMarginForView(self);
+    CGFloat margin = ORKStandardHorizontalMarginForView(self);
     self.layoutMargins = (UIEdgeInsets){.left = margin, .right = margin};
     _quantityPairView.layoutMargins = self.layoutMargins;
 }
 
-- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+- (void)setFrame:(CGRect)frame {
+    [super setFrame:frame];
+    [self updateMargins];
+}
+
+- (void)setBounds:(CGRect)bounds {
+    [super setBounds:bounds];
     [self updateMargins];
 }
 

--- a/ResearchKit/ActiveTasks/ORKTappingContentView.m
+++ b/ResearchKit/ActiveTasks/ORKTappingContentView.m
@@ -151,6 +151,21 @@
     [self setNeedsUpdateConstraints];
 }
 
+- (void)updateLayoutMargins {
+    CGFloat margin = ORKStandardHorizontalMarginForView(self);
+    self.layoutMargins = (UIEdgeInsets) { .left=margin*2, .right=margin*2 };
+}
+
+- (void)setFrame:(CGRect)frame {
+    [super setFrame:frame];
+    [self updateLayoutMargins];
+}
+
+- (void)setBounds:(CGRect)bounds {
+    [super setBounds:bounds];
+    [self updateLayoutMargins];
+}
+
 - (void)updateConstraints {
     if ([_constraints count]) {
         [NSLayoutConstraint deactivateConstraints:_constraints];
@@ -160,8 +175,6 @@
     ORKScreenType screenType = _screenType;
     const CGFloat HeaderBaselineToCaptionTop = ORKGetMetricForScreenType(ORKScreenMetricCaptionBaselineToTappingLabelTop, screenType);
     const CGFloat AssumedHeaderBaselineToStepViewTop = ORKGetMetricForScreenType(ORKScreenMetricLearnMoreBaselineToStepViewTop, screenType);
-    CGFloat margin = ORKStandardHorizMarginForView(self);
-    self.layoutMargins = (UIEdgeInsets) { .left=margin*2, .right=margin*2 };
     
     static const CGFloat CaptionBaselineToTapCountBaseline = 56;
     static const CGFloat TapButtonBottomToBottom = 36;

--- a/ResearchKit/ActiveTasks/ORKToneAudiometryContentView.m
+++ b/ResearchKit/ActiveTasks/ORKToneAudiometryContentView.m
@@ -101,12 +101,25 @@
     self.tapButton.enabled = NO;
 }
 
+- (void)updateLayoutMargins {
+    CGFloat margin = ORKStandardHorizontalMarginForView(self);
+    self.layoutMargins = (UIEdgeInsets) { .left=margin*2, .right=margin*2 };
+}
+
+- (void)setFrame:(CGRect)frame {
+    [super setFrame:frame];
+    [self updateLayoutMargins];
+}
+
+- (void)setBounds:(CGRect)bounds {
+    [super setBounds:bounds];
+    [self updateLayoutMargins];
+}
+
 - (void)setupConstraints {
     ORKScreenType screenType = _screenType;
     const CGFloat HeaderBaselineToCaptionTop = ORKGetMetricForScreenType(ORKScreenMetricCaptionBaselineToTappingLabelTop, screenType);
     const CGFloat AssumedHeaderBaselineToStepViewTop = ORKGetMetricForScreenType(ORKScreenMetricLearnMoreBaselineToStepViewTop, screenType);
-    CGFloat margin = ORKStandardHorizMarginForView(self);
-    self.layoutMargins = (UIEdgeInsets) { .left=margin*2, .right=margin*2 };
 
     static const CGFloat TapButtonBottomToBottom = 36;
 

--- a/ResearchKit/Charts/ORKGraphChartView.m
+++ b/ResearchKit/Charts/ORKGraphChartView.m
@@ -344,8 +344,16 @@ inline static CALayer *graphVerticalReferenceLineLayerWithTintColor(UIColor *tin
 #pragma mark - Layout
 
 - (void)setBounds:(CGRect)bounds {
-    BOOL sizeChanged = !CGRectEqualToRect(bounds, self.bounds);
+    BOOL sizeChanged = !CGSizeEqualToSize(bounds.size, self.bounds.size);
     [super setBounds:bounds];
+    if (sizeChanged) {
+        [self setNeedsLayout];
+    }
+}
+
+- (void)setFrame:(CGRect)frame {
+    BOOL sizeChanged = !CGSizeEqualToSize(frame.size, self.frame.size);
+    [super setFrame:frame];
     if (sizeChanged) {
         [self setNeedsLayout];
     }

--- a/ResearchKit/Common/ORKCustomStepView.m
+++ b/ResearchKit/Common/ORKCustomStepView.m
@@ -104,4 +104,14 @@
 
 }
 
+- (void)setBounds:(CGRect)bounds {
+    [super setBounds:bounds];
+    self.layoutMargins = ORKStandardFullScreenLayoutMarginsForView(self);
+}
+
+- (void)setFrame:(CGRect)frame {
+    [super setFrame:frame];
+    self.layoutMargins = ORKStandardFullScreenLayoutMarginsForView(self);
+}
+
 @end

--- a/ResearchKit/Common/ORKSkin.h
+++ b/ResearchKit/Common/ORKSkin.h
@@ -146,11 +146,11 @@ CGFloat ORKGetMetricForScreenType(ORKScreenMetric metric, ORKScreenType screenTy
 CGFloat ORKGetMetricForWindow(ORKScreenMetric metric, UIWindow *__nullable window);
 
 CGFloat ORKStandardLeftMarginForTableViewCell(UIView *view);
-CGFloat ORKStandardHorizMarginForView(UIView *view);
+CGFloat ORKStandardHorizontalMarginForView(UIView *view);
 UIEdgeInsets ORKStandardLayoutMarginsForTableViewCell(UIView *view);
 UIEdgeInsets ORKStandardFullScreenLayoutMarginsForView(UIView *view);
 UIEdgeInsets ORKScrollIndicatorInsetsForScrollView(UIView *view);
-CGFloat ORKWidthForSignatureView(UIWindow *window);
+CGFloat ORKWidthForSignatureView(UIWindow *__nullable window);
 
 void ORKUpdateScrollViewBottomInset(UIScrollView *scrollView, CGFloat bottomInset);
 

--- a/ResearchKit/Common/ORKTableViewCell.m
+++ b/ResearchKit/Common/ORKTableViewCell.m
@@ -70,13 +70,23 @@
     return self;
 }
 
-- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+- (void)updateSeparatorInsets {
     if (self.topSeparatorLeftInset > 0) {
-        self.topSeparatorLeftInset = ORKStandardHorizMarginForView(self);
+        self.topSeparatorLeftInset = ORKStandardHorizontalMarginForView(self);
     }
     if (self.bottomSeparatorLeftInset > 0) {
-        self.bottomSeparatorLeftInset = ORKStandardHorizMarginForView(self);
+        self.bottomSeparatorLeftInset = ORKStandardHorizontalMarginForView(self);
     }
+}
+
+- (void)setFrame:(CGRect)frame {
+    [super setFrame:frame];
+    [self updateSeparatorInsets];
+}
+
+- (void)setBounds:(CGRect)bounds {
+    [super setBounds:bounds];
+    [self updateSeparatorInsets];
 }
 
 - (void)setShowBottomSeparator:(BOOL)showBottomSeparator {

--- a/ResearchKit/Common/ORKVerticalContainerView.m
+++ b/ResearchKit/Common/ORKVerticalContainerView.m
@@ -71,17 +71,11 @@ static const CGFloat AssumedStatusBarHeight = 20;
 - (instancetype)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
-        CGFloat margin = ORKStandardHorizMarginForView(self);
-        UIEdgeInsets layoutMargins = (UIEdgeInsets){.left = margin, .right = margin};
-        self.layoutMargins = layoutMargins;
         _verticalScreenType = ORKScreenTypeiPhone4;
         _scrollContainer = [UIView new];
         [self addSubview:_scrollContainer];
         _container = [UIView new];
         [_scrollContainer addSubview:_container];
-        
-        _scrollContainer.layoutMargins = layoutMargins;
-        _container.layoutMargins = layoutMargins;
         
         {
             _headerView = [ORKStepHeaderView new];
@@ -182,6 +176,16 @@ static const CGFloat AssumedStatusBarHeight = 20;
         [notificationCenter removeObserver:self name:UIKeyboardWillHideNotification object:nil];
         [notificationCenter removeObserver:self name:UIKeyboardWillChangeFrameNotification object:nil];
     }
+}
+
+- (void)setBounds:(CGRect)bounds {
+    [super setBounds:bounds];
+    [self updateLayoutMargins];
+}
+
+- (void)setFrame:(CGRect)frame {
+    [super setFrame:frame];
+    [self updateLayoutMargins];
 }
 
 - (void)willMoveToWindow:(UIWindow *)newWindow {
@@ -297,22 +301,15 @@ static const CGFloat AssumedStatusBarHeight = 20;
     }
 }
 
+- (void)updateLayoutMargins {
+    CGFloat margin = ORKStandardHorizontalMarginForView(self);
+    UIEdgeInsets layoutMargins = (UIEdgeInsets){.left = margin, .right = margin};
+    self.layoutMargins = layoutMargins;
+    _scrollContainer.layoutMargins = layoutMargins;
+    _container.layoutMargins = layoutMargins;
+}
+
 - (void)updateConstraintConstants {
-    
-    CGFloat margin = ORKStandardHorizMarginForView(self);
-    
-    if (self.layoutMargins.left != margin) {
-        UIEdgeInsets layoutMargins = (UIEdgeInsets){.left = margin, .right = margin};
-        self.layoutMargins = layoutMargins;
-        _scrollContainer.layoutMargins = layoutMargins;
-        _container.layoutMargins = layoutMargins;
-    }
-    
-    UIWindow *window = self.window;
-    if (window) {
-        _verticalScreenType = ORKGetVerticalScreenTypeForWindow(window);
-    }
-    
     ORKScreenType verticalScreenType = _verticalScreenType;
     
     const CGFloat StepViewBottomToContinueTop = ORKGetMetricForScreenType(ORKScreenMetricContinueButtonTopMargin, verticalScreenType);
@@ -588,6 +585,7 @@ static const CGFloat AssumedStatusBarHeight = 20;
     
     [self updateCustomViewContainerConstraints];
     [self updateStepViewContainerConstraints];
+    [self updateLayoutMargins];
     [self updateConstraintConstants];
     
     [super updateConstraints];

--- a/ResearchKit/Consent/ORKConsentReviewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewController.m
@@ -46,6 +46,7 @@
 @implementation ORKConsentReviewController {
     UIToolbar *_toolbar;
     NSString *_htmlString;
+    NSMutableArray *_variableConstraints;
 }
 
 - (instancetype)initWithHTML:(NSString *)html delegate:(id<ORKConsentReviewControllerDelegate>)delegate {
@@ -80,43 +81,54 @@
     _toolbar.translatesAutoresizingMaskIntoConstraints = NO;
     _toolbar.translucent = YES;
 
-    const CGFloat horizMargin = ORKStandardHorizMarginForView(self.view);
     _webView.clipsToBounds = NO;
     _webView.scrollView.clipsToBounds = NO;
-    _webView.scrollView.scrollIndicatorInsets = (UIEdgeInsets){.left = -horizMargin, .right = -horizMargin};
-
+    [self updateLayoutMargins];
+    
     [self.view addSubview:_webView];
     [self.view addSubview:_toolbar];
-    
-    [self setupConstraints];
 }
 
-- (void)setupConstraints {
-    NSMutableArray *constraints = [NSMutableArray new];
+- (void)updateLayoutMargins {
+    const CGFloat margin = ORKStandardHorizontalMarginForView(self.view);
+    _webView.scrollView.scrollIndicatorInsets = (UIEdgeInsets){.left = -margin, .right = -margin};
+}
+
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    [self updateLayoutMargins];
+}
+
+- (void)updateViewConstraints {
+    [super updateViewConstraints];
+    if (!_variableConstraints) {
+        _variableConstraints = [NSMutableArray new];
+    }
+    [NSLayoutConstraint deactivateConstraints:_variableConstraints];
+    [_variableConstraints removeAllObjects];
     
     NSDictionary *views = NSDictionaryOfVariableBindings(_webView, _toolbar);
-    const CGFloat horizMargin = ORKStandardHorizMarginForView(self.view);
-    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-horizMargin-[_webView]-horizMargin-|"
-                                                                      options:(NSLayoutFormatOptions)0
-                                                                      metrics:@{ @"horizMargin": @(horizMargin) }
-                                                                        views:views]];
-    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_toolbar]|"
-                                                                      options:(NSLayoutFormatOptions)0
-                                                                      metrics:nil
-                                                                        views:views]];
-    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_webView][_toolbar]|"
-                                                                      options:(NSLayoutFormatOptions)0 metrics:nil
-                                                                        views:views]];
+    const CGFloat horizontalMargin = ORKStandardHorizontalMarginForView(self.view);
+    [_variableConstraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-horizMargin-[_webView]-horizMargin-|"
+                                                                                      options:(NSLayoutFormatOptions)0
+                                                                                      metrics:@{ @"horizMargin": @(horizontalMargin) }
+                                                                                        views:views]];
+    [_variableConstraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_toolbar]|"
+                                                                                      options:(NSLayoutFormatOptions)0
+                                                                                      metrics:nil
+                                                                                        views:views]];
+    [_variableConstraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_webView][_toolbar]|"
+                                                                                      options:(NSLayoutFormatOptions)0 metrics:nil
+                                                                                        views:views]];
     
-    [constraints addObject:[NSLayoutConstraint constraintWithItem:_toolbar
-                                                            attribute:NSLayoutAttributeHeight
-                                                            relatedBy:NSLayoutRelationEqual
-                                                               toItem:nil
-                                                            attribute:NSLayoutAttributeNotAnAttribute
-                                                           multiplier:1.0
-                                                         constant:ORKGetMetricForScreenType(ORKScreenMetricToolbarHeight, ORKScreenTypeiPhone4)]];
+    [_variableConstraints addObject:[NSLayoutConstraint constraintWithItem:_toolbar
+                                                                 attribute:NSLayoutAttributeHeight
+                                                                 relatedBy:NSLayoutRelationEqual
+                                                                    toItem:nil
+                                                                 attribute:NSLayoutAttributeNotAnAttribute
+                                                                multiplier:1.0
+                                                                  constant:ORKGetMetricForScreenType(ORKScreenMetricToolbarHeight, ORKScreenTypeiPhone4)]];
     
-    [NSLayoutConstraint activateConstraints:constraints];
+    [NSLayoutConstraint activateConstraints:_variableConstraints];
 }
 
 - (IBAction)cancel {

--- a/ResearchKit/Consent/ORKConsentSignatureController.m
+++ b/ResearchKit/Consent/ORKConsentSignatureController.m
@@ -84,12 +84,26 @@
             [self addSubview:_signatureView];
         }
         
-        CGFloat margin = ORKStandardHorizMarginForView(self);
-        self.layoutMargins = (UIEdgeInsets){.left = margin, .right = margin };
-        
         [self setNeedsUpdateConstraints];
     }
     return self;
+}
+
+- (void)updateLayoutMargins {
+    CGFloat margin = ORKStandardHorizontalMarginForView(self);
+    self.layoutMargins = (UIEdgeInsets){.left = margin, .right = margin };
+}
+
+- (void)setBounds:(CGRect)bounds {
+    [super setBounds:bounds];
+    [self updateLayoutMargins];
+    [self setNeedsUpdateConstraints];
+}
+
+- (void)setFrame:(CGRect)frame {
+    [super setFrame:frame];
+    [self updateLayoutMargins];
+    [self setNeedsUpdateConstraints];
 }
 
 - (void)setClearButtonEnabled:(BOOL)clearButtonEnabled {

--- a/ResearchKit/Consent/ORKSignatureView.m
+++ b/ResearchKit/Consent/ORKSignatureView.m
@@ -141,6 +141,16 @@ static const CGFloat kPointMinDistanceSquared = kPointMinDistance * kPointMinDis
     return self;
 }
 
+- (void)setBounds:(CGRect)bounds {
+    [super setBounds:bounds];
+    [self setNeedsDisplay];
+}
+
+- (void)setFrame:(CGRect)frame {
+    [super setFrame:frame];
+    [self setNeedsDisplay];
+}
+
 - (UIBezierPath *)pathWithRoundedStyle {
     UIBezierPath *path = [UIBezierPath bezierPath];
     path.lineCapStyle = kCGLineCapRound;


### PR DESCRIPTION
Fixes views not having wide iPad margins introduced on [PR #370] (https://github.com/ResearchKit/ResearchKit/pull/370).

Also fixes some views not updating their `layoutMargins` properly when going in and out of *Split View* mode.
