### PR TITLE
ORKGraphChartView: fix accessibility crash when 'graphChartView:titleForXAxisAtPointIndex:' is not implemented

### DIFF
--- a/ResearchKit/Charts/ORKGraphChartView.h
+++ b/ResearchKit/Charts/ORKGraphChartView.h
@@ -204,12 +204,12 @@ ORK_AVAILABLE_DECL
  See also: `numberOfDivisionsInXAxisForGraphChartView:`.
 
  @param graphChartView  The graph chart view asking for the tile.
- @param index           The index of the specified x-axis division.
+ @param pointIndex      The index of the specified x-axis division.
 
  @return The title string to be displayed adjacent to each division of the x-axis of the graph chart
  view.
 */
-- (NSString *)graphChartView:(ORKGraphChartView *)graphChartView titleForXAxisAtIndex:(NSInteger)index;
+- (NSString *)graphChartView:(ORKGraphChartView *)graphChartView titleForXAxisAtPointIndex:(NSInteger)pointIndex;
 
 @end
 

--- a/ResearchKit/Charts/ORKGraphChartView.m
+++ b/ResearchKit/Charts/ORKGraphChartView.m
@@ -1066,7 +1066,11 @@ inline static CALayer *graphPointLayerWithColor(UIColor *color) {
             }
         }
         
-        element.accessibilityLabel = [self.dataSource graphChartView:self titleForXAxisAtIndex:pointIndex];
+        if ([_dataSource respondsToSelector:@selector(pieChartView:titleForSegmentAtIndex:)]) {
+            element.accessibilityLabel = [self.dataSource graphChartView:self titleForXAxisAtPointIndex:pointIndex];
+        } else {
+            element.accessibilityLabel = [[NSString alloc] initWithFormat:ORKLocalizedString(@"AX_CHART_POINT_%@", nil), @(pointIndex).stringValue];
+        }
         element.accessibilityValue = value;
         [accessibilityElements addObject:element];
     }

--- a/ResearchKit/Charts/ORKXAxisView.m
+++ b/ResearchKit/Charts/ORKXAxisView.m
@@ -148,13 +148,13 @@ static const CGFloat LastLabelHeight = 20.0;
     _titleLabels = nil;
     _titleTickLayers = nil;
     
-    if ([_parentGraphChartView.dataSource respondsToSelector:@selector(graphChartView:titleForXAxisAtIndex:)]) {
+    if ([_parentGraphChartView.dataSource respondsToSelector:@selector(graphChartView:titleForXAxisAtPointIndex:)]) {
         _titleLabels = [NSMutableArray new];
         _titleTickLayers = [NSMutableArray new];
 
         NSInteger numberOfTitleLabels = _parentGraphChartView.numberOfXAxisPoints;
         for (NSInteger i = 0; i < numberOfTitleLabels; i++) {
-            NSString *title = [_parentGraphChartView.dataSource graphChartView:_parentGraphChartView titleForXAxisAtIndex:i];
+            NSString *title = [_parentGraphChartView.dataSource graphChartView:_parentGraphChartView titleForXAxisAtPointIndex:i];
             UILabel *label = [UILabel new];
             label.text = title;
             label.font = _titleFont;

--- a/ResearchKit/Localized/en.lproj/Localizable.strings
+++ b/ResearchKit/Localized/en.lproj/Localizable.strings
@@ -317,3 +317,4 @@
 
 "AX_GRAPH_RANGE_FORMAT" = "Range from %@ to %@";
 "AX_GRAPH_AND_SEPARATOR" = " and ";
+"AX_GRAPH_POINT_%@" = "Point: %@";


### PR DESCRIPTION
This PR fixes a crash when `graphChartView:titleForXAxisAtPointIndex:` (which is an optional method) is not implemented. Unfortunately, this fix needs new localized strings.