### PR TITLE
Fixed the graph view and time label overlapping.

### DIFF
--- a/ResearchKit/ActiveTasks/ORKAudioContentView.m
+++ b/ResearchKit/ActiveTasks/ORKAudioContentView.m
@@ -64,23 +64,6 @@ static const CGFloat kValueLineMargin = 1.5;
 - (instancetype)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
-        NSLayoutConstraint *constraint1 = [NSLayoutConstraint constraintWithItem:self
-                                                                       attribute:NSLayoutAttributeWidth
-                                                                       relatedBy:NSLayoutRelationEqual
-                                                                          toItem:nil
-                                                                       attribute:NSLayoutAttributeNotAnAttribute
-                                                                      multiplier:1
-                                                                        constant:CGFLOAT_MAX];
-        constraint1.priority = UILayoutPriorityFittingSizeLevel;
-        NSLayoutConstraint *constraint2 = [NSLayoutConstraint constraintWithItem:self
-                                                              attribute:NSLayoutAttributeHeight
-                                                              relatedBy:NSLayoutRelationEqual
-                                                                 toItem:nil
-                                                                       attribute:NSLayoutAttributeNotAnAttribute
-                                                                      multiplier:1
-                                                                        constant:CGFLOAT_MAX];
-        constraint2.priority = UILayoutPriorityFittingSizeLevel;
-        [NSLayoutConstraint activateConstraints:@[constraint1, constraint2]];
         
 #if TARGET_IPHONE_SIMULATOR
         _values = @[@(0.2),@(0.6),@(0.55), @(0.1), @(0.75), @(0.7)];


### PR DESCRIPTION
This issue happens on iPhone only.
Some how, it works after I removed the constraints in GraphView.

![img_0808](https://cloud.githubusercontent.com/assets/11466704/9621075/d102c7f6-50d6-11e5-914f-f0a2d5070a5c.PNG)

