### PR TITLE
IOI # 495 - Localization fallback language

### DIFF
--- a/ResearchKit/Common/ORKDefines_Private.h
+++ b/ResearchKit/Common/ORKDefines_Private.h
@@ -35,9 +35,13 @@
 #define STRONGTYPE(x) __strong __typeof(x)
 
 ORK_EXTERN NSBundle *ORKBundle() ORK_AVAILABLE_DECL;
+ORK_EXTERN NSBundle *ORKDefaultLocaleBundle();
+
+#define ORKDefaultLocalizedValue(key) \
+[ORKDefaultLocaleBundle() localizedStringForKey:key value:@"" table:nil]
 
 #define ORKLocalizedString(key, comment) \
-[ORKBundle() localizedStringForKey:(key) value:@"" table:nil]
+[ORKBundle() localizedStringForKey:(key) value:ORKDefaultLocalizedValue(key) table:nil]
 
 #define ORKLocalizedStringFromNumber(number) \
 [NSNumberFormatter localizedStringFromNumber:number numberStyle:NSNumberFormatterNoStyle]

--- a/ResearchKit/Common/ORKHelpers.h
+++ b/ResearchKit/Common/ORKHelpers.h
@@ -155,6 +155,7 @@
 // Bundle for video assets
 NSBundle *ORKAssetsBundle(void);
 NSBundle *ORKBundle();
+NSBundle *ORKDefaultLocaleBundle();
 
 // Pass 0xcccccc and get color #cccccc
 UIColor *ORKRGB(uint32_t x);

--- a/ResearchKit/Common/ORKHelpers.m
+++ b/ResearchKit/Common/ORKHelpers.m
@@ -262,7 +262,8 @@ NSBundle *ORKDefaultLocaleBundle() {
     
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        __bundle = [NSBundle bundleWithPath:[ORKBundle() pathForResource:@"en" ofType:@"lproj"]];
+        NSString *path = [ORKBundle() pathForResource:[ORKBundle() objectForInfoDictionaryKey:@"CFBundleDevelopmentRegion"] ofType:@"lproj"];
+        __bundle = [NSBundle bundleWithPath:path];
     });
     
     return __bundle;

--- a/ResearchKit/Common/ORKHelpers.m
+++ b/ResearchKit/Common/ORKHelpers.m
@@ -247,14 +247,25 @@ NSDateFormatter *ORKTimeOfDayLabelFormatter() {
 }
 
 NSBundle *ORKBundle() {
-    NSBundle *bundle = [NSBundle bundleForClass:[ORKStep class]];
-    return bundle;
+    static NSBundle *__bundle;
+    
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        __bundle = [NSBundle bundleForClass:[ORKStep class]];
+    });
+    
+    return __bundle;
 }
 
 NSBundle *ORKDefaultLocaleBundle() {
-    NSString * path = [ORKBundle() pathForResource:@"en" ofType:@"lproj"];
-    NSBundle * bundle = [NSBundle bundleWithPath:path];
-    return bundle;
+    static NSBundle *__bundle;
+    
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        __bundle = [NSBundle bundleWithPath:[ORKBundle() pathForResource:@"en" ofType:@"lproj"]];
+    });
+    
+    return __bundle;
 }
 
 NSDateComponentsFormatter *ORKTimeIntervalLabelFormatter() {

--- a/ResearchKit/Common/ORKHelpers.m
+++ b/ResearchKit/Common/ORKHelpers.m
@@ -251,6 +251,12 @@ NSBundle *ORKBundle() {
     return bundle;
 }
 
+NSBundle *ORKDefaultLocaleBundle() {
+    NSString * path = [ORKBundle() pathForResource:@"en" ofType:@"lproj"];
+    NSBundle * bundle = [NSBundle bundleWithPath:path];
+    return bundle;
+}
+
 NSDateComponentsFormatter *ORKTimeIntervalLabelFormatter() {
     static NSDateComponentsFormatter *durationFormatter = nil;
     static dispatch_once_t onceToken;


### PR DESCRIPTION
#### Localization fallback language
Currently, ORKLocalizedString() returns the key as a string if a value is not found for that key.
> For example, if we are in the German language setting, then it will display "PASSCODE_PROMPT_MESSAGE".

This PR redirects ORKLocalizedString() to find the value for the key in U.S. English and return that instead. If there is no value in the U.S. English either, then it will just return the key.
> With this update, if we are in the German language setting, then it will display "Enter passcode", if there is no translation available in German.

Issue #495 