### PR TITLE
Fix audio task layout problem

### DIFF
--- a/ResearchKit/ActiveTasks/ORKAudioContentView.m
+++ b/ResearchKit/ActiveTasks/ORKAudioContentView.m
@@ -74,14 +74,6 @@ static const CGFloat ValueLineMargin = 1.5;
 }
 
 - (void)setUpConstraints {
-    NSLayoutConstraint *widthConstraint = [NSLayoutConstraint constraintWithItem:self
-                                                                       attribute:NSLayoutAttributeWidth
-                                                                       relatedBy:NSLayoutRelationEqual
-                                                                          toItem:nil
-                                                                       attribute:NSLayoutAttributeNotAnAttribute
-                                                                      multiplier:1.0
-                                                                        constant:CGFLOAT_MAX];
-    widthConstraint.priority = UILayoutPriorityFittingSizeLevel;
     
     NSLayoutConstraint *heightConstraint = [NSLayoutConstraint constraintWithItem:self
                                                                         attribute:NSLayoutAttributeHeight
@@ -92,7 +84,7 @@ static const CGFloat ValueLineMargin = 1.5;
                                                                          constant:CGFLOAT_MAX];
     heightConstraint.priority = UILayoutPriorityFittingSizeLevel;
     
-    [NSLayoutConstraint activateConstraints:@[widthConstraint, heightConstraint]];
+    [NSLayoutConstraint activateConstraints:@[heightConstraint]];
 }
 
 - (void)setValues:(NSArray *)values {


### PR DESCRIPTION

For #482, fixed by removing a constraint.

<img width="383" alt="screen shot 2015-09-30 at 11 21 03 am" src="https://cloud.githubusercontent.com/assets/11466704/10202378/66b48a88-6765-11e5-90fb-513ad08cc288.png">