### PR TITLE
Scale hide value label

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -547,6 +547,11 @@ ORK_CLASS_AVAILABLE
  */
 @property (readonly, getter=isVertical) BOOL vertical;
 
+/**
+ A Boolean value indicating whether the value label should be hidden. (read-only)
+ */
+@property (assign, getter=shouldHideValueLabel) BOOL hideValueLabel;
+
 @end
 
 

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -347,6 +347,11 @@ ORK_CLASS_AVAILABLE
  */
 @property (strong, nullable) UIImage *minimumImage;
 
+/**
+ A Boolean value indicating whether the value label should be hidden. (read-only)
+ */
+@property (assign, getter=shouldHideValueLabel) BOOL hideValueLabel;
+
 @end
 
 

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -482,6 +482,11 @@ ORK_CLASS_AVAILABLE
  */
 @property (strong, nullable) UIImage *minimumImage;
 
+/**
+ A Boolean value indicating whether the value label should be hidden. (read-only)
+ */
+@property (assign, getter=shouldHideValueLabel) BOOL hideValueLabel;
+
 @end
 
 

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -348,9 +348,9 @@ ORK_CLASS_AVAILABLE
 @property (strong, nullable) UIImage *minimumImage;
 
 /**
- A Boolean value indicating whether the value label should be hidden. (read-only)
+ A Boolean value indicating whether the selected value should be hidden. (read-only)
  */
-@property (assign, getter=shouldHideValueLabel) BOOL hideValueLabel;
+@property (assign, getter=shouldHideValueLabel) BOOL hideSelectedValue;
 
 @end
 
@@ -483,9 +483,9 @@ ORK_CLASS_AVAILABLE
 @property (strong, nullable) UIImage *minimumImage;
 
 /**
- A Boolean value indicating whether the value label should be hidden. (read-only)
+ A Boolean value indicating whether the selected value should be hidden. (read-only)
  */
-@property (assign, getter=shouldHideValueLabel) BOOL hideValueLabel;
+@property (assign, getter=shouldHideValueLabel) BOOL hideSelectedValue;
 
 @end
 
@@ -548,9 +548,9 @@ ORK_CLASS_AVAILABLE
 @property (readonly, getter=isVertical) BOOL vertical;
 
 /**
- A Boolean value indicating whether the value label should be hidden. (read-only)
+ A Boolean value indicating whether the selected value should be hidden. (read-only)
  */
-@property (assign, getter=shouldHideValueLabel) BOOL hideValueLabel;
+@property (assign, getter=shouldHideValueLabel) BOOL hideSelectedValue;
 
 @end
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1322,6 +1322,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         _vertical = vertical;
         _maximumValueDescription = maximumValueDescription;
         _minimumValueDescription = minimumValueDescription;
+        _hideValueLabel = NO;
         
         [self validateParameters];
     }
@@ -1453,6 +1454,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         ORK_DECODE_OBJ(aDecoder, minimumValueDescription);
         ORK_DECODE_IMAGE(aDecoder, maximumImage);
         ORK_DECODE_IMAGE(aDecoder, minimumImage);
+        ORK_DECODE_BOOL(aDecoder, hideValueLabel);
     }
     return self;
 }
@@ -1468,6 +1470,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     ORK_ENCODE_OBJ(aCoder, minimumValueDescription);
     ORK_ENCODE_IMAGE(aCoder, maximumImage);
     ORK_ENCODE_IMAGE(aCoder, minimumImage);
+    ORK_ENCODE_BOOL(aCoder, hideValueLabel);
 }
 
 + (BOOL)supportsSecureCoding {

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1530,6 +1530,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         _vertical = vertical;
         _maximumValueDescription = maximumValueDescription;
         _minimumValueDescription = minimumValueDescription;
+        _hideValueLabel = NO;
         
         [self validateParameters];
     }
@@ -1644,6 +1645,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         ORK_DECODE_OBJ(aDecoder, minimumValueDescription);
         ORK_DECODE_IMAGE(aDecoder, maximumImage);
         ORK_DECODE_IMAGE(aDecoder, minimumImage);
+        ORK_DECODE_BOOL(aDecoder, hideValueLabel);
     }
     return self;
 }
@@ -1660,6 +1662,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     ORK_ENCODE_OBJ(aCoder, minimumValueDescription);
     ORK_ENCODE_IMAGE(aCoder, maximumImage);
     ORK_ENCODE_IMAGE(aCoder, minimumImage);
+    ORK_ENCODE_BOOL(aCoder, hideValueLabel);
 }
 
 + (BOOL)supportsSecureCoding {

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1322,7 +1322,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         _vertical = vertical;
         _maximumValueDescription = maximumValueDescription;
         _minimumValueDescription = minimumValueDescription;
-        _hideValueLabel = NO;
+        _hideSelectedValue = NO;
         
         [self validateParameters];
     }
@@ -1454,7 +1454,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         ORK_DECODE_OBJ(aDecoder, minimumValueDescription);
         ORK_DECODE_IMAGE(aDecoder, maximumImage);
         ORK_DECODE_IMAGE(aDecoder, minimumImage);
-        ORK_DECODE_BOOL(aDecoder, hideValueLabel);
+        ORK_DECODE_BOOL(aDecoder, hideSelectedValue);
     }
     return self;
 }
@@ -1470,7 +1470,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     ORK_ENCODE_OBJ(aCoder, minimumValueDescription);
     ORK_ENCODE_IMAGE(aCoder, maximumImage);
     ORK_ENCODE_IMAGE(aCoder, minimumImage);
-    ORK_ENCODE_BOOL(aCoder, hideValueLabel);
+    ORK_ENCODE_BOOL(aCoder, hideSelectedValue);
 }
 
 + (BOOL)supportsSecureCoding {
@@ -1530,7 +1530,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         _vertical = vertical;
         _maximumValueDescription = maximumValueDescription;
         _minimumValueDescription = minimumValueDescription;
-        _hideValueLabel = NO;
+        _hideSelectedValue = NO;
         
         [self validateParameters];
     }
@@ -1645,7 +1645,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         ORK_DECODE_OBJ(aDecoder, minimumValueDescription);
         ORK_DECODE_IMAGE(aDecoder, maximumImage);
         ORK_DECODE_IMAGE(aDecoder, minimumImage);
-        ORK_DECODE_BOOL(aDecoder, hideValueLabel);
+        ORK_DECODE_BOOL(aDecoder, hideSelectedValue);
     }
     return self;
 }
@@ -1662,7 +1662,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     ORK_ENCODE_OBJ(aCoder, minimumValueDescription);
     ORK_ENCODE_IMAGE(aCoder, maximumImage);
     ORK_ENCODE_IMAGE(aCoder, minimumImage);
-    ORK_ENCODE_BOOL(aCoder, hideValueLabel);
+    ORK_ENCODE_BOOL(aCoder, hideSelectedValue);
 }
 
 + (BOOL)supportsSecureCoding {
@@ -1715,7 +1715,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         _textChoices = [textChoices copy];
         _defaultIndex = defaultIndex;
         _vertical = vertical;
-        _hideValueLabel = NO;
+        _hideSelectedValue = NO;
         
         [self validateParameters];
     }
@@ -1793,7 +1793,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         ORK_DECODE_OBJ_ARRAY(aDecoder, textChoices, ORKTextChoice);
         ORK_DECODE_INTEGER(aDecoder, defaultIndex);
         ORK_DECODE_BOOL(aDecoder, vertical);
-        ORK_DECODE_BOOL(aDecoder, hideValueLabel);
+        ORK_DECODE_BOOL(aDecoder, hideSelectedValue);
     }
     return self;
 }
@@ -1803,7 +1803,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     ORK_ENCODE_OBJ(aCoder, textChoices);
     ORK_ENCODE_INTEGER(aCoder, defaultIndex);
     ORK_ENCODE_BOOL(aCoder, vertical);
-    ORK_ENCODE_BOOL(aCoder, hideValueLabel);
+    ORK_ENCODE_BOOL(aCoder, hideSelectedValue);
 }
 
 + (BOOL)supportsSecureCoding {

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1715,6 +1715,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         _textChoices = [textChoices copy];
         _defaultIndex = defaultIndex;
         _vertical = vertical;
+        _hideValueLabel = NO;
         
         [self validateParameters];
     }
@@ -1792,6 +1793,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         ORK_DECODE_OBJ_ARRAY(aDecoder, textChoices, ORKTextChoice);
         ORK_DECODE_INTEGER(aDecoder, defaultIndex);
         ORK_DECODE_BOOL(aDecoder, vertical);
+        ORK_DECODE_BOOL(aDecoder, hideValueLabel);
     }
     return self;
 }
@@ -1801,6 +1803,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     ORK_ENCODE_OBJ(aCoder, textChoices);
     ORK_ENCODE_INTEGER(aCoder, defaultIndex);
     ORK_ENCODE_BOOL(aCoder, vertical);
+    ORK_ENCODE_BOOL(aCoder, hideValueLabel);
 }
 
 + (BOOL)supportsSecureCoding {

--- a/ResearchKit/Common/ORKAnswerFormat_Internal.h
+++ b/ResearchKit/Common/ORKAnswerFormat_Internal.h
@@ -134,6 +134,7 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTimeIntervalAnswerFormat)
 - (UIImage *)maximumImage;
 - (UIImage *)minimumImage;
 - (NSArray<ORKTextChoice *> *)textChoices;
+- (BOOL)shouldHideValueLabel;
 
 @end
 

--- a/ResearchKit/Common/ORKScaleSliderView.m
+++ b/ResearchKit/Common/ORKScaleSliderView.m
@@ -423,6 +423,14 @@
                                                      options:NSLayoutFormatAlignAllCenterY | NSLayoutFormatDirectionLeftToRight
                                                      metrics:@{@"kMargin": @(kMargin)}
                                                        views:views]];
+            
+            if ([_formatProvider shouldHideValueLabel]) {
+                [self addConstraints:
+                 [NSLayoutConstraint constraintsWithVisualFormat:@"V:[_valueLabel(==0)]"
+                                                         options:0
+                                                         metrics:nil
+                                                           views:views]];
+            }
         }
     }
     return self;

--- a/ResearchKit/Common/ORKScaleSliderView.m
+++ b/ResearchKit/Common/ORKScaleSliderView.m
@@ -388,6 +388,14 @@
                                                                  attribute:NSLayoutAttributeCenterY
                                                                 multiplier:1.0
                                                                   constant:0]];
+                
+                if ([_formatProvider shouldHideValueLabel]) {
+                    [self addConstraints:
+                     [NSLayoutConstraint constraintsWithVisualFormat:@"V:[_valueLabel(==0)]"
+                                                             options:0
+                                                             metrics:nil
+                                                               views:views]];
+                }
             }
             
         } else {

--- a/ResearchKit/Common/ORKScaleSliderView.m
+++ b/ResearchKit/Common/ORKScaleSliderView.m
@@ -388,14 +388,6 @@
                                                                  attribute:NSLayoutAttributeCenterY
                                                                 multiplier:1.0
                                                                   constant:0]];
-                
-                if ([_formatProvider shouldHideValueLabel]) {
-                    [self addConstraints:
-                     [NSLayoutConstraint constraintsWithVisualFormat:@"V:[_valueLabel(==0)]"
-                                                             options:0
-                                                             metrics:nil
-                                                               views:views]];
-                }
             }
             
         } else {
@@ -431,14 +423,17 @@
                                                      options:NSLayoutFormatAlignAllCenterY | NSLayoutFormatDirectionLeftToRight
                                                      metrics:@{@"kMargin": @(kMargin)}
                                                        views:views]];
-            
-            if ([_formatProvider shouldHideValueLabel]) {
-                [self addConstraints:
-                 [NSLayoutConstraint constraintsWithVisualFormat:@"V:[_valueLabel(==0)]"
-                                                         options:0
-                                                         metrics:nil
-                                                           views:views]];
-            }
+        }
+        
+        // Hide the value label if necessary
+        // It can't be hidden when it's a vertical text choise slider
+        if ([formatProvider shouldHideValueLabel] &&
+            !([formatProvider isVertical] && self.slider.textChoices)) {
+            [self addConstraints:
+             [NSLayoutConstraint constraintsWithVisualFormat:@"V:[_valueLabel(==0)]"
+                                                     options:0
+                                                     metrics:nil
+                                                       views:views]];
         }
     }
     return self;

--- a/Testing/ORKTest/ORKTest/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTest/ORKESerialization.m
@@ -712,7 +712,8 @@ ret =
           PROPERTY(step, NSNumber, NSObject, NO, nil, nil),
           PROPERTY(vertical, NSNumber, NSObject, NO, nil, nil),
           PROPERTY(maximumValueDescription, NSString, NSObject, NO, nil, nil),
-          PROPERTY(minimumValueDescription, NSString, NSObject, NO, nil, nil)
+          PROPERTY(minimumValueDescription, NSString, NSObject, NO, nil, nil),
+          PROPERTY(hideSelectedValue, NSNumber, NSObject, NO, nil, nil)
           })),
   ENTRY(ORKContinuousScaleAnswerFormat,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
@@ -728,7 +729,8 @@ ret =
                    ^id(id numeric) { return tableMapForward([numeric integerValue], numberFormattingStyleTable()); },
                    ^id(id string) { return @(tableMapReverse(string, numberFormattingStyleTable())); }),
           PROPERTY(maximumValueDescription, NSString, NSObject, NO, nil, nil),
-          PROPERTY(minimumValueDescription, NSString, NSObject, NO, nil, nil)
+          PROPERTY(minimumValueDescription, NSString, NSObject, NO, nil, nil),
+          PROPERTY(hideSelectedValue, NSNumber, NSObject, NO, nil, nil)
           })),
    ENTRY(ORKTextScaleAnswerFormat,
          ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
@@ -738,6 +740,7 @@ ret =
             PROPERTY(textChoices, ORKTextChoice, NSArray<ORKTextChoice *>, NO, nil, nil),
             PROPERTY(defaultIndex, NSNumber, NSObject, NO, nil, nil),
             PROPERTY(vertical, NSNumber, NSObject, NO, nil, nil),
+            PROPERTY(hideSelectedValue, NSNumber, NSObject, NO, nil, nil)
             })),
   ENTRY(ORKTextAnswerFormat,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -277,8 +277,6 @@ enum TaskListRow: Int, CustomStringConvertible {
         case ContinuousVerticalScaleQuestionStep
         case TextScaleQuestionStep
         case TextVerticalScaleQuestionStep
-        case DiscreteScaleHiddenValueLabelQuestionStep
-        case ContinuousScaleHiddenValueLabelQuestionStep
 
         // Task with an example of free text entry.
         case TextQuestionTask
@@ -615,7 +613,7 @@ enum TaskListRow: Int, CustomStringConvertible {
             questionStep3,
             questionStep4,
             questionStep5,
-            questionStep6,
+            questionStep6
             ])
     }
     

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -609,24 +609,6 @@ enum TaskListRow: Int, CustomStringConvertible {
         
         questionStep6.text = exampleDetailText
         
-        // The seventh step is a horizontal discrete scale control with ten ticks and a hidden value label.
-        let step7AnswerFormat = ORKAnswerFormat.scaleAnswerFormatWithMaximumValue(10, minimumValue: 1, defaultValue: NSIntegerMax, step: 1, vertical: false, maximumValueDescription: exampleHighValueText, minimumValueDescription: exampleLowValueText)
-        
-        step7AnswerFormat.hideValueLabel = true
-        
-        let questionStep7 = ORKQuestionStep(identifier: String(Identifier.DiscreteScaleHiddenValueLabelQuestionStep), title: exampleQuestionText, answer: step7AnswerFormat)
-        
-        questionStep7.text = exampleDetailText
-        
-        // The eight step is a vertical continuous scale control with a hidden value label.
-        let step8AnswerFormat = ORKAnswerFormat.continuousScaleAnswerFormatWithMaximumValue(1.0, minimumValue: 0.0, defaultValue: 99.0, maximumFractionDigits: 0, vertical: true, maximumValueDescription: nil, minimumValueDescription: nil)
-        
-        step8AnswerFormat.hideValueLabel = true
-        
-        let questionStep8 = ORKQuestionStep(identifier: String(Identifier.ContinuousScaleHiddenValueLabelQuestionStep), title: exampleQuestionText, answer: step8AnswerFormat)
-        
-        questionStep8.text = exampleDetailText
-        
         return ORKOrderedTask(identifier: String(Identifier.ScaleQuestionTask), steps: [
             questionStep1,
             questionStep2,
@@ -634,8 +616,6 @@ enum TaskListRow: Int, CustomStringConvertible {
             questionStep4,
             questionStep5,
             questionStep6,
-            questionStep7,
-            questionStep8
             ])
     }
     

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -613,7 +613,7 @@ enum TaskListRow: Int, CustomStringConvertible {
         
         step7AnswerFormat.hideValueLabel = true
         
-        let questionStep7 = ORKQuestionStep(identifier: String(Identifier.DiscreteScaleHiddenValueLabelQuestionStep), title: exampleQuestionText, answer: step1AnswerFormat)
+        let questionStep7 = ORKQuestionStep(identifier: String(Identifier.DiscreteScaleHiddenValueLabelQuestionStep), title: exampleQuestionText, answer: step7AnswerFormat)
         
         questionStep7.text = exampleDetailText
         

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -607,13 +607,23 @@ enum TaskListRow: Int, CustomStringConvertible {
         
         questionStep6.text = exampleDetailText
         
+        // The seventh step is a horizontal discrete scale control with ten ticks and a hidden value label.
+        let step7AnswerFormat = ORKAnswerFormat.scaleAnswerFormatWithMaximumValue(10, minimumValue: 1, defaultValue: NSIntegerMax, step: 1, vertical: false, maximumValueDescription: exampleHighValueText, minimumValueDescription: exampleLowValueText)
+        
+        step7AnswerFormat.hideValueLabel = true
+        
+        let questionStep7 = ORKQuestionStep(identifier: String(Identifier.DiscreteScaleQuestionStep), title: exampleQuestionText, answer: step1AnswerFormat)
+        
+        questionStep7.text = exampleDetailText
+        
         return ORKOrderedTask(identifier: String(Identifier.ScaleQuestionTask), steps: [
             questionStep1,
             questionStep2,
             questionStep3,
             questionStep4,
             questionStep5,
-            questionStep6
+            questionStep6,
+            questionStep7
             ])
     }
     

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -618,8 +618,8 @@ enum TaskListRow: Int, CustomStringConvertible {
         
         questionStep7.text = exampleDetailText
         
-        // The eight step is a horizontal continuous scale control with a hidden value label.
-        let step8AnswerFormat = ORKAnswerFormat.continuousScaleAnswerFormatWithMaximumValue(1.0, minimumValue: 0.0, defaultValue: 99.0, maximumFractionDigits: 0, vertical: false, maximumValueDescription: nil, minimumValueDescription: nil)
+        // The eight step is a vertical continuous scale control with a hidden value label.
+        let step8AnswerFormat = ORKAnswerFormat.continuousScaleAnswerFormatWithMaximumValue(1.0, minimumValue: 0.0, defaultValue: 99.0, maximumFractionDigits: 0, vertical: true, maximumValueDescription: nil, minimumValueDescription: nil)
         
         step8AnswerFormat.hideValueLabel = true
         

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -278,6 +278,7 @@ enum TaskListRow: Int, CustomStringConvertible {
         case TextScaleQuestionStep
         case TextVerticalScaleQuestionStep
         case DiscreteScaleHiddenValueLabelQuestionStep
+        case ContinuousScaleHiddenValueLabelQuestionStep
 
         // Task with an example of free text entry.
         case TextQuestionTask
@@ -617,6 +618,15 @@ enum TaskListRow: Int, CustomStringConvertible {
         
         questionStep7.text = exampleDetailText
         
+        // The eight step is a horizontal continuous scale control with a hidden value label.
+        let step8AnswerFormat = ORKAnswerFormat.continuousScaleAnswerFormatWithMaximumValue(1.0, minimumValue: 0.0, defaultValue: 99.0, maximumFractionDigits: 0, vertical: false, maximumValueDescription: nil, minimumValueDescription: nil)
+        
+        step8AnswerFormat.hideValueLabel = true
+        
+        let questionStep8 = ORKQuestionStep(identifier: String(Identifier.ContinuousScaleHiddenValueLabelQuestionStep), title: exampleQuestionText, answer: step8AnswerFormat)
+        
+        questionStep8.text = exampleDetailText
+        
         return ORKOrderedTask(identifier: String(Identifier.ScaleQuestionTask), steps: [
             questionStep1,
             questionStep2,
@@ -624,7 +634,8 @@ enum TaskListRow: Int, CustomStringConvertible {
             questionStep4,
             questionStep5,
             questionStep6,
-            questionStep7
+            questionStep7,
+            questionStep8
             ])
     }
     

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -277,6 +277,7 @@ enum TaskListRow: Int, CustomStringConvertible {
         case ContinuousVerticalScaleQuestionStep
         case TextScaleQuestionStep
         case TextVerticalScaleQuestionStep
+        case DiscreteScaleHiddenValueLabelQuestionStep
 
         // Task with an example of free text entry.
         case TextQuestionTask
@@ -612,7 +613,7 @@ enum TaskListRow: Int, CustomStringConvertible {
         
         step7AnswerFormat.hideValueLabel = true
         
-        let questionStep7 = ORKQuestionStep(identifier: String(Identifier.DiscreteScaleQuestionStep), title: exampleQuestionText, answer: step1AnswerFormat)
+        let questionStep7 = ORKQuestionStep(identifier: String(Identifier.DiscreteScaleHiddenValueLabelQuestionStep), title: exampleQuestionText, answer: step1AnswerFormat)
         
         questionStep7.text = exampleDetailText
         


### PR DESCRIPTION
This pull request adds an optional boolean to all scale answer formats to hide the value label of the scale. The boolean value is not included in the initialisers, but has to be set explicitly if one wants to override the default behaviour. Two steps are added to ORKCatalog to the scale task. The first added step contains a discrete horizontal scale with a hidden value label. The second added step contains a continuous vertical scale with a hidden value label.