### PR TITLE
Add another convenient constructor for ORKQuestionStep

### DIFF
--- a/ResearchKit/Common/ORKQuestionStep.h
+++ b/ResearchKit/Common/ORKQuestionStep.h
@@ -73,7 +73,7 @@ ORK_CLASS_AVAILABLE
  
  @param identifier    The identifier of the step (a step identifier should be unique within the task).
  @param title         A localized string that represents the primary text of the question.
- @param text          A localized string that represents the additional text of the question..
+ @param text          A localized string that represents the additional text of the question.
  @param answerFormat  The format in which the answer is expected.
  */
 + (instancetype)questionStepWithIdentifier:(NSString *)identifier

--- a/ResearchKit/Common/ORKQuestionStep.h
+++ b/ResearchKit/Common/ORKQuestionStep.h
@@ -69,6 +69,19 @@ ORK_CLASS_AVAILABLE
                                     answer:(nullable ORKAnswerFormat *)answerFormat;
 
 /**
+ Returns a new question step that includes the specified identifier, title, text, and answer format.
+ 
+ @param identifier    The identifier of the step (a step identifier should be unique within the task).
+ @param title         A localized string that represents the primary text of the question.
+ @param text          A localized string that represents the additional text of the question..
+ @param answerFormat  The format in which the answer is expected.
+ */
++ (instancetype)questionStepWithIdentifier:(NSString *)identifier
+                                     title:(nullable NSString *)title
+                                      text:(nullable NSString *)text
+                                    answer:(nullable ORKAnswerFormat *)answerFormat;
+
+/**
  The format of the answer.
  
  For example, the answer format might include the type of data to collect, the constraints

--- a/ResearchKit/Common/ORKQuestionStep.m
+++ b/ResearchKit/Common/ORKQuestionStep.m
@@ -53,6 +53,18 @@
     return step;
 }
 
++ (instancetype)questionStepWithIdentifier:(NSString *)identifier
+                                     title:(nullable NSString *)title
+                                      text:(nullable NSString *)text
+                                    answer:(nullable ORKAnswerFormat *)answerFormat {
+
+    ORKQuestionStep *step = [[ORKQuestionStep alloc] initWithIdentifier:identifier];
+    step.title = title;
+    step.text = text;
+    step.answerFormat = answerFormat;
+    return step;
+}
+
 - (instancetype)initWithIdentifier:(NSString *)identifier {
     
     self = [super initWithIdentifier:identifier];


### PR DESCRIPTION
The `text` attribute is often missed by developers.