### PR TITLE
Fix placeholder get truncated in FormItemCell.

### DIFF
--- a/ResearchKit/Common/ORKFormItemCell.m
+++ b/ResearchKit/Common/ORKFormItemCell.m
@@ -262,20 +262,22 @@ static const CGFloat kHMargin = 15.0;
 }
 
 - (void)updateConstraints {
-    CGFloat labelMinWidth = self.maxLabelWidth;
+    CGFloat labelWidth = self.maxLabelWidth;
     CGFloat boundWidth = self.expectedLayoutWidth;
     
     id labelLabel = self.labelLabel, textFieldView = _textFieldView;
     NSDictionary *dictionary = NSDictionaryOfVariableBindings(labelLabel,textFieldView);
     ORKEnableAutoLayoutForViews([dictionary allValues]);
     
-    NSDictionary *metrics = @{@"vMargin":@(10), @"hMargin":@(self.separatorInset.left), @"hSpacer":@(16), @"vSpacer":@(15), @"labelMinWidth": @(labelMinWidth)};
+    NSDictionary *metrics = @{@"vMargin":@(10), @"hMargin":@(self.separatorInset.left), @"hSpacer":@(16), @"vSpacer":@(15), @"labelWidth": @(labelWidth)};
     
     [self.contentView removeConstraints:self.myConstraints];
     
     self.myConstraints = [NSMutableArray new];
     
-    if ((labelMinWidth) >= 0.5*boundWidth) {
+    CGFloat fieldWidth = _textFieldView.estimatedWidth;
+    
+    if ( labelWidth >= 0.5*boundWidth || (fieldWidth + labelWidth) > 0.9*boundWidth ) {
 
         [self.myConstraints addObjectsFromArray:
          [NSLayoutConstraint constraintsWithVisualFormat:@"H:|-hMargin-[labelLabel]-hMargin-|" options:NSLayoutFormatDirectionLeadingToTrailing metrics:metrics views:dictionary]];
@@ -289,7 +291,7 @@ static const CGFloat kHMargin = 15.0;
     } else {
         
         [self.myConstraints addObjectsFromArray:
-         [NSLayoutConstraint constraintsWithVisualFormat:@"H:|-hMargin-[labelLabel(==labelMinWidth)]-hSpacer-[textFieldView]|" options:NSLayoutFormatAlignAllCenterY metrics:metrics views:dictionary]];
+         [NSLayoutConstraint constraintsWithVisualFormat:@"H:|-hMargin-[labelLabel(==labelWidth)]-hSpacer-[textFieldView]|" options:NSLayoutFormatAlignAllCenterY metrics:metrics views:dictionary]];
         
         [self.myConstraints addObject:
          [NSLayoutConstraint constraintWithItem:labelLabel attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:self.contentView attribute:NSLayoutAttributeCenterY multiplier:1.0 constant:0]];

--- a/ResearchKit/Common/ORKFormItemCell.m
+++ b/ResearchKit/Common/ORKFormItemCell.m
@@ -277,6 +277,7 @@ static const CGFloat kHMargin = 15.0;
     
     CGFloat fieldWidth = _textFieldView.estimatedWidth;
     
+    // Leave half space for field, also be able to display placeholder in full.
     if ( labelWidth >= 0.5*boundWidth || (fieldWidth + labelWidth) > 0.9*boundWidth ) {
 
         [self.myConstraints addObjectsFromArray:

--- a/ResearchKit/Common/ORKTextFieldView.h
+++ b/ResearchKit/Common/ORKTextFieldView.h
@@ -60,6 +60,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, readonly) ORKUnitTextField *textField;
 
+@property (nonatomic, readonly) CGFloat estimatedWidth;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKTextFieldView.m
+++ b/ResearchKit/Common/ORKTextFieldView.m
@@ -390,8 +390,9 @@ static const UIEdgeInsets paddingGuess = (UIEdgeInsets){.left = 6, .right=6};
         textAndUnit = [textAndUnit stringByAppendingString:unitString];
     }
     
-    CGFloat fieldWidth = [textAndUnit sizeWithAttributes:@{ NSFontAttributeName : self.textField.font }].width;
-    fieldWidth = MAX([placeholderAndUnit sizeWithAttributes:@{ NSFontAttributeName : self.textField.font }].width, fieldWidth);
+    NSDictionary *attributes = @{ NSFontAttributeName : self.textField.font };
+    CGFloat fieldWidth = MAX([placeholderAndUnit sizeWithAttributes:attributes].width,
+                             [textAndUnit sizeWithAttributes:attributes].width);
     
     return fieldWidth;
 }

--- a/ResearchKit/Common/ORKTextFieldView.m
+++ b/ResearchKit/Common/ORKTextFieldView.m
@@ -379,5 +379,22 @@ static const UIEdgeInsets paddingGuess = (UIEdgeInsets){.left = 6, .right=6};
     [super updateConstraints];
 }
 
+- (CGFloat)estimatedWidth {
+    
+    NSString *placeholderAndUnit = self.textField.placeholder;
+    NSString *textAndUnit = self.textField.text;
+    
+    if (self.textField.unit.length > 0) {
+        NSString *unitString = [NSString stringWithFormat:@"  %@", self.textField.unit];
+        placeholderAndUnit = [placeholderAndUnit stringByAppendingString:unitString];
+        textAndUnit = [textAndUnit stringByAppendingString:unitString];
+    }
+    
+    CGFloat fieldWidth = [textAndUnit sizeWithAttributes:@{ NSFontAttributeName : self.textField.font }].width;
+    fieldWidth = MAX([placeholderAndUnit sizeWithAttributes:@{ NSFontAttributeName : self.textField.font }].width, fieldWidth);
+    
+    return fieldWidth;
+}
+
 
 @end


### PR DESCRIPTION
Take _textFieldView's estimatedWidth into consideration when building the constraints for textFieldBasedformItemCell.

- implemented _textFieldView.estimatedWidth to return the larger value of text+unit and placeholder+unit 

<img width="747" alt="screen shot 2015-08-28 at 6 07 26 pm" src="https://cloud.githubusercontent.com/assets/11466704/9559808/ac9724c2-4daf-11e5-839d-dc1a792dce6d.png">
