### PR TITLE
Fixed a crash cause by omitted `fillLayer`

### DIFF
--- a/ResearchKit/Charts/ORKLineGraphChartView.m
+++ b/ResearchKit/Charts/ORKLineGraphChartView.m
@@ -40,14 +40,14 @@
 const CGFloat FillColorAlpha = 0.4;
 
 @implementation ORKLineGraphChartView {
-    NSMutableArray *_fillLayers;
+    NSMutableDictionary *_fillLayers;
 }
 
 #pragma mark - Init
 
 - (void)sharedInit {
     [super sharedInit];
-    _fillLayers = [NSMutableArray new];
+    _fillLayers = [NSMutableDictionary new];
 }
 
 - (BOOL)shouldDrawLinesForPlotIndex:(NSInteger)plotIndex {
@@ -58,16 +58,17 @@ const CGFloat FillColorAlpha = 0.4;
 
 - (void)updatePlotColors {
     [super updatePlotColors];
-    for (NSUInteger plotIndex = 0; plotIndex < _fillLayers.count; plotIndex++) {
+    NSInteger numberOfPlots = [self numberOfPlots];
+    for (NSUInteger plotIndex = 0; plotIndex < numberOfPlots; plotIndex++) {
         UIColor *fillColor = (plotIndex == 0) ?
         [self.tintColor colorWithAlphaComponent:FillColorAlpha] : [self.referenceLineColor colorWithAlphaComponent:FillColorAlpha];
-        CAShapeLayer *fillLayer = _fillLayers[plotIndex];
+        CAShapeLayer *fillLayer = _fillLayers[@(plotIndex)];
         fillLayer.fillColor = fillColor.CGColor;
     }
 }
 
 - (void)updateLineLayers {
-    [_fillLayers makeObjectsPerformSelector:@selector(removeFromSuperlayer)];
+    [[_fillLayers allValues] makeObjectsPerformSelector:@selector(removeFromSuperlayer)];
     [_fillLayers removeAllObjects];
     [super updateLineLayers];
 }
@@ -104,10 +105,18 @@ const CGFloat FillColorAlpha = 0.4;
     fillLayer.fillColor = (plotIndex == 0) ? [self.tintColor colorWithAlphaComponent:0.4].CGColor : [self.referenceLineColor colorWithAlphaComponent:0.4].CGColor;
     
     [self.plotView.layer addSublayer:fillLayer];
-    [_fillLayers addObject:fillLayer];    
+    _fillLayers[@(plotIndex)] = fillLayer;
 }
 
 - (void)layoutLineLayersForPlotIndex:(NSInteger)plotIndex {
+    
+    CAShapeLayer *fillLayer = _fillLayers[@(plotIndex)];
+    
+    if (fillLayer == nil) {
+        // Skip for a nil fillLayer
+        return;
+    }
+    
     NSUInteger lineLayerIndex = 0;
     UIBezierPath *fillPath = [UIBezierPath bezierPath];
     CGFloat positionOnXAxis = ORKCGFloatInvalidValue;
@@ -145,9 +154,9 @@ const CGFloat FillColorAlpha = 0.4;
     }
     
     [fillPath addLineToPoint:CGPointMake(positionOnXAxis, CGRectGetHeight(self.plotView.frame))];
-    
-    CAShapeLayer *fillLayer = _fillLayers[plotIndex];
+        
     fillLayer.path = fillPath.CGPath;
+    
 }
 
 #pragma mark - Graph Calculations
@@ -225,12 +234,12 @@ const CGFloat FillColorAlpha = 0.4;
 #pragma mark - Animations
 
 - (void)animateWithDuration:(NSTimeInterval)animationDuration {
-    [_fillLayers makeObjectsPerformSelector:@selector(removeAllAnimations)];
-    for (NSUInteger plotIndex = 0; plotIndex < _fillLayers.count; plotIndex++) {
-        for (CAShapeLayer *fillLayer in _fillLayers) {
-            fillLayer.opacity = 0;
-        }
-    }
+    
+    [_fillLayers enumerateKeysAndObjectsUsingBlock:^(id key, CAShapeLayer *fillLayer, BOOL *stop) {
+        [fillLayer removeAllAnimations];
+        fillLayer.opacity = 0;
+    }];
+    
     [super animateWithDuration:animationDuration];
 }
 
@@ -243,14 +252,14 @@ const CGFloat FillColorAlpha = 0.4;
 
 - (void)animateLayersSequentiallyWithDuration:(NSTimeInterval)duration {
     [super animateLayersSequentiallyWithDuration:duration];
-    for (NSUInteger i = 0; i < _fillLayers.count; i++) {
-        CAShapeLayer *layer = _fillLayers[i];
+    
+    [_fillLayers enumerateKeysAndObjectsUsingBlock:^(id key, CAShapeLayer *layer, BOOL *stop) {
         [self animateLayer:layer
                    keyPath:@"opacity"
                   duration:duration * (1/3.0)
                 startDelay:duration * (2/3.0)
             timingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear]];
-    }
+    }];
 }
 
 @end

--- a/ResearchKit/Charts/ORKLineGraphChartView.m
+++ b/ResearchKit/Charts/ORKLineGraphChartView.m
@@ -109,7 +109,6 @@ const CGFloat FillColorAlpha = 0.4;
 }
 
 - (void)layoutLineLayersForPlotIndex:(NSInteger)plotIndex {
-    
     CAShapeLayer *fillLayer = _fillLayers[@(plotIndex)];
     
     if (fillLayer == nil) {
@@ -156,7 +155,6 @@ const CGFloat FillColorAlpha = 0.4;
     [fillPath addLineToPoint:CGPointMake(positionOnXAxis, CGRectGetHeight(self.plotView.frame))];
         
     fillLayer.path = fillPath.CGPath;
-    
 }
 
 #pragma mark - Graph Calculations
@@ -234,7 +232,6 @@ const CGFloat FillColorAlpha = 0.4;
 #pragma mark - Animations
 
 - (void)animateWithDuration:(NSTimeInterval)animationDuration {
-    
     [_fillLayers enumerateKeysAndObjectsUsingBlock:^(id key, CAShapeLayer *fillLayer, BOOL *stop) {
         [fillLayer removeAllAnimations];
         fillLayer.opacity = 0;


### PR DESCRIPTION
`shouldDrawLinesForPlotIndex:` skips certain fillLayers with less than 2 valid data points. Crashed on line 149 `CAShapeLayer *fillLayer = _fillLayers[plotIndex];`.

- Use NSMutableDictionary (instead of a NSMutableArray) to store _fillLayers
- `plotIndex` is used as key in the dictionary
- Improved _fillLayers iteration