### PR TITLE
uialertview tintColor fix

### DIFF
--- a/ResearchKit/Consent/ORKConsentReviewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewController.m
@@ -148,6 +148,8 @@
                                                                    message:self.localizedReasonForConsent
                                                             preferredStyle:UIAlertControllerStyleAlert];
     
+    alert.view.tintColor = self.view.tintColor;
+
     [alert addAction:[UIAlertAction actionWithTitle:ORKLocalizedString(@"BUTTON_CANCEL", nil) style:UIAlertActionStyleDefault handler:nil]];
     [alert addAction:[UIAlertAction actionWithTitle:ORKLocalizedString(@"BUTTON_AGREE", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
         // Have to dispatch, so following transition animation works

--- a/ResearchKit/Consent/ORKConsentSignatureFormatter.m
+++ b/ResearchKit/Consent/ORKConsentSignatureFormatter.m
@@ -46,11 +46,11 @@
     BOOL addedSig = NO;
 
     NSMutableArray *signatureElements = [NSMutableArray array];
+    NSString *nameStr = @"&nbsp;";
 
     // Signature
     if (signature.requiresName || signature.familyName || signature.givenName) {
         addedSig = YES;
-        NSString *nameStr = @"&nbsp;";
         if (signature.familyName || signature.givenName) {
             NSMutableArray *names = [NSMutableArray array];
             if (signature.givenName) {
@@ -79,7 +79,7 @@
         } else {
             [body appendString:@"<br/>"];
         }
-        NSString *titleFormat = ORKLocalizedString(@"CONSENT_DOC_LINE_SIGNATURE", nil);
+        NSString *titleFormat = [NSString stringWithFormat:ORKLocalizedString(@"CONSENT_DOC_LINE_SIGNATURE", nil), nameStr];
         [signatureElements addObject:[NSString stringWithFormat:signatureElementWrapper, imageTag?:@"&nbsp;", hr, [NSString stringWithFormat:titleFormat, signature.title]]];
     }
 

--- a/ResearchKit/Consent/ORKConsentSignatureFormatter.m
+++ b/ResearchKit/Consent/ORKConsentSignatureFormatter.m
@@ -65,7 +65,7 @@
             nameStr = [names componentsJoinedByString:@"&nbsp;"];
         }
 
-        NSString *titleFormat = ORKLocalizedString(@"CONSENT_DOC_LINE_PRINTED_NAME", nil);
+        NSString *titleFormat = [NSString stringWithFormat:ORKLocalizedString(@"CONSENT_DOC_LINE_PRINTED_NAME", nil),nameStr];
         [signatureElements addObject:[NSString stringWithFormat:signatureElementWrapper, nameStr, hr, [NSString stringWithFormat:titleFormat,signature.title]]];
     }
 


### PR DESCRIPTION
I noticed that setting a tintColor for ORKConsentReview does not affect the tintColor of the alert.
This commit forces uialertview to use the same tint color of the view in order to avoid color issue