### PR TITLE
Fix text label layout problem in right-to-left UI.

### DIFF
--- a/ResearchKit/Common/ORKChoiceViewCell.m
+++ b/ResearchKit/Common/ORKChoiceViewCell.m
@@ -48,6 +48,7 @@ static const CGFloat kLabelRightMargin = 44.0;
     if (self) {
         self.clipsToBounds = YES;
         _checkView = [[UIImageView alloc] initWithImage:[[UIImage imageNamed:@"checkmark" inBundle:ORKBundle() compatibleWithTraitCollection:nil] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]];
+        self.accessoryView = _checkView;
     }
     return self;
 }
@@ -130,7 +131,7 @@ static const CGFloat kLabelRightMargin = 44.0;
 
 - (void)updateSelectedItem {
     if (_immediateNavigation == NO) {
-        self.accessoryView = _selectedItem ? _checkView : nil;
+        self.accessoryView.hidden = _selectedItem ? NO : YES;
         self.shortLabel.textColor = _selectedItem ? [self tintColor] : [UIColor blackColor];
         self.longLabel.textColor = _selectedItem ? [[self tintColor] colorWithAlphaComponent:192/255.] : [UIColor ork_darkGrayColor];
     }

--- a/ResearchKit/Common/ORKSurveyAnswerCellForText.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForText.m
@@ -208,7 +208,7 @@
     _textField.text = @"";
     
     _textField.placeholder = self.step.placeholder? : ORKLocalizedString(@"PLACEHOLDER_TEXT_OR_NUMBER", nil);
-    _textField.textAlignment = NSTextAlignmentLeft;
+    _textField.textAlignment = NSTextAlignmentNatural;
     _textField.delegate = self;
     _textField.keyboardType = UIKeyboardTypeDefault;
 


### PR DESCRIPTION
- Make the checkmark always in the choiceCell, hide it when the cell is unselected.
So layout code get consistent bounds to calculate label's rect.

![iphone_timed_walk_2_1_6](https://cloud.githubusercontent.com/assets/11466704/9558556/f7c2511a-4d9b-11e5-802e-a063898c25ff.png)
