### PR TITLE
ORKFormItem: implement 'optional' property

### DIFF
--- a/ResearchKit/Common/ORKFormStep.h
+++ b/ResearchKit/Common/ORKFormStep.h
@@ -46,8 +46,15 @@ NS_ASSUME_NONNULL_BEGIN
  When the task completes, the user's answers are encoded in the result hierarchy
  in the task view controller.
  
- Each question in the form is represented by an `ORKFormItem` object. The form
- can be broken into sections by using an `ORKFormItem` object that includes only a section title.
+ Each question in the form is represented by an `ORKFormItem` object. The form items have an
+ `optional` property that defaults to `YES`. All non-optional questions need to be answered for the
+ Continue button to be enabled. If all the form items are optional, at least one question needs to
+ be answered for the Continue button to be enabled. You can allow the user to completely skip a
+ form step using the Skip button, even if it has non-optional form items, by setting the form step
+ `optional` property to yes.
+ 
+ The form can be broken into sections by using an `ORKFormItem` object that includes only a section
+ title.
  
  The result of a form step is an `ORKStepResult` object that includes a child `ORKQuestionResult`
  object for each form item.
@@ -131,8 +138,8 @@ ORK_CLASS_AVAILABLE
 /**
  A Boolean value indicating whether the form item is optional.
  
- The default value of this property is `NO`. When the value is `YES`, this form item doesn't need
- to be answered for the Continue/Done button of a step form to be enabled.
+ The default value of this property is `YES`. When the value is `YES`, this form item doesn't need
+ to be answered for the Continue button of a step form to be enabled.
  */
 @property (nonatomic, getter=isOptional) BOOL optional;
 

--- a/ResearchKit/Common/ORKFormStep.h
+++ b/ResearchKit/Common/ORKFormStep.h
@@ -129,6 +129,14 @@ ORK_CLASS_AVAILABLE
 @property (nonatomic, copy, readonly) NSString *identifier;
 
 /**
+ A Boolean value indicating whether the form item is optional.
+ 
+ The default value of this property is `NO`. When the value is `YES`, this form item doesn't need
+ to be answered for the Continue/Done button of a step form to be enabled.
+ */
+@property (nonatomic, getter=isOptional) BOOL optional;
+
+/**
  A localized string that describes the form item.
  
  If the descriptive text is sufficiently short, you can display it as a prompt next to the item.

--- a/ResearchKit/Common/ORKFormStep.h
+++ b/ResearchKit/Common/ORKFormStep.h
@@ -47,10 +47,10 @@ NS_ASSUME_NONNULL_BEGIN
  in the task view controller.
  
  Each question in the form is represented by an `ORKFormItem` object. The form items have an
- `optional` property that defaults to `YES`. All non-optional questions need to be answered for the
+ `optional` property that defaults to `YES`. All required questions need to be answered for the
  Continue button to be enabled. If all the form items are optional, at least one question needs to
  be answered for the Continue button to be enabled. You can allow the user to completely skip a
- form step using the Skip button, even if it has non-optional form items, by setting the form step
+ form step using the Skip button, even if it has required form items, by setting the form step
  `optional` property to yes.
  
  The form can be broken into sections by using an `ORKFormItem` object that includes only a section

--- a/ResearchKit/Common/ORKFormStep.m
+++ b/ResearchKit/Common/ORKFormStep.m
@@ -143,7 +143,7 @@
     self = [super init];
     if (self) {
         ORKThrowInvalidArgumentExceptionIfNil(identifier);
-        
+        _optional = NO;
         _identifier = [identifier copy];
         _text = [text copy];
         _answerFormat = [answerFormat copy];
@@ -165,7 +165,8 @@
 
 - (instancetype)copyWithZone:(NSZone *)zone {
     ORKFormItem *item = [[[self class] allocWithZone:zone] initWithIdentifier:[_identifier copy] text:[_text copy] answerFormat:[_answerFormat copy]];
-    item.placeholder = self.placeholder;
+    item.optional = _optional;
+    item.placeholder = _placeholder;
     return item;
 }
 
@@ -173,6 +174,7 @@
     self = [super init];
     if (self) {
         ORK_DECODE_OBJ_CLASS(aDecoder, identifier, NSString);
+        ORK_DECODE_BOOL(aDecoder, optional);
         ORK_DECODE_OBJ_CLASS(aDecoder, text, NSString);
         ORK_DECODE_OBJ_CLASS(aDecoder, placeholder, NSString);
         ORK_DECODE_OBJ_CLASS(aDecoder, answerFormat, ORKAnswerFormat);
@@ -183,6 +185,7 @@
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
     ORK_ENCODE_OBJ(aCoder, identifier);
+    ORK_ENCODE_BOOL(aCoder, optional);
     ORK_ENCODE_OBJ(aCoder, text);
     ORK_ENCODE_OBJ(aCoder, placeholder);
     ORK_ENCODE_OBJ(aCoder, answerFormat);
@@ -198,6 +201,7 @@
     // Ignore the step reference - it's not part of the content of this item
     __typeof(self) castObject = object;
     return (ORKEqualObjects(self.identifier, castObject.identifier)
+            && self.optional == castObject.optional
             && ORKEqualObjects(self.text, castObject.text)
             && ORKEqualObjects(self.placeholder, castObject.placeholder)
             && ORKEqualObjects(self.answerFormat, castObject.answerFormat));
@@ -205,7 +209,7 @@
 
 - (NSUInteger)hash {
      // Ignore the step reference - it's not part of the content of this item
-    return [_identifier hash] ^ [_text hash] ^ [_placeholder hash] ^ [_answerFormat hash];
+    return [_identifier hash] ^ [_text hash] ^ [_placeholder hash] ^ [_answerFormat hash] ^ (_optional ? 0xf : 0x0);
 }
 
 - (ORKAnswerFormat *)impliedAnswerFormat {

--- a/ResearchKit/Common/ORKFormStep.m
+++ b/ResearchKit/Common/ORKFormStep.m
@@ -143,7 +143,7 @@
     self = [super init];
     if (self) {
         ORKThrowInvalidArgumentExceptionIfNil(identifier);
-        _optional = NO;
+        _optional = YES;
         _identifier = [identifier copy];
         _text = [text copy];
         _answerFormat = [answerFormat copy];

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -1512,7 +1512,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     
     {
         
-        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_002" title:@"Non-optional form step" text:nil];
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_002" title:@"Required form step" text:nil];
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_001"
                                                                text:@"Value"
                                                        answerFormat:[ORKNumericAnswerFormat valuePickerAnswerFormatWithTextChoices:@[@"1", @"2", @"3"]]];
@@ -1546,7 +1546,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     NSMutableArray *steps = [NSMutableArray new];
     
     {
-        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_000" title:@"Optional Form Items" text:@"Optional form with all optional items"];
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_000" title:@"Optional Form Items" text:@"Optional form with no required items"];
         NSMutableArray *items = [NSMutableArray new];
         [steps addObject:step];
         
@@ -1577,7 +1577,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     }
     
     {
-        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_001" title:@"Optional Form Items" text:@"Optional form with some optional items"];
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_001" title:@"Optional Form Items" text:@"Optional form with some required items"];
         NSMutableArray *items = [NSMutableArray new];
         [steps addObject:step];
         
@@ -1605,7 +1605,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         }
         
         {
-            ORKFormItem *item = [[ORKFormItem alloc] initWithSectionTitle:@"Non-optional"];
+            ORKFormItem *item = [[ORKFormItem alloc] initWithSectionTitle:@"Required"];
             [items addObject:item];
         }
 
@@ -1631,12 +1631,12 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     }
 
     {
-        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_002" title:@"Optional Form Items" text:@"Optional form with no optional items"];
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_002" title:@"Optional Form Items" text:@"Optional form with all items required"];
         NSMutableArray *items = [NSMutableArray new];
         [steps addObject:step];
         
         {
-            ORKFormItem *item = [[ORKFormItem alloc] initWithSectionTitle:@"Non-optional"];
+            ORKFormItem *item = [[ORKFormItem alloc] initWithSectionTitle:@"Required"];
             [items addObject:item];
         }
 
@@ -1682,7 +1682,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     }
 
     {
-        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_003" title:@"Optional Form Items" text:@"Non-optional form with all optional items"];
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_003" title:@"Optional Form Items" text:@"Required form with no required items"];
         NSMutableArray *items = [NSMutableArray new];
         [steps addObject:step];
         
@@ -1714,7 +1714,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     }
     
     {
-        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_004" title:@"Optional Form Items" text:@"Non-optional form with some optional items"];
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_004" title:@"Optional Form Items" text:@"Required form with some required items"];
         NSMutableArray *items = [NSMutableArray new];
         [steps addObject:step];
         
@@ -1742,7 +1742,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         }
         
         {
-            ORKFormItem *item = [[ORKFormItem alloc] initWithSectionTitle:@"Non-optional"];
+            ORKFormItem *item = [[ORKFormItem alloc] initWithSectionTitle:@"Required"];
             [items addObject:item];
         }
 
@@ -1769,12 +1769,12 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     }
 
     {
-        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_005" title:@"Optional Form Items" text:@"Non-optional form with no optional items"];
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_005" title:@"Optional Form Items" text:@"Required form with all items required"];
         NSMutableArray *items = [NSMutableArray new];
         [steps addObject:step];
         
         {
-            ORKFormItem *item = [[ORKFormItem alloc] initWithSectionTitle:@"Non-optional"];
+            ORKFormItem *item = [[ORKFormItem alloc] initWithSectionTitle:@"Required"];
             [items addObject:item];
         }
 

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -41,29 +41,33 @@
 
 #define DefineStringKey(x) static NSString *const x = @#x
 
-DefineStringKey(DatePickingTaskIdentifier);
-DefineStringKey(SelectionSurveyTaskIdentifier);
-DefineStringKey(ActiveStepTaskIdentifier);
-DefineStringKey(ConsentReviewTaskIdentifier);
 DefineStringKey(ConsentTaskIdentifier);
-DefineStringKey(MiniFormTaskIdentifier);
-DefineStringKey(ScreeningTaskIdentifier);
-DefineStringKey(ScalesTaskIdentifier);
-DefineStringKey(ImageChoicesTaskIdentifier);
+DefineStringKey(ConsentReviewTaskIdentifier);
+
+DefineStringKey(DatePickingTaskIdentifier);
 DefineStringKey(ImageCaptureTaskIdentifier);
+DefineStringKey(ImageChoicesTaskIdentifier);
+DefineStringKey(ScalesTaskIdentifier);
+DefineStringKey(MiniFormTaskIdentifier);
+DefineStringKey(OptionalFormTaskIdentifier);
+DefineStringKey(SelectionSurveyTaskIdentifier);
+
+DefineStringKey(ActiveStepTaskIdentifier);
 DefineStringKey(AudioTaskIdentifier);
-DefineStringKey(ToneAudiometryTaskIdentifier);
 DefineStringKey(FitnessTaskIdentifier);
 DefineStringKey(GaitTaskIdentifier);
 DefineStringKey(MemoryTaskIdentifier);
-DefineStringKey(DynamicTaskIdentifier);
-DefineStringKey(TwoFingerTapTaskIdentifier);
-DefineStringKey(ReactionTimeTaskIdentifier);
-DefineStringKey(TowerOfHanoiTaskIdentifier);
-DefineStringKey(TimedWalkTaskIdentifier);
 DefineStringKey(PSATTaskIdentifier);
-DefineStringKey(StepNavigationTaskIdentifier);
+DefineStringKey(ReactionTimeTaskIdentifier);
+DefineStringKey(ScreeningTaskIdentifier);
+DefineStringKey(TimedWalkTaskIdentifier);
+DefineStringKey(ToneAudiometryTaskIdentifier);
+DefineStringKey(TowerOfHanoiTaskIdentifier);
+DefineStringKey(TwoFingerTapTaskIdentifier);
+
 DefineStringKey(CustomNavigationItemTaskIdentifier);
+DefineStringKey(DynamicTaskIdentifier);
+DefineStringKey(StepNavigationTaskIdentifier);
 
 DefineStringKey(CollectionViewHeaderReuseIdentifier);
 DefineStringKey(CollectionViewCellReuseIdentifier);
@@ -259,6 +263,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                            @"Image Choices",
                            @"Scale",
                            @"Mini Form",
+                           @"Optional Form",
                            @"Selection Survey",
                            ],
                        @[ // Active Tasks
@@ -364,6 +369,8 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         return task;
     } else if ([identifier isEqualToString:MiniFormTaskIdentifier]) {
         return [self makeMiniFormTask];
+    } else if ([identifier isEqualToString:OptionalFormTaskIdentifier]) {
+        return [self makeOptionalFormTask];
     } else if ([identifier isEqualToString:FitnessTaskIdentifier]) {
         return [ORKOrderedTask fitnessCheckTaskWithIdentifier:FitnessTaskIdentifier
                                        intendedUseDescription:nil
@@ -1171,7 +1178,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
          A short form for testing behavior when loading multiple HealthKit
          default values on the same form.
          */
-        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_000" title:@"Mini Form" text:@"Mini Form groups multi-entry in one page"];
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_000" title:@"Mini Form" text:@"Mini form groups multi-entry in one page"];
         NSMutableArray *items = [NSMutableArray new];
         [steps addObject:step];
         
@@ -1224,7 +1231,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
          A long "kitchen-sink" form with all the different types of supported
          answer formats.
          */
-        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_001" title:@"Mini Form" text:@"Mini Form groups multi-entry in one page"];
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_001" title:@"Mini Form" text:@"Mini form groups multi-entry in one page"];
         NSMutableArray *items = [NSMutableArray new];
         
         {
@@ -1504,7 +1511,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     
     {
         
-        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_002" title:@"Non optional form step" text:nil];
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_002" title:@"Non-optional form step" text:nil];
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_001"
                                                                text:@"Value"
                                                        answerFormat:[ORKNumericAnswerFormat valuePickerAnswerFormatWithTextChoices:@[@"1", @"2", @"3"]]];
@@ -1527,6 +1534,253 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
 
 - (IBAction)miniFormButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:MiniFormTaskIdentifier];
+}
+
+#pragma mark - Mini form task
+
+/*
+ The optional form task is used to test form items' optional functionality (`ORKFormStep`, `ORKFormItem`).
+ */
+- (id<ORKTask>)makeOptionalFormTask {
+    NSMutableArray *steps = [NSMutableArray new];
+    
+    {
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_000" title:@"Optional Form Items" text:@"Optional form with all optional items"];
+        NSMutableArray *items = [NSMutableArray new];
+        [steps addObject:step];
+        
+        {
+            ORKTextAnswerFormat *format = [ORKAnswerFormat textAnswerFormatWithMaximumLength:12];
+            format.multipleLines = NO;
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text3"
+                                                                   text:@"Text (optional)"
+                                                           answerFormat:format];
+            item.optional = YES;
+            item.placeholder = @"Input any text here.";
+            [items addObject:item];
+        }
+        
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text4"
+                                                                   text:@"Number (optional)"
+                                                           answerFormat:[ORKNumericAnswerFormat decimalAnswerFormatWithUnit:nil]];
+            item.optional = YES;
+            item.placeholder = @"Input any number here.";
+            [items addObject:item];
+        }
+        
+        [step setFormItems:items];
+    }
+    
+    {
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_001" title:@"Optional Form Items" text:@"Optional form with some optional items"];
+        NSMutableArray *items = [NSMutableArray new];
+        [steps addObject:step];
+        
+        ORKTextAnswerFormat *format = [ORKAnswerFormat textAnswerFormatWithMaximumLength:12];
+        format.multipleLines = NO;
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text1"
+                                                                   text:@"Text A (optional)"
+                                                           answerFormat:format];
+            item.optional = YES;
+            item.placeholder = @"Input any text here.";
+            [items addObject:item];
+        }
+        
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text2"
+                                                                   text:@"Text B (optional)"
+                                                           answerFormat:format];
+            item.optional = YES;
+            item.placeholder = @"Input any text here.";
+            [items addObject:item];
+        }
+        
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text3"
+                                                                   text:@"Text C"
+                                                           answerFormat:format];
+            item.placeholder = @"Input any text here.";
+            [items addObject:item];
+        }
+        
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text4"
+                                                                   text:@"Number"
+                                                           answerFormat:[ORKNumericAnswerFormat decimalAnswerFormatWithUnit:nil]];
+            item.placeholder = @"Input any number here.";
+            [items addObject:item];
+        }
+        
+        [step setFormItems:items];
+    }
+
+    {
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_002" title:@"Optional Form Items" text:@"Optional form with no optional items"];
+        NSMutableArray *items = [NSMutableArray new];
+        [steps addObject:step];
+        
+        ORKTextAnswerFormat *format = [ORKAnswerFormat textAnswerFormatWithMaximumLength:12];
+        format.multipleLines = NO;
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text1"
+                                                                   text:@"Text A"
+                                                           answerFormat:format];
+            item.placeholder = @"Input any text here.";
+            [items addObject:item];
+        }
+        
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text2"
+                                                                   text:@"Text B"
+                                                           answerFormat:format];
+            item.placeholder = @"Input any text here.";
+            [items addObject:item];
+        }
+        
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text3"
+                                                                   text:@"Text C"
+                                                           answerFormat:format];
+            item.placeholder = @"Input any text here.";
+            [items addObject:item];
+        }
+        
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text4"
+                                                                   text:@"Number"
+                                                           answerFormat:[ORKNumericAnswerFormat decimalAnswerFormatWithUnit:nil]];
+            item.placeholder = @"Input any number here.";
+            [items addObject:item];
+        }
+        
+        [step setFormItems:items];
+    }
+
+    {
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_003" title:@"Optional Form Items" text:@"Non-optional form with all optional items"];
+        NSMutableArray *items = [NSMutableArray new];
+        [steps addObject:step];
+        
+        {
+            ORKTextAnswerFormat *format = [ORKAnswerFormat textAnswerFormatWithMaximumLength:6];
+            format.multipleLines = NO;
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text3"
+                                                                   text:@"Text (optional)"
+                                                           answerFormat:format];
+            item.optional = YES;
+            item.placeholder = @"Input any text here.";
+            [items addObject:item];
+        }
+        
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text4"
+                                                                   text:@"Number (optional)"
+                                                           answerFormat:[ORKNumericAnswerFormat decimalAnswerFormatWithUnit:nil]];
+            item.placeholder = @"Input any number here.";
+            item.optional = YES;
+            [items addObject:item];
+        }
+        
+        [step setFormItems:items];
+        step.optional = NO;
+    }
+    
+    {
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_004" title:@"Optional Form Items" text:@"Non-optional form with some optional items"];
+        NSMutableArray *items = [NSMutableArray new];
+        [steps addObject:step];
+        
+        ORKTextAnswerFormat *format = [ORKAnswerFormat textAnswerFormatWithMaximumLength:12];
+        format.multipleLines = NO;
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text1"
+                                                                   text:@"Text A (optional)"
+                                                           answerFormat:format];
+            item.optional = YES;
+            item.placeholder = @"Input your text here.";
+            [items addObject:item];
+        }
+        
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text2"
+                                                                   text:@"Text B (optional)"
+                                                           answerFormat:format];
+            item.optional = YES;
+            item.placeholder = @"Input your text here.";
+            [items addObject:item];
+        }
+        
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text3"
+                                                                   text:@"Text C"
+                                                           answerFormat:format];
+            item.placeholder = @"Input your text here.";
+            [items addObject:item];
+        }
+        
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text4"
+                                                                   text:@"Number"
+                                                           answerFormat:[ORKNumericAnswerFormat decimalAnswerFormatWithUnit:nil]];
+            item.placeholder = @"Input any number here.";
+            [items addObject:item];
+        }
+        
+        [step setFormItems:items];
+        step.optional = NO;
+    }
+
+    {
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_005" title:@"Optional Form Items" text:@"Non-optional form with no optional items"];
+        NSMutableArray *items = [NSMutableArray new];
+        [steps addObject:step];
+        
+        ORKTextAnswerFormat *format = [ORKAnswerFormat textAnswerFormatWithMaximumLength:12];
+        format.multipleLines = NO;
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text1"
+                                                                   text:@"Text A"
+                                                           answerFormat:format];
+            item.placeholder = @"Input any text here.";
+            [items addObject:item];
+        }
+        
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text2"
+                                                                   text:@"Text B"
+                                                           answerFormat:format];
+            item.placeholder = @"Input any text here.";
+            [items addObject:item];
+        }
+        
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text3"
+                                                                   text:@"Text C"
+                                                           answerFormat:format];
+            item.placeholder = @"Input any text here.";
+            [items addObject:item];
+        }
+        
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text4"
+                                                                   text:@"Number"
+                                                           answerFormat:[ORKNumericAnswerFormat decimalAnswerFormatWithUnit:nil]];
+            item.placeholder = @"Input any number here.";
+            [items addObject:item];
+        }
+        
+        [step setFormItems:items];
+    }
+    
+    ORKOrderedTask *task = [[ORKOrderedTask alloc] initWithIdentifier:MiniFormTaskIdentifier steps:steps];
+    
+    return task;
+}
+
+- (IBAction)optionalFormButtonTapped:(id)sender {
+    [self beginTaskWithIdentifier:OptionalFormTaskIdentifier];
 }
 
 #pragma mark - Active tasks

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -1244,6 +1244,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
             ORKFormItem *item = [[ORKFormItem alloc] initWithSectionTitle:@"Pre1"];
             [items addObject:item];
         }
+        
         {
             ORKFormItem *item = [[ORKFormItem alloc] initWithSectionTitle:@"Basic Information"];
             [items addObject:item];
@@ -1550,56 +1551,15 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         [steps addObject:step];
         
         {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithSectionTitle:@"Optional"];
+            [items addObject:item];
+        }
+
+        {
             ORKTextAnswerFormat *format = [ORKAnswerFormat textAnswerFormatWithMaximumLength:12];
             format.multipleLines = NO;
             ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text3"
-                                                                   text:@"Text (optional)"
-                                                           answerFormat:format];
-            item.optional = YES;
-            item.placeholder = @"Input any text here.";
-            [items addObject:item];
-        }
-        
-        {
-            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text4"
-                                                                   text:@"Number (optional)"
-                                                           answerFormat:[ORKNumericAnswerFormat decimalAnswerFormatWithUnit:nil]];
-            item.optional = YES;
-            item.placeholder = @"Input any number here.";
-            [items addObject:item];
-        }
-        
-        [step setFormItems:items];
-    }
-    
-    {
-        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_001" title:@"Optional Form Items" text:@"Optional form with some optional items"];
-        NSMutableArray *items = [NSMutableArray new];
-        [steps addObject:step];
-        
-        ORKTextAnswerFormat *format = [ORKAnswerFormat textAnswerFormatWithMaximumLength:12];
-        format.multipleLines = NO;
-        {
-            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text1"
-                                                                   text:@"Text A (optional)"
-                                                           answerFormat:format];
-            item.optional = YES;
-            item.placeholder = @"Input any text here.";
-            [items addObject:item];
-        }
-        
-        {
-            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text2"
-                                                                   text:@"Text B (optional)"
-                                                           answerFormat:format];
-            item.optional = YES;
-            item.placeholder = @"Input any text here.";
-            [items addObject:item];
-        }
-        
-        {
-            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text3"
-                                                                   text:@"Text C"
+                                                                   text:@"Text"
                                                            answerFormat:format];
             item.placeholder = @"Input any text here.";
             [items addObject:item];
@@ -1615,12 +1575,17 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         
         [step setFormItems:items];
     }
-
+    
     {
-        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_002" title:@"Optional Form Items" text:@"Optional form with no optional items"];
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_001" title:@"Optional Form Items" text:@"Optional form with some optional items"];
         NSMutableArray *items = [NSMutableArray new];
         [steps addObject:step];
         
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithSectionTitle:@"Optional"];
+            [items addObject:item];
+        }
+
         ORKTextAnswerFormat *format = [ORKAnswerFormat textAnswerFormatWithMaximumLength:12];
         format.multipleLines = NO;
         {
@@ -1640,9 +1605,15 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         }
         
         {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithSectionTitle:@"Non-optional"];
+            [items addObject:item];
+        }
+
+        {
             ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text3"
                                                                    text:@"Text C"
                                                            answerFormat:format];
+            item.optional = NO;
             item.placeholder = @"Input any text here.";
             [items addObject:item];
         }
@@ -1651,6 +1622,58 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
             ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text4"
                                                                    text:@"Number"
                                                            answerFormat:[ORKNumericAnswerFormat decimalAnswerFormatWithUnit:nil]];
+            item.optional = NO;
+            item.placeholder = @"Input any number here.";
+            [items addObject:item];
+        }
+        
+        [step setFormItems:items];
+    }
+
+    {
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_002" title:@"Optional Form Items" text:@"Optional form with no optional items"];
+        NSMutableArray *items = [NSMutableArray new];
+        [steps addObject:step];
+        
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithSectionTitle:@"Non-optional"];
+            [items addObject:item];
+        }
+
+        ORKTextAnswerFormat *format = [ORKAnswerFormat textAnswerFormatWithMaximumLength:12];
+        format.multipleLines = NO;
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text1"
+                                                                   text:@"Text A"
+                                                           answerFormat:format];
+            item.optional = NO;
+            item.placeholder = @"Input any text here.";
+            [items addObject:item];
+        }
+        
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text2"
+                                                                   text:@"Text B"
+                                                           answerFormat:format];
+            item.optional = NO;
+            item.placeholder = @"Input any text here.";
+            [items addObject:item];
+        }
+        
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text3"
+                                                                   text:@"Text C"
+                                                           answerFormat:format];
+            item.optional = NO;
+            item.placeholder = @"Input any text here.";
+            [items addObject:item];
+        }
+        
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text4"
+                                                                   text:@"Number"
+                                                           answerFormat:[ORKNumericAnswerFormat decimalAnswerFormatWithUnit:nil]];
+            item.optional = NO;
             item.placeholder = @"Input any number here.";
             [items addObject:item];
         }
@@ -1664,22 +1687,25 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         [steps addObject:step];
         
         {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithSectionTitle:@"Optional"];
+            [items addObject:item];
+        }
+
+        {
             ORKTextAnswerFormat *format = [ORKAnswerFormat textAnswerFormatWithMaximumLength:6];
             format.multipleLines = NO;
             ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text3"
-                                                                   text:@"Text (optional)"
+                                                                   text:@"Text"
                                                            answerFormat:format];
-            item.optional = YES;
             item.placeholder = @"Input any text here.";
             [items addObject:item];
         }
         
         {
             ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text4"
-                                                                   text:@"Number (optional)"
+                                                                   text:@"Number"
                                                            answerFormat:[ORKNumericAnswerFormat decimalAnswerFormatWithUnit:nil]];
             item.placeholder = @"Input any number here.";
-            item.optional = YES;
             [items addObject:item];
         }
         
@@ -1692,30 +1718,39 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         NSMutableArray *items = [NSMutableArray new];
         [steps addObject:step];
         
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithSectionTitle:@"Optional"];
+            [items addObject:item];
+        }
+
         ORKTextAnswerFormat *format = [ORKAnswerFormat textAnswerFormatWithMaximumLength:12];
         format.multipleLines = NO;
         {
             ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text1"
-                                                                   text:@"Text A (optional)"
+                                                                   text:@"Text A"
                                                            answerFormat:format];
-            item.optional = YES;
             item.placeholder = @"Input your text here.";
             [items addObject:item];
         }
         
         {
             ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text2"
-                                                                   text:@"Text B (optional)"
+                                                                   text:@"Text B"
                                                            answerFormat:format];
-            item.optional = YES;
             item.placeholder = @"Input your text here.";
             [items addObject:item];
         }
         
         {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithSectionTitle:@"Non-optional"];
+            [items addObject:item];
+        }
+
+        {
             ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text3"
                                                                    text:@"Text C"
                                                            answerFormat:format];
+            item.optional = NO;
             item.placeholder = @"Input your text here.";
             [items addObject:item];
         }
@@ -1724,6 +1759,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
             ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text4"
                                                                    text:@"Number"
                                                            answerFormat:[ORKNumericAnswerFormat decimalAnswerFormatWithUnit:nil]];
+            item.optional = NO;
             item.placeholder = @"Input any number here.";
             [items addObject:item];
         }
@@ -1737,12 +1773,18 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         NSMutableArray *items = [NSMutableArray new];
         [steps addObject:step];
         
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithSectionTitle:@"Non-optional"];
+            [items addObject:item];
+        }
+
         ORKTextAnswerFormat *format = [ORKAnswerFormat textAnswerFormatWithMaximumLength:12];
         format.multipleLines = NO;
         {
             ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text1"
                                                                    text:@"Text A"
                                                            answerFormat:format];
+            item.optional = NO;
             item.placeholder = @"Input any text here.";
             [items addObject:item];
         }
@@ -1751,6 +1793,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
             ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text2"
                                                                    text:@"Text B"
                                                            answerFormat:format];
+            item.optional = NO;
             item.placeholder = @"Input any text here.";
             [items addObject:item];
         }
@@ -1759,6 +1802,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
             ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text3"
                                                                    text:@"Text C"
                                                            answerFormat:format];
+            item.optional = NO;
             item.placeholder = @"Input any text here.";
             [items addObject:item];
         }
@@ -1767,11 +1811,13 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
             ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"fqid_text4"
                                                                    text:@"Number"
                                                            answerFormat:[ORKNumericAnswerFormat decimalAnswerFormatWithUnit:nil]];
+            item.optional = NO;
             item.placeholder = @"Input any number here.";
             [items addObject:item];
         }
         
         [step setFormItems:items];
+        step.optional = NO;
     }
     
     ORKOrderedTask *task = [[ORKOrderedTask alloc] initWithIdentifier:MiniFormTaskIdentifier steps:steps];

--- a/Testing/ORKTest/ORKTest/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTest/ORKESerialization.m
@@ -30,6 +30,7 @@
 
 
 #import "ORKESerialization.h"
+#import <ResearchKit/ResearchKit_Private.h>
 
 
 static NSString *ORKEStringFromDateISO8601(NSDate *date) {
@@ -585,6 +586,7 @@ ret =
         },
         (@{
           PROPERTY(identifier, NSString, NSObject, NO, nil, nil),
+          PROPERTY(optional, NSNumber, NSObject, YES, nil, nil),
           PROPERTY(text, NSString, NSObject, NO, nil, nil),
           PROPERTY(placeholder, NSString, NSObject, YES, nil, nil),
           PROPERTY(answerFormat, ORKAnswerFormat, NSObject, NO, nil, nil),


### PR DESCRIPTION
Implements `ORKFormItem`'s `optional` property ([Issue #421](https://github.com/ResearchKit/ResearchKit/issues/421)). Also adds corresponding `ORKCatalog` example.

Now the *Continue/Done* button of form steps, irregardless of them being optional, only enables if:
- At least one form item has an answer.
- All answered form items are valid.
- All the non-optional form items have answers.

The previous behaviour was that the *Continue/Done button* was enabled for *optional form steps* if at least one question was answered; and was enabled for *non-optional form step* if all answers were answered. I changed this behaviour for homogeneity between forms, and because the implemented *form step optionality* provides maximum flexibility.

The *Skip button* behaviour remains unchanged: show it for *optional form steps* and hide it for *non-optional form steps*.