### PR TITLE
Charts: add lightweight generics to all array declarations

### DIFF
--- a/ResearchKit/Charts/ORKCenteredCollectionViewLayout.m
+++ b/ResearchKit/Charts/ORKCenteredCollectionViewLayout.m
@@ -32,8 +32,8 @@
 
 @implementation ORKCenteredCollectionViewLayout
 
-- (NSArray *)layoutAttributesForElementsInRect:(CGRect)rect {
-    NSArray *attributesArray = [super layoutAttributesForElementsInRect:rect];
+- (NSArray<UICollectionViewLayoutAttributes *> *)layoutAttributesForElementsInRect:(CGRect)rect {
+    NSArray<UICollectionViewLayoutAttributes *> *attributesArray = [super layoutAttributesForElementsInRect:rect];
     for (UICollectionViewLayoutAttributes *attributes in attributesArray) {
         attributes.frame = [self layoutAttributesForItemAtIndexPath:attributes.indexPath].frame;
     }

--- a/ResearchKit/Charts/ORKDiscreteGraphChartView.m
+++ b/ResearchKit/Charts/ORKDiscreteGraphChartView.m
@@ -61,9 +61,9 @@
 }
 
 - (void)updateLineLayersForPlotIndex:(NSInteger)plotIndex {
-    NSUInteger pointCount = ((NSArray *)self.dataPoints[plotIndex]).count;
+    NSUInteger pointCount = self.dataPoints[plotIndex].count;
     for (NSUInteger pointIndex = 0; pointIndex < pointCount; pointIndex++) {
-        ORKRangedPoint *dataPointValue = [self dataPointAtPlotIndex:plotIndex pointIndex:pointIndex];
+        ORKRangedPoint *dataPointValue = self.dataPoints[plotIndex][pointIndex];
         if (!dataPointValue.isUnset && !dataPointValue.hasEmptyRange) {
             CAShapeLayer *lineLayer = graphLineLayer();
             lineLayer.strokeColor = [self colorForplotIndex:plotIndex].CGColor;
@@ -79,10 +79,10 @@
     NSUInteger lineLayerIndex = 0;
     CGFloat positionOnXAxis = ORKCGFloatInvalidValue;
     ORKRangedPoint *positionOnYAxis = nil;
-    NSUInteger pointCount = ((NSArray *)self.yAxisPoints[plotIndex]).count;
+    NSUInteger pointCount = self.yAxisPoints[plotIndex].count;
     for (NSUInteger pointIndex = 0; pointIndex < pointCount; pointIndex++) {
         
-        ORKRangedPoint *dataPointValue = [self dataPointAtPlotIndex:plotIndex pointIndex:pointIndex];
+        ORKRangedPoint *dataPointValue = self.dataPoints[plotIndex][pointIndex];
         
         if (!dataPointValue.isUnset && !dataPointValue.hasEmptyRange) {
             
@@ -90,7 +90,7 @@
             
             positionOnXAxis = xAxisPoint(pointIndex, self.numberOfXAxisPoints, self.plotView.bounds.size.width);
             positionOnXAxis += [self offsetForPlotIndex:plotIndex];
-            positionOnYAxis = ((ORKRangedPoint *)self.yAxisPoints[plotIndex][pointIndex]);
+            positionOnYAxis = self.yAxisPoints[plotIndex][pointIndex];
             
             [linePath moveToPoint:CGPointMake(positionOnXAxis, positionOnYAxis.minimumValue)];
             [linePath addLineToPoint:CGPointMake(positionOnXAxis, positionOnYAxis.maximumValue)];
@@ -127,7 +127,7 @@
     CGFloat canvasYPosition = 0;
     if (snapped) {
         NSInteger pointIndex = [self pointIndexForXPosition:xPosition];
-        canvasYPosition = ((ORKRangedPoint *)self.yAxisPoints[plotIndex][pointIndex-1]).maximumValue;
+        canvasYPosition = self.yAxisPoints[plotIndex][pointIndex-1].maximumValue;
     }
     return canvasYPosition;
 }

--- a/ResearchKit/Charts/ORKGraphChartView.m
+++ b/ResearchKit/Charts/ORKGraphChartView.m
@@ -71,8 +71,8 @@ static const CGFloat ScrubberLabelVerticalPadding = 4.0;
     ORKYAxisView *_yAxisView;
     BOOL _hasDataPoints;
     CAShapeLayer *_horizontalReferenceLineLayer;
-    NSMutableArray *_verticalReferenceLineLayers;
-    NSMutableArray *_pointLayers;
+    NSMutableArray<CALayer *> *_verticalReferenceLineLayers;
+    NSMutableArray<NSMutableArray<CALayer *> *> *_pointLayers;
     UILabel *_scrubberLabel;
     UIView *_scrubberThumbView;
 }
@@ -239,12 +239,12 @@ static const CGFloat ScrubberLabelVerticalPadding = 4.0;
 - (void)updatePlotColors {
     for (NSUInteger plotIndex = 0; plotIndex < _lineLayers.count; plotIndex++) {
         UIColor *color = [self colorForplotIndex:plotIndex];
-        for (NSUInteger pointIndex = 0; pointIndex < ((NSArray *)_lineLayers[plotIndex]).count; pointIndex++) {
+        for (NSUInteger pointIndex = 0; pointIndex < _lineLayers[plotIndex].count; pointIndex++) {
             CAShapeLayer *lineLayer = _lineLayers[plotIndex][pointIndex];
             lineLayer.strokeColor = color.CGColor;
         }
-        for (NSUInteger pointIndex = 0; pointIndex < ((NSArray *)_pointLayers[plotIndex]).count; pointIndex++) {
-            CAShapeLayer *pointLayer = _pointLayers[plotIndex][pointIndex];
+        for (NSUInteger pointIndex = 0; pointIndex < _pointLayers[plotIndex].count; pointIndex++) {
+            CALayer *pointLayer = _pointLayers[plotIndex][pointIndex];
             pointLayer.contents = (__bridge id)(graphPointLayerImageWithColor(color).CGImage);
         }
     }
@@ -363,7 +363,7 @@ inline static CALayer *graphVerticalReferenceLineLayerWithColor(UIColor *color, 
         }
 
         // Add dummy points for empty data points
-        NSInteger emptyPointsCount = self.numberOfXAxisPoints - ((NSArray *)_dataPoints[plotIndex]).count;
+        NSInteger emptyPointsCount = self.numberOfXAxisPoints - _dataPoints[plotIndex].count;
         for (NSInteger idx = 0; idx < emptyPointsCount; idx++) {
             ORKRangedPoint *dummyPoint = [[ORKRangedPoint alloc] init];
             [_dataPoints[plotIndex] addObject:dummyPoint];
@@ -512,7 +512,7 @@ inline static CALayer *graphPointLayerWithColor(UIColor *color) {
     
     NSInteger numberOfPlots = [self numberOfPlots];
     for (NSInteger plotIndex = 0; plotIndex < numberOfPlots; plotIndex++) {
-        NSMutableArray *currentPlotPointLayers = [NSMutableArray new];
+        NSMutableArray<CALayer *> *currentPlotPointLayers = [NSMutableArray new];
         [_pointLayers addObject:currentPlotPointLayers];
         [self updatePointLayersForPlotIndex:plotIndex];
     }
@@ -523,15 +523,11 @@ inline static CALayer *graphPointLayerWithColor(UIColor *color) {
     }
 }
 
-- (ORKRangedPoint *)dataPointAtPlotIndex:(NSUInteger)plotIndex pointIndex:(NSUInteger)pointIndex {
-    return _dataPoints[plotIndex][pointIndex];
-}
-
 - (void)updatePointLayersForPlotIndex:(NSInteger)plotIndex {
     UIColor *color = [self colorForplotIndex:plotIndex];
-    NSUInteger pointCount = ((NSArray *)_dataPoints[plotIndex]).count;
+    NSUInteger pointCount = _dataPoints[plotIndex].count;
     for (NSUInteger pointIndex = 0; pointIndex < pointCount; pointIndex++) {
-        ORKRangedPoint *dataPoint = [self dataPointAtPlotIndex:plotIndex pointIndex:pointIndex];
+        ORKRangedPoint *dataPoint = _dataPoints[plotIndex][pointIndex];
         if (!dataPoint.isUnset) {
             CALayer *pointLayer = graphPointLayerWithColor(color);
             [_plotView.layer addSublayer:pointLayer];
@@ -561,18 +557,18 @@ inline static CALayer *graphPointLayerWithColor(UIColor *color) {
 
 - (void)layoutPointLayersForPlotIndex:(NSInteger)plotIndex {
     NSUInteger pointLayerIndex = 0;
-    for (NSUInteger pointIndex = 0; pointIndex < ((NSArray *)_dataPoints[plotIndex]).count; pointIndex++) {
-        ORKRangedPoint *dataPointValue = [self dataPointAtPlotIndex:plotIndex pointIndex:pointIndex];
+    for (NSUInteger pointIndex = 0; pointIndex < _dataPoints[plotIndex].count; pointIndex++) {
+        ORKRangedPoint *dataPointValue = _dataPoints[plotIndex][pointIndex];
         if (!dataPointValue.isUnset) {
             CGFloat positionOnXAxis = xAxisPoint(pointIndex, self.numberOfXAxisPoints, _plotView.bounds.size.width);
             positionOnXAxis += [self offsetForPlotIndex:plotIndex];
             ORKRangedPoint *positionOnYAxis = (ORKRangedPoint *)_yAxisPoints[plotIndex][pointIndex];
-            CAShapeLayer *pointLayer = _pointLayers[plotIndex][pointLayerIndex];
+            CALayer *pointLayer = _pointLayers[plotIndex][pointLayerIndex];
             pointLayer.position = CGPointMake(positionOnXAxis, positionOnYAxis.minimumValue);
             pointLayerIndex++;
             
             if (!positionOnYAxis.hasEmptyRange) {
-                CAShapeLayer *pointLayer = _pointLayers[plotIndex][pointLayerIndex];
+                CALayer *pointLayer = _pointLayers[plotIndex][pointLayerIndex];
                 pointLayer.position = CGPointMake(positionOnXAxis, positionOnYAxis.maximumValue);
                 pointLayerIndex++;
             }
@@ -589,7 +585,7 @@ inline static CALayer *graphPointLayerWithColor(UIColor *color) {
     NSInteger numberOfPlots = [self numberOfPlots];
     for (NSInteger plotIndex = 0; plotIndex < numberOfPlots; plotIndex++) {
         // Add array even if it should not draw lines so all layer arays have the same number of elements for animating purposes
-        NSMutableArray *currentPlotLineLayers = [NSMutableArray new];
+        NSMutableArray<CAShapeLayer *> *currentPlotLineLayers = [NSMutableArray new];
         [self.lineLayers addObject:currentPlotLineLayers];
         if ([self shouldDrawLinesForPlotIndex:plotIndex]) {
             [self updateLineLayersForPlotIndex:plotIndex];
@@ -772,10 +768,10 @@ inline static CALayer *graphPointLayerWithColor(UIColor *color) {
 - (CGFloat)snappedXPosition:(CGFloat)xPosition plotIndex:(NSInteger)plotIndex {
     CGFloat numberOfXAxisPoints = self.numberOfXAxisPoints;
     CGFloat widthBetweenPoints = CGRectGetWidth(_plotView.frame) / numberOfXAxisPoints;
-    NSUInteger positionCount = ((NSArray *)_dataPoints[plotIndex]).count;
+    NSUInteger positionCount = _dataPoints[plotIndex].count;
     for (NSUInteger positionIndex = 0; positionIndex < positionCount; positionIndex++) {
         
-        CGFloat dataPointValue = [self dataPointAtPlotIndex:plotIndex pointIndex:positionIndex].maximumValue;
+        CGFloat dataPointValue = _dataPoints[plotIndex][positionIndex].maximumValue;
         
         if (dataPointValue != ORKCGFloatInvalidValue) {
             CGFloat value = xAxisPoint(positionIndex, numberOfXAxisPoints, _plotView.bounds.size.width);
@@ -800,7 +796,7 @@ inline static CALayer *graphPointLayerWithColor(UIColor *color) {
                 break;
             }
         }
-        value = [self dataPointAtPlotIndex:plotIndex pointIndex:positionIndex].maximumValue;
+        value = _dataPoints[plotIndex][positionIndex].maximumValue;
     }
     return value;
 }
@@ -857,18 +853,18 @@ inline static CALayer *graphPointLayerWithColor(UIColor *color) {
     
     for (NSUInteger plotIndex = 0; plotIndex < _pointLayers.count; plotIndex++) {
       
-        NSUInteger numberOfPoints = ((NSArray *)_pointLayers[plotIndex]).count;
+        NSUInteger numberOfPoints = _pointLayers[plotIndex].count;
         if (numberOfPoints > 0) {
             CGFloat pointFadeDuration = duration / numberOfPoints;
             CGFloat pointDelay = 0.0;
             for (NSUInteger pointIndex = 0; pointIndex < numberOfPoints; pointIndex++) {
-                CAShapeLayer *layer = _pointLayers[plotIndex][pointIndex];
+                CALayer *layer = _pointLayers[plotIndex][pointIndex];
                 [self animateLayer:layer keyPath:@"opacity" duration:pointFadeDuration startDelay:pointDelay];
                 pointDelay += pointFadeDuration;
             }
         }
 
-        NSUInteger numberOfLines = ((NSArray *)_lineLayers[plotIndex]).count;
+        NSUInteger numberOfLines = _lineLayers[plotIndex].count;
         if (numberOfLines > 0) {
             CGFloat lineFadeDuration = duration / numberOfLines;
             CGFloat lineDelay = 0.0;
@@ -881,7 +877,7 @@ inline static CALayer *graphPointLayerWithColor(UIColor *color) {
     }
 }
 
-- (void)animateLayer:(CAShapeLayer *)layer
+- (void)animateLayer:(CALayer *)layer
              keyPath:(NSString *)keyPath
             duration:(CGFloat)duration
           startDelay:(CGFloat)startDelay {
@@ -922,14 +918,14 @@ inline static CALayer *graphPointLayerWithColor(UIColor *color) {
     return count;
 }
 
-- (NSArray *)normalizedCanvasPointsForPlotIndex:(NSInteger)plotIndex canvasHeight:(CGFloat)viewHeight {
-    NSMutableArray *normalizedPoints = [NSMutableArray new];
+- (NSMutableArray<ORKRangedPoint *> *)normalizedCanvasPointsForPlotIndex:(NSInteger)plotIndex canvasHeight:(CGFloat)viewHeight {
+    NSMutableArray<ORKRangedPoint *> *normalizedPoints = [NSMutableArray new];
     
-    NSUInteger pointCount = ((NSArray *)_dataPoints[plotIndex]).count;
+    NSUInteger pointCount = _dataPoints[plotIndex].count;
     for (NSUInteger pointIndex = 0; pointIndex < pointCount; pointIndex++) {
         
         ORKRangedPoint *normalizedRangePoint = [ORKRangedPoint new];
-        ORKRangedPoint *dataPointValue = [self dataPointAtPlotIndex:plotIndex pointIndex:pointIndex];
+        ORKRangedPoint *dataPointValue = _dataPoints[plotIndex][pointIndex];
         
         if (dataPointValue.isUnset) {
             normalizedRangePoint.minimumValue = normalizedRangePoint.maximumValue = viewHeight;
@@ -946,7 +942,7 @@ inline static CALayer *graphPointLayerWithColor(UIColor *color) {
         [normalizedPoints addObject:normalizedRangePoint];
     }
     
-    return [normalizedPoints copy];
+    return normalizedPoints;
 }
 
 - (void)calculateMinAndMaxValues {
@@ -969,9 +965,9 @@ inline static CALayer *graphPointLayerWithColor(UIColor *color) {
     if (!minimumValueProvided || !maximumValueProvided) {
         NSInteger numberOfPlots = [self numberOfPlots];
         for (NSInteger plotIndex = 0; plotIndex < numberOfPlots; plotIndex++) {
-            NSInteger numberOfPlotPoints = ((NSArray *)_dataPoints[plotIndex]).count;
+            NSInteger numberOfPlotPoints = _dataPoints[plotIndex].count;
             for (NSInteger pointIndex = 0; pointIndex < numberOfPlotPoints; pointIndex++) {
-                ORKRangedPoint *point = [self dataPointAtPlotIndex:plotIndex pointIndex:pointIndex];
+                ORKRangedPoint *point = _dataPoints[plotIndex][pointIndex];
                 if (!minimumValueProvided &&
                     point.minimumValue != ORKCGFloatInvalidValue &&
                     ((_minimumValue == ORKCGFloatInvalidValue) || (point.minimumValue < _minimumValue))) {
@@ -1052,7 +1048,7 @@ inline static CALayer *graphPointLayerWithColor(UIColor *color) {
 
 - (void)_axCreateAccessibilityElements {
     NSInteger maxNumberOfPoints = [[_dataPoints valueForKeyPath:@"@max.@count.self"] integerValue];
-    NSMutableArray *accessibilityElements = [[NSMutableArray alloc] initWithCapacity:maxNumberOfPoints];
+    NSMutableArray<id> *accessibilityElements = [[NSMutableArray alloc] initWithCapacity:maxNumberOfPoints];
     
     for (NSInteger pointIndex = 0; pointIndex < maxNumberOfPoints; pointIndex++) {
         ORKLineGraphAccessibilityElement *element = [[ORKLineGraphAccessibilityElement alloc] initWithAccessibilityContainer:self index:pointIndex maxIndex:maxNumberOfPoints];
@@ -1064,7 +1060,7 @@ inline static CALayer *graphPointLayerWithColor(UIColor *color) {
             // Boundary check
             if ( pointIndex < [_dataPoints[plotIndex] count] ) {
                 NSString *and = (value == nil || value.length == 0 ? nil : ORKLocalizedString(@"AX_GRAPH_AND_SEPARATOR", nil));
-                ORKRangedPoint *rangePoint = [self dataPointAtPlotIndex:plotIndex pointIndex:pointIndex];
+                ORKRangedPoint *rangePoint = _dataPoints[plotIndex][pointIndex];
                 value = ORKAccessibilityStringForVariables(value, and, rangePoint.accessibilityLabel);
             }
         }

--- a/ResearchKit/Charts/ORKGraphChartView.m
+++ b/ResearchKit/Charts/ORKGraphChartView.m
@@ -562,7 +562,7 @@ inline static CALayer *graphPointLayerWithColor(UIColor *color) {
         if (!dataPointValue.isUnset) {
             CGFloat positionOnXAxis = xAxisPoint(pointIndex, self.numberOfXAxisPoints, _plotView.bounds.size.width);
             positionOnXAxis += [self offsetForPlotIndex:plotIndex];
-            ORKRangedPoint *positionOnYAxis = (ORKRangedPoint *)_yAxisPoints[plotIndex][pointIndex];
+            ORKRangedPoint *positionOnYAxis = _yAxisPoints[plotIndex][pointIndex];
             CALayer *pointLayer = _pointLayers[plotIndex][pointLayerIndex];
             pointLayer.position = CGPointMake(positionOnXAxis, positionOnYAxis.minimumValue);
             pointLayerIndex++;

--- a/ResearchKit/Charts/ORKGraphChartView_Internal.h
+++ b/ResearchKit/Charts/ORKGraphChartView_Internal.h
@@ -65,13 +65,13 @@ static inline CGFloat xAxisPoint(NSInteger pointIndex, CGFloat numberOfXAxisPoin
 
 @interface ORKGraphChartView ()
 
-@property (nonatomic) NSMutableArray *lineLayers;
+@property (nonatomic) NSMutableArray<NSMutableArray<CAShapeLayer *> *> *lineLayers;
 
 @property (nonatomic) NSInteger numberOfXAxisPoints;
 
-@property (nonatomic) NSMutableArray *dataPoints; // Actual data
+@property (nonatomic) NSMutableArray<NSMutableArray<ORKRangedPoint *> *> *dataPoints; // Actual data
 
-@property (nonatomic) NSMutableArray *yAxisPoints; // Normalized for the plot view height
+@property (nonatomic) NSMutableArray<NSMutableArray<ORKRangedPoint *> *> *yAxisPoints; // Normalized for the plot view height
 
 @property (nonatomic) UIView *plotView; // Holds the plots
 
@@ -82,8 +82,6 @@ static inline CGFloat xAxisPoint(NSInteger pointIndex, CGFloat numberOfXAxisPoin
 - (void)sharedInit;
 
 - (NSInteger)numberOfPlots;
-
-- (ORKRangedPoint *)dataPointAtPlotIndex:(NSUInteger)plotIndex pointIndex:(NSUInteger)pointIndex;
 
 - (CGFloat)offsetForPlotIndex:(NSInteger)plotIndex;
 

--- a/ResearchKit/Charts/ORKLineGraphChartView.m
+++ b/ResearchKit/Charts/ORKLineGraphChartView.m
@@ -75,9 +75,9 @@ const CGFloat FillColorAlpha = 0.4;
 - (void)updateLineLayersForPlotIndex:(NSInteger)plotIndex {
     BOOL previousPointExists = NO;
     BOOL emptyDataPresent = NO;
-    NSUInteger pointCount = ((NSArray *)self.dataPoints[plotIndex]).count;
+    NSUInteger pointCount = self.dataPoints[plotIndex].count;
     for (NSUInteger pointIndex = 0; pointIndex < pointCount; pointIndex++) {
-        if ([self dataPointAtPlotIndex:plotIndex pointIndex:pointIndex].isUnset) {
+        if (self.dataPoints[plotIndex][pointIndex].isUnset) {
             emptyDataPresent = YES;
             continue;
         }
@@ -121,9 +121,9 @@ const CGFloat FillColorAlpha = 0.4;
     CGFloat positionOnXAxis = ORKCGFloatInvalidValue;
     ORKRangedPoint *positionOnYAxis = nil;
     BOOL previousPointExists = NO;
-    NSUInteger pointCount = ((NSArray *)self.yAxisPoints[plotIndex]).count;
+    NSUInteger pointCount = self.yAxisPoints[plotIndex].count;
     for (NSUInteger pointIndex = 0; pointIndex < pointCount; pointIndex++) {
-        if ([self dataPointAtPlotIndex:plotIndex pointIndex:pointIndex].isUnset) {
+        if (self.dataPoints[plotIndex][pointIndex].isUnset) {
             continue;
         }
         
@@ -139,7 +139,7 @@ const CGFloat FillColorAlpha = 0.4;
         }
         
         positionOnXAxis = xAxisPoint(pointIndex, self.numberOfXAxisPoints, self.plotView.bounds.size.width);
-        positionOnYAxis = (ORKRangedPoint *)self.yAxisPoints[plotIndex][pointIndex];
+        positionOnYAxis = self.yAxisPoints[plotIndex][pointIndex];
         
         if (!previousPointExists) {
             continue;
@@ -181,8 +181,8 @@ const CGFloat FillColorAlpha = 0.4;
         CGFloat x1 = xAxisPoint(previousValidIndex, numberOfXAxisPoints, viewWidth);
         CGFloat x2 = xAxisPoint(nextValidIndex, numberOfXAxisPoints, viewWidth);
         
-        CGFloat y1 = [self dataPointAtPlotIndex:plotIndex pointIndex:previousValidIndex].minimumValue;
-        CGFloat y2 = [self dataPointAtPlotIndex:plotIndex pointIndex:nextValidIndex].minimumValue;
+        CGFloat y1 = self.dataPoints[plotIndex][previousValidIndex].minimumValue;
+        CGFloat y2 = self.dataPoints[plotIndex][nextValidIndex].minimumValue;
         
         if (y1 == ORKCGFloatInvalidValue || y2 == ORKCGFloatInvalidValue) {
             return ORKCGFloatInvalidValue;
@@ -207,8 +207,8 @@ const CGFloat FillColorAlpha = 0.4;
     CGFloat x1 = xAxisPoint(previousValidIndex, numberOfXAxisPoints, viewWidth);
     CGFloat x2 = xAxisPoint(nextValidIndex, numberOfXAxisPoints, viewWidth);
     
-    CGFloat y1 = ((ORKRangedPoint *)self.yAxisPoints[plotIndex][previousValidIndex]).minimumValue;
-    CGFloat y2 = ((ORKRangedPoint *)self.yAxisPoints[plotIndex][nextValidIndex]).minimumValue;
+    CGFloat y1 = self.yAxisPoints[plotIndex][previousValidIndex].minimumValue;
+    CGFloat y2 = self.yAxisPoints[plotIndex][nextValidIndex].minimumValue;
         
     CGFloat slope = (y2 - y1)/(x2 - x1);
     
@@ -221,9 +221,9 @@ const CGFloat FillColorAlpha = 0.4;
 - (NSInteger)nextValidPointIndexForPointIndex:(NSInteger)pointIndex plotIndex:(NSInteger)plotIndex {
     NSUInteger validPosition = pointIndex;
     
-    NSUInteger pointCountMinusOne = (((NSArray *)self.dataPoints[plotIndex]).count - 1);
+    NSUInteger pointCountMinusOne = (self.dataPoints[plotIndex].count - 1);
     while (validPosition < pointCountMinusOne) {
-        if ([self dataPointAtPlotIndex:plotIndex pointIndex:validPosition].maximumValue != ORKCGFloatInvalidValue) {
+        if (self.dataPoints[plotIndex][validPosition].maximumValue != ORKCGFloatInvalidValue) {
             break;
         }
         validPosition++;
@@ -235,7 +235,7 @@ const CGFloat FillColorAlpha = 0.4;
 - (NSInteger)previousValidPointIndexForPointIndex:(NSInteger)pointIndex plotIndex:(NSInteger)plotIndex {
     NSInteger validPosition = pointIndex - 1;
     while (validPosition > 0) {
-        if ([self dataPointAtPlotIndex:plotIndex pointIndex:validPosition].minimumValue != ORKCGFloatInvalidValue) {
+        if (self.dataPoints[plotIndex][validPosition].minimumValue != ORKCGFloatInvalidValue) {
             break;
         }
         validPosition--;

--- a/ResearchKit/Charts/ORKPieChartLegendCell.m
+++ b/ResearchKit/Charts/ORKPieChartLegendCell.m
@@ -74,7 +74,7 @@ const CGFloat DotToLabelPadding = 6.0;
 #pragma mark - Layout
 
 - (void)setUpConstraints {
-    NSMutableArray *constraints = [NSMutableArray new];
+    NSMutableArray<NSLayoutConstraint *> *constraints = [NSMutableArray new];
     NSDictionary *views = NSDictionaryOfVariableBindings(_titleLabel, _dotView);
     
     [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=0)-[_titleLabel]-(>=0)-|"

--- a/ResearchKit/Charts/ORKPieChartLegendView.m
+++ b/ResearchKit/Charts/ORKPieChartLegendView.m
@@ -96,7 +96,7 @@
 }
 
 - (void)animateWithDuration:(NSTimeInterval)animationDuration {
-    NSArray *sortedCells = [self.visibleCells sortedArrayUsingComparator:^NSComparisonResult(UICollectionViewCell *cell1, UICollectionViewCell *cell2) {
+    NSArray<UICollectionViewCell *> *sortedCells = [self.visibleCells sortedArrayUsingComparator:^NSComparisonResult(UICollectionViewCell *cell1, UICollectionViewCell *cell2) {
         return cell1.tag > cell2.tag;
     }];
     NSUInteger cellCount = sortedCells.count;

--- a/ResearchKit/Charts/ORKPieChartPieView.m
+++ b/ResearchKit/Charts/ORKPieChartPieView.m
@@ -44,9 +44,9 @@ static const CGFloat InterAnimationDelay = 0.05;
     __weak ORKPieChartView *_parentPieChartView;
     
     CAShapeLayer *_circleLayer;
-    NSMutableArray *_normalizedValues;
-    NSMutableArray *_segmentLayers;
-    NSMutableArray *_pieSections;
+    NSMutableArray<NSNumber *> *_normalizedValues;
+    NSMutableArray<CAShapeLayer *> *_segmentLayers;
+    NSMutableArray<ORKPieChartSection *> *_pieSections;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
@@ -158,7 +158,7 @@ static const CGFloat InterAnimationDelay = 0.05;
         segmentLayer.path = _circleLayer.path;
         segmentLayer.lineWidth = _circleLayer.lineWidth;
         segmentLayer.strokeColor = [_parentPieChartView colorForSegmentAtIndex:idx].CGColor;
-        CGFloat value = ((NSNumber *)_normalizedValues[idx]).floatValue;
+        CGFloat value = _normalizedValues[idx].floatValue;
         
         if (value != 0) {
             if (idx == 0) {
@@ -186,7 +186,7 @@ static const CGFloat InterAnimationDelay = 0.05;
         CGFloat cumulativeValue = 0;
         NSInteger numberOfSegments = [_parentPieChartView.dataSource numberOfSegmentsInPieChartView:_parentPieChartView];
         for (NSInteger idx = 0; idx < numberOfSegments; idx++) {
-            CGFloat value = ((NSNumber *)_normalizedValues[idx]).floatValue;
+            CGFloat value = _normalizedValues[idx].floatValue;
             
             if (value != 0) {
                 
@@ -246,7 +246,7 @@ static const CGFloat InterAnimationDelay = 0.05;
     CGFloat cumulativeValue = 0;
     NSInteger numberOfSegments = [_parentPieChartView.dataSource numberOfSegmentsInPieChartView:_parentPieChartView];
     for (NSInteger idx = 0; idx < numberOfSegments; idx++) {
-        CGFloat value = ((NSNumber *)_normalizedValues[idx]).floatValue;
+        CGFloat value = _normalizedValues[idx].floatValue;
         if (value != 0) {
             // Create a label
             ORKPieChartSection *pieSection = _pieSections[idx];
@@ -287,7 +287,7 @@ static const CGFloat InterAnimationDelay = 0.05;
     return  CGPointMake(x, y);
 }
 
-- (void)adjustIntersectionsOfPercentageLabels:(NSArray *)pieSections pieRadius:(CGFloat)pieRadius {
+- (void)adjustIntersectionsOfPercentageLabels:(NSArray<ORKPieChartSection *> *)pieSections pieRadius:(CGFloat)pieRadius {
     if (pieSections.count == 0) {
         return;
     }
@@ -372,7 +372,7 @@ static const CGFloat InterAnimationDelay = 0.05;
     CGFloat cumulativeValue = 0;
     for (NSInteger idx = 0; idx < numberOfSegmentLayers ; idx++) {
         CAShapeLayer *segmentLayer = _segmentLayers[idx];
-        CGFloat value = ((NSNumber *)_normalizedValues[idx]).floatValue;
+        CGFloat value = _normalizedValues[idx].floatValue;
         CABasicAnimation *strokeAnimation = [CABasicAnimation animationWithKeyPath:@"strokeEnd"];
         strokeAnimation.fromValue = @(segmentLayer.strokeStart);
         strokeAnimation.toValue = @(cumulativeValue + value);
@@ -401,7 +401,7 @@ static const CGFloat InterAnimationDelay = 0.05;
 
 #pragma mark - Accessibility
 
-- (NSArray *)accessibilityElements {
+- (NSArray<id> *)accessibilityElements {
     return _pieSections;
 }
 

--- a/ResearchKit/Charts/ORKPieChartTitleTextView.m
+++ b/ResearchKit/Charts/ORKPieChartTitleTextView.m
@@ -40,7 +40,7 @@
 @implementation ORKPieChartTitleTextView  {
     __weak ORKPieChartView *_parentPieChartView;
     
-    NSMutableArray *_variableConstraints;
+    NSMutableArray<NSLayoutConstraint *> *_variableConstraints;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
@@ -87,7 +87,7 @@
 }
 
 - (void)setUpConstraints {
-    NSMutableArray *constraints = [NSMutableArray new];
+    NSMutableArray<NSLayoutConstraint *> *constraints = [NSMutableArray new];
     [constraints addObject:[NSLayoutConstraint constraintWithItem:_titleLabel
                                                         attribute:NSLayoutAttributeCenterX
                                                         relatedBy:NSLayoutRelationEqual
@@ -159,12 +159,12 @@
 
 #pragma mark - Accessibility
 
-- (NSArray *)accessibilityElements {
+- (NSArray<id> *)accessibilityElements {
     if (!_titleLabel || !_textLabel || !_noDataLabel) {
         return nil;
     }
     
-    NSMutableArray *accessibilityElements = [[NSMutableArray alloc] init];
+    NSMutableArray<id> *accessibilityElements = [[NSMutableArray alloc] init];
     if (!_noDataLabel.hidden) {
         [accessibilityElements addObject:_noDataLabel];
     } else {

--- a/ResearchKit/Charts/ORKPieChartView.m
+++ b/ResearchKit/Charts/ORKPieChartView.m
@@ -72,7 +72,7 @@ static const CGFloat PieToLegendPadding = 8.0;
 
 
 @implementation ORKPieChartView {
-    NSMutableArray *_variableConstraints;
+    NSMutableArray<NSLayoutConstraint *> *_variableConstraints;
 
     ORKPieChartPieView *_pieView;
     ORKPieChartLegendView *_legendView;
@@ -218,7 +218,7 @@ static const CGFloat PieToLegendPadding = 8.0;
 }
 
 - (void)setUpConstraints {
-    NSMutableArray *constraints = [NSMutableArray new];
+    NSMutableArray<NSLayoutConstraint *> *constraints = [NSMutableArray new];
     NSDictionary *views = NSDictionaryOfVariableBindings(_pieView);
     [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_pieView]|"
                                                                              options:(NSLayoutFormatOptions)0
@@ -368,8 +368,8 @@ static const CGFloat PieToLegendPadding = 8.0;
     return NO;
 }
 
-- (NSArray *)accessibilityElements {
-    NSMutableArray *accessibilityElements = [[NSMutableArray alloc] init];
+- (NSArray<id> *)accessibilityElements {
+    NSMutableArray<id> *accessibilityElements = [[NSMutableArray alloc] init];
     [accessibilityElements addObjectsFromArray:_titleTextView.accessibilityElements];
     
     // Use legends if there are any and percentage labels if not

--- a/ResearchKit/Charts/ORKXAxisView.m
+++ b/ResearchKit/Charts/ORKXAxisView.m
@@ -40,8 +40,8 @@ static const CGFloat LastLabelHeight = 20.0;
 @implementation ORKXAxisView {
     __weak ORKGraphChartView *_parentGraphChartView;
     CALayer *_lineLayer;
-    NSMutableArray *_titleLabels;
-    NSMutableArray *_titleTickLayers;
+    NSMutableArray<UILabel *> *_titleLabels;
+    NSMutableArray<CALayer *> *_titleTickLayers;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
@@ -77,11 +77,11 @@ static const CGFloat LastLabelHeight = 20.0;
         titleTickLayer.frame = CGRectMake(positionOnXAxis - 0.5, -ORKGraphChartViewAxisTickLength, 1, ORKGraphChartViewAxisTickLength);
         index++;
     }
-    ((UILabel *)_titleLabels.lastObject).layer.cornerRadius = LastLabelHeight * 0.5;
+    _titleLabels.lastObject.layer.cornerRadius = LastLabelHeight * 0.5;
 }
 
 - (void)setUpConstraints {
-    NSMutableArray *constraints = [NSMutableArray new];
+    NSMutableArray<NSLayoutConstraint *> *constraints = [NSMutableArray new];
     
     NSUInteger numberOfTitleLabels = _titleLabels.count;
     for (NSUInteger i = 0; i < numberOfTitleLabels; i++) {

--- a/ResearchKit/Charts/ORKYAxisView.m
+++ b/ResearchKit/Charts/ORKYAxisView.m
@@ -38,8 +38,6 @@ static const CGFloat ImageVerticalPadding = 3.0;
 
 @implementation ORKYAxisView {
     __weak ORKGraphChartView *_parentGraphChartView;
-    NSMutableArray *_titleTickLayers;
-    
     UIImageView *_maxImageView;
     UIImageView *_minImageView;
     


### PR DESCRIPTION
Add *lightweight generics* to all array declarations in the *chart* files.

This allows to remove all the *array-accessing casts*. Also a few incorrect `CALayer *` to `CAShapeLayer *` casts were detected and fixed.
 
I have also removed the `dataPointAtPlotIndex:pointIndex:` method since it no longer provides any advantage over directly accessing the *generics-parametrized array*.