### PR TITLE
Fix `blank` consent html review page.

### DIFF
--- a/ResearchKit/Consent/ORKConsentReviewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewController.m
@@ -87,6 +87,8 @@
     
     [self.view addSubview:_webView];
     [self.view addSubview:_toolbar];
+    
+    [self.view setNeedsUpdateConstraints];
 }
 
 - (void)updateLayoutMargins {
@@ -95,6 +97,7 @@
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
     [self updateLayoutMargins];
 }
 

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -133,10 +133,6 @@ typedef NS_ENUM(NSInteger, ORKConsentReviewPhase) {
     [self stepDidChange];
 }
 
-- (void)viewDidAppear:(BOOL)animated {
-    [super viewDidAppear:animated];
-}
-
 - (UIBarButtonItem *)goToPreviousPageButtonItem {
     UIBarButtonItem *button = [UIBarButtonItem ork_backBarButtonItemWithTarget:self action:@selector(goToPreviousPage)];
     button.accessibilityLabel = ORKLocalizedString(@"AX_BUTTON_BACK", nil);


### PR DESCRIPTION
To reproduce:
1. Run ORKTest
2. Select Consent
3. Navigate to consent review step

Somehow `updateViewConstraints` is not being called. Have to force it.
Also added  super call to `viewWillTransitionToSize`


 
<img width="361" alt="screen shot 2015-09-14 at 1 59 28 pm" src="https://cloud.githubusercontent.com/assets/11466704/9861713/da72c694-5ae8-11e5-8ae0-7b5c1287db6a.png"><img width="360" alt="screen shot 2015-09-14 at 1 59 11 pm" src="https://cloud.githubusercontent.com/assets/11466704/9861714/da77cbe4-5ae8-11e5-936c-27fcef5c63c1.png">