### PR TITLE
Charts: update ORKCatalog to use new data source method (convergence)

### DIFF
--- a/samples/ORKCatalog/ORKCatalog/Charts/ChartDataSources.swift
+++ b/samples/ORKCatalog/ORKCatalog/Charts/ChartDataSources.swift
@@ -98,7 +98,7 @@ class LineGraphDataSource: NSObject, ORKGraphChartViewDataSource {
         return 0
     }
     
-    func graphChartView(graphChartView: ORKGraphChartView, titleForXAxisAtIndex pointIndex: Int) -> String {
+    func graphChartView(graphChartView: ORKGraphChartView, titleForXAxisAtPointIndex pointIndex: Int) -> String {
         return "\(pointIndex + 1)"
     }
 }
@@ -137,7 +137,7 @@ class DiscreteGraphDataSource: NSObject, ORKGraphChartViewDataSource {
         return plotPoints[plotIndex].count
     }
     
-    func graphChartView(graphChartView: ORKGraphChartView, titleForXAxisAtIndex pointIndex: Int) -> String {
+    func graphChartView(graphChartView: ORKGraphChartView, titleForXAxisAtPointIndex pointIndex: Int) -> String {
         return "\(pointIndex + 1)"
     }
 


### PR DESCRIPTION
Sorry, I forgot to update `ORKCatalog` as well.