### PR TITLE
Fixed truncation issue of string "Total Taps" in "Two Finger Tapping"

### DIFF
--- a/ResearchKit/ActiveTasks/ORKTappingContentView.m
+++ b/ResearchKit/ActiveTasks/ORKTappingContentView.m
@@ -163,7 +163,7 @@
     CGFloat margin = ORKStandardHorizMarginForView(self);
     self.layoutMargins = (UIEdgeInsets) { .left=margin*2, .right=margin*2 };
     
-    static const CGFloat CaptionBaselineToTapCountBaseline = 56;
+    static const CGFloat CaptionBaselineToTapCountBaseline = 60;
     static const CGFloat TapButtonBottomToBottom = 36;
     
     // On the iPhone, _progressView is positioned outside the bounds of this view, to be in-between the header and this view.


### PR DESCRIPTION
in Vietnamese/Thai/Arabic

Increased the margin.

<img width="699" alt="screen shot 2015-08-28 at 3 51 49 pm" src="https://cloud.githubusercontent.com/assets/11466704/9558685/50da722c-4d9d-11e5-9554-7120db1117b5.png">
