### PR TITLE
If a task in ORKTest has been cancelled and saved, the output directory should be kept.

### DIFF
--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -3090,12 +3090,12 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
 /*
  Dismisses the task view controller.
  */
-- (void)dismissTaskViewController:(ORKTaskViewController *)taskViewController removeOutputDirectory:(BOOL)removeDir{
+- (void)dismissTaskViewController:(ORKTaskViewController *)taskViewController removeOutputDirectory:(BOOL)removeOutputDirectory {
     _currentDocument = nil;
     
-    NSURL *dir = taskViewController.outputDirectory;
+    NSURL *outputDirectoryURL = taskViewController.outputDirectory;
     [self dismissViewControllerAnimated:YES completion:^{
-        if (dir && removeDir)
+        if (outputDirectoryURL && removeOutputDirectory)
         {
             /*
              We attempt to clean up the output directory.
@@ -3105,8 +3105,8 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
              delete your data when you've processed it or sent it to a server.
              */
             NSError *err = nil;
-            if (! [[NSFileManager defaultManager] removeItemAtURL:dir error:&err]) {
-                NSLog(@"Error removing %@: %@", dir, err);
+            if (! [[NSFileManager defaultManager] removeItemAtURL:outputDirectoryURL error:&err]) {
+                NSLog(@"Error removing %@: %@", outputDirectoryURL, err);
             }
         }
     }];

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -3090,12 +3090,12 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
 /*
  Dismisses the task view controller.
  */
-- (void)dismissTaskViewController:(ORKTaskViewController *)taskViewController {
+- (void)dismissTaskViewController:(ORKTaskViewController *)taskViewController removeOutputDirectory:(BOOL)removeDir{
     _currentDocument = nil;
     
     NSURL *dir = taskViewController.outputDirectory;
     [self dismissViewControllerAnimated:YES completion:^{
-        if (dir)
+        if (dir && removeDir)
         {
             /*
              We attempt to clean up the output directory.
@@ -3273,7 +3273,7 @@ stepViewControllerWillAppear:(ORKStepViewController *)stepViewController {
             NSLog(@"Error on step %@: %@", taskViewController.currentStepViewController.step, error);
             break;
         case ORKTaskViewControllerFinishReasonDiscarded:
-            [self dismissTaskViewController:taskViewController];
+            [self dismissTaskViewController:taskViewController removeOutputDirectory:YES];
             break;
         case ORKTaskViewControllerFinishReasonSaved:
         {
@@ -3289,7 +3289,7 @@ stepViewControllerWillAppear:(ORKStepViewController *)stepViewController {
             if ([task isKindOfClass:[ORKNavigableOrderedTask class]]) {
                 _savedTasks[task.identifier] = [NSKeyedArchiver archivedDataWithRootObject:task];
             }
-            [self dismissTaskViewController:taskViewController];
+            [self dismissTaskViewController:taskViewController removeOutputDirectory:NO];
             return;
         }
             break;


### PR DESCRIPTION
Fix for #506 
ORKURLFromBookmarkData() fails to return a valid URL, when the resolving directory is not exist.