### PR TITLE
iPad: fix separator inset in 'numeric' and 'text' questions

### DIFF
--- a/ResearchKit/Common/ORKSurveyAnswerCell.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCell.m
@@ -57,6 +57,7 @@
         _answer = answer;
         self.step  = step;
         self.answer = answer;
+        self.clipsToBounds = YES;
     }
     return self;
 }

--- a/ResearchKit/Common/ORKTableViewCell.m
+++ b/ResearchKit/Common/ORKTableViewCell.m
@@ -71,11 +71,12 @@
 }
 
 - (void)updateSeparatorInsets {
+    
     if (self.topSeparatorLeftInset > 0) {
-        self.topSeparatorLeftInset = ORKStandardHorizontalMarginForView(self);
+        self.topSeparatorLeftInset = ORKStandardLeftMarginForTableViewCell(self);
     }
     if (self.bottomSeparatorLeftInset > 0) {
-        self.bottomSeparatorLeftInset = ORKStandardHorizontalMarginForView(self);
+        self.bottomSeparatorLeftInset = ORKStandardLeftMarginForTableViewCell(self);
     }
 }
 


### PR DESCRIPTION
Fixes the separator inset in the *numeric* and *test* questions on *iPad*.

Before:
---
![simulator screen shot 4 sep 2015 20 10 35](https://cloud.githubusercontent.com/assets/444313/9692442/06e856bc-5341-11e5-946c-d65a7afecac4.png)
---

After:
---
![simulator screen shot 4 sep 2015 20 06 53](https://cloud.githubusercontent.com/assets/444313/9692398/b782d99e-5340-11e5-9880-e16c007b6975.png)
---