### PR TITLE
Fixed a bug: updating array during a for loop cause incorrect behavior(cause crash)

### DIFF
--- a/ResearchKit/Charts/ORKGraphChartView.m
+++ b/ResearchKit/Charts/ORKGraphChartView.m
@@ -331,11 +331,10 @@ inline static CALayer *graphVerticalReferenceLineLayerWithTintColor(UIColor *tin
         }
 
         // Add dummy points for empty data points
-        if (_dataPoints.count < self.numberOfXAxisPoints ) {
+        NSInteger emptyPointsCount = self.numberOfXAxisPoints - ((NSArray *)_dataPoints[plotIndex]).count;
+        for (NSInteger idx = 0; idx < emptyPointsCount; idx++) {
             ORKRangedPoint *dummyPoint = [[ORKRangedPoint alloc] init];
-            for (NSInteger idx = 0; idx < self.numberOfXAxisPoints - ((NSArray *)_dataPoints[plotIndex]).count; idx++) {
-                [_dataPoints[plotIndex] addObject:dummyPoint];
-            }
+            [_dataPoints[plotIndex] addObject:dummyPoint];
         }
         
     }
@@ -405,7 +404,8 @@ inline static CALayer *graphVerticalReferenceLineLayerWithTintColor(UIColor *tin
 
 - (void)updateYAxisPoints {
     [_yAxisPoints removeAllObjects];
-    for (NSInteger plotIndex = 0; plotIndex < [self numberOfPlots]; plotIndex++) {
+    NSInteger numberOfPlots = [self numberOfPlots];
+    for (NSInteger plotIndex = 0; plotIndex < numberOfPlots; plotIndex++) {
         [_yAxisPoints addObject:[self normalizedCanvasPointsForPlotIndex:plotIndex canvasHeight:_plotView.bounds.size.height]];
     }
 }
@@ -429,7 +429,8 @@ inline static CALayer *graphVerticalReferenceLineLayerWithTintColor(UIColor *tin
         _verticalReferenceLineLayers = [NSMutableArray new];
         CGFloat plotViewHeight = _plotView.bounds.size.height;
         CGFloat plotViewWidth = _plotView.bounds.size.width;
-        for (NSUInteger i = 1; i < [self numberOfXAxisPoints]; i++) {
+        NSInteger numberOfXAxisPoints = [self numberOfXAxisPoints];
+        for (NSUInteger i = 1; i < numberOfXAxisPoints; i++) {
             CALayer *verticalReferenceLineLayer = graphVerticalReferenceLineLayerWithTintColor(_referenceLineColor, plotViewHeight);
             CGFloat positionOnXAxis = xAxisPoint(i, [self numberOfXAxisPoints], plotViewWidth);
             verticalReferenceLineLayer.position = CGPointMake(positionOnXAxis - 0.5, 0);
@@ -479,7 +480,9 @@ inline static CALayer *graphPointLayerWithTintColor(UIColor *tintColor) {
         [_pointLayers[plotIndex] makeObjectsPerformSelector:@selector(removeFromSuperlayer)];
     }
     [_pointLayers removeAllObjects];
-    for (NSInteger plotIndex = 0; plotIndex < self.numberOfPlots; plotIndex++) {
+    
+    NSInteger numberOfPlots = self.numberOfPlots;
+    for (NSInteger plotIndex = 0; plotIndex < numberOfPlots; plotIndex++) {
         NSMutableArray *currentPlotPointLayers = [NSMutableArray new];
         [_pointLayers addObject:currentPlotPointLayers];
         [self updatePointLayersForPlotIndex:plotIndex];
@@ -511,9 +514,13 @@ inline static CALayer *graphPointLayerWithTintColor(UIColor *tintColor) {
 
 - (void)layoutPointLayers {
     NSUInteger numberOfPlots = [self numberOfPlots];
-    if (_yAxisPoints.count != numberOfPlots) { return; } // avoid layout if points have not been normalized yet
+    
+    if (_yAxisPoints.count != numberOfPlots) {
+        // avoid layout if points have not been normalized yet
+        return;
+    }
 
-    for (NSInteger plotIndex = 0; plotIndex < [self numberOfPlots]; plotIndex++) {
+    for (NSInteger plotIndex = 0; plotIndex < numberOfPlots; plotIndex++) {
         [self layoutPointLayersForPlotIndex:plotIndex];
     }
 }
@@ -544,7 +551,9 @@ inline static CALayer *graphPointLayerWithTintColor(UIColor *tintColor) {
         [_lineLayers[plotIndex] makeObjectsPerformSelector:@selector(removeFromSuperlayer)];
     }
     [_lineLayers removeAllObjects];
-    for (NSInteger plotIndex = 0; plotIndex < [self numberOfPlots]; plotIndex++) {
+    
+    NSUInteger numberOfPlots = [self numberOfPlots];
+    for (NSInteger plotIndex = 0; plotIndex < numberOfPlots; plotIndex++) {
         // Add array even if it should not draw lines so all layer arays have the same number of elements for animating purposes
         NSMutableArray *currentPlotLineLayers = [NSMutableArray new];
         [self.lineLayers addObject:currentPlotLineLayers];
@@ -555,10 +564,14 @@ inline static CALayer *graphPointLayerWithTintColor(UIColor *tintColor) {
 }
 
 - (void)layoutLineLayers {
-    NSUInteger numberOfPlots = [self numberOfPlots];
-    if (_yAxisPoints.count != numberOfPlots) { return; } // avoid layout if points have not been normalized yet
     
-    for (NSInteger plotIndex = 0; plotIndex < [self numberOfPlots]; plotIndex++) {
+    NSInteger numberOfPlots = [self numberOfPlots];
+    if (_yAxisPoints.count != numberOfPlots) {
+        // avoid layout if points have not been normalized yet
+        return;
+    }
+    
+    for (NSInteger plotIndex = 0; plotIndex < numberOfPlots; plotIndex++) {
         if ([self shouldDrawLinesForPlotIndex:plotIndex]) {
             [self layoutLineLayersForPlotIndex:plotIndex];
         }

--- a/ResearchKit/Charts/ORKGraphChartView.m
+++ b/ResearchKit/Charts/ORKGraphChartView.m
@@ -429,10 +429,10 @@ inline static CALayer *graphVerticalReferenceLineLayerWithTintColor(UIColor *tin
         _verticalReferenceLineLayers = [NSMutableArray new];
         CGFloat plotViewHeight = _plotView.bounds.size.height;
         CGFloat plotViewWidth = _plotView.bounds.size.width;
-        NSInteger numberOfXAxisPoints = [self numberOfXAxisPoints];
+        NSInteger numberOfXAxisPoints = self.numberOfXAxisPoints;
         for (NSUInteger i = 1; i < numberOfXAxisPoints; i++) {
             CALayer *verticalReferenceLineLayer = graphVerticalReferenceLineLayerWithTintColor(_referenceLineColor, plotViewHeight);
-            CGFloat positionOnXAxis = xAxisPoint(i, [self numberOfXAxisPoints], plotViewWidth);
+            CGFloat positionOnXAxis = xAxisPoint(i, self.numberOfXAxisPoints, plotViewWidth);
             verticalReferenceLineLayer.position = CGPointMake(positionOnXAxis - 0.5, 0);
             [_referenceLinesView.layer insertSublayer:verticalReferenceLineLayer atIndex:0];
             [_verticalReferenceLineLayers addObject:verticalReferenceLineLayer];
@@ -481,7 +481,7 @@ inline static CALayer *graphPointLayerWithTintColor(UIColor *tintColor) {
     }
     [_pointLayers removeAllObjects];
     
-    NSInteger numberOfPlots = self.numberOfPlots;
+    NSInteger numberOfPlots = [self numberOfPlots];
     for (NSInteger plotIndex = 0; plotIndex < numberOfPlots; plotIndex++) {
         NSMutableArray *currentPlotPointLayers = [NSMutableArray new];
         [_pointLayers addObject:currentPlotPointLayers];
@@ -513,7 +513,7 @@ inline static CALayer *graphPointLayerWithTintColor(UIColor *tintColor) {
 }
 
 - (void)layoutPointLayers {
-    NSUInteger numberOfPlots = [self numberOfPlots];
+    NSInteger numberOfPlots = [self numberOfPlots];
     
     if (_yAxisPoints.count != numberOfPlots) {
         // avoid layout if points have not been normalized yet
@@ -552,7 +552,7 @@ inline static CALayer *graphPointLayerWithTintColor(UIColor *tintColor) {
     }
     [_lineLayers removeAllObjects];
     
-    NSUInteger numberOfPlots = [self numberOfPlots];
+    NSInteger numberOfPlots = [self numberOfPlots];
     for (NSInteger plotIndex = 0; plotIndex < numberOfPlots; plotIndex++) {
         // Add array even if it should not draw lines so all layer arays have the same number of elements for animating purposes
         NSMutableArray *currentPlotLineLayers = [NSMutableArray new];

--- a/ResearchKit/Charts/ORKXAxisView.m
+++ b/ResearchKit/Charts/ORKXAxisView.m
@@ -152,7 +152,7 @@ static const CGFloat LastLabelHeight = 20.0;
         _titleLabels = [NSMutableArray new];
         _titleTickLayers = [NSMutableArray new];
 
-        NSUInteger numberOfTitleLabels = [_parentGraphChartView numberOfXAxisPoints];
+        NSInteger numberOfTitleLabels = _parentGraphChartView.numberOfXAxisPoints;
         for (NSUInteger i = 0; i < numberOfTitleLabels; i++) {
             NSString *title = [_parentGraphChartView.dataSource graphChartView:_parentGraphChartView titleForXAxisAtIndex:i];
             UILabel *label = [UILabel new];


### PR DESCRIPTION
Fixed this:
```
for (NSInteger idx = 0; idx < self.numberOfXAxisPoints - ((NSArray *)_dataPoints[plotIndex]).count; idx++) {
 [_dataPoints[plotIndex] addObject:dummyPoint];
}
```

Also Improved the code quality of `for loops` in charts code.