### PR TITLE
Use results for backwards navigation in 'ORKNavigableOrderedTask'

### DIFF
--- a/ResearchKit/Common/ORKHelpers.h
+++ b/ResearchKit/Common/ORKHelpers.h
@@ -286,3 +286,4 @@ const CGFloat ORKCGFloatInvalidValue;
 
 void ORKAdjustPageViewControllerNavigationDirectionForRTL(UIPageViewControllerNavigationDirection *direction);
 
+NSString *ORKPaddingWithNumberOfSpaces(NSUInteger numberOfPaddingSpaces);

--- a/ResearchKit/Common/ORKHelpers.m
+++ b/ResearchKit/Common/ORKHelpers.m
@@ -547,10 +547,5 @@ void ORKAdjustPageViewControllerNavigationDirectionForRTL(UIPageViewControllerNa
 }
 
 NSString *ORKPaddingWithNumberOfSpaces(NSUInteger numberOfPaddingSpaces) {
-    NSMutableString *padding = [NSMutableString new];
-    while (numberOfPaddingSpaces) {
-        [padding appendString:@" "];
-        numberOfPaddingSpaces--;
-    }
-    return padding;
+    return [@"" stringByPaddingToLength:numberOfPaddingSpaces withString:@" " startingAtIndex:0];
 }

--- a/ResearchKit/Common/ORKHelpers.m
+++ b/ResearchKit/Common/ORKHelpers.m
@@ -545,3 +545,12 @@ void ORKAdjustPageViewControllerNavigationDirectionForRTL(UIPageViewControllerNa
         *direction = (*direction == UIPageViewControllerNavigationDirectionForward) ? UIPageViewControllerNavigationDirectionReverse : UIPageViewControllerNavigationDirectionForward;
     }
 }
+
+NSString *ORKPaddingWithNumberOfSpaces(NSUInteger numberOfPaddingSpaces) {
+    NSMutableString *padding = [NSMutableString new];
+    while (numberOfPaddingSpaces) {
+        [padding appendString:@" "];
+        numberOfPaddingSpaces--;
+    }
+    return padding;
+}

--- a/ResearchKit/Common/ORKNavigableOrderedTask.h
+++ b/ResearchKit/Common/ORKNavigableOrderedTask.h
@@ -48,6 +48,15 @@ NS_ASSUME_NONNULL_BEGIN
  For example, if you want to display a survey question only when the user answered Yes to a previous
  question you can use `ORKPredicateStepNavigationRule`; or if you want to define an arbitrary jump
  between two steps you can use `ORKDirectStepNavigationRule`.
+ 
+ Navigable ordered tasks support looping over previously visited steps. Note, however, that results
+ for steps that are visited more than once will be ovewritten when you revisit the step on the loop.
+ Thus, going over a loop will produce duplicate results within the task results for the steps that
+ are seen more than once, but all the duplicate step results will point to the same result instance:
+ the one corresponding to the last time you visited the step.
+ 
+ The same applies when navigating backwards over looped steps: only your last valid answer is shown
+ every time you encounter a revisited step.
  */
 ORK_CLASS_AVAILABLE
 @interface ORKNavigableOrderedTask : ORKOrderedTask

--- a/ResearchKit/Common/ORKNavigableOrderedTask.m
+++ b/ResearchKit/Common/ORKNavigableOrderedTask.m
@@ -81,11 +81,9 @@
         if (nextStepIdentifier) {
             nextStep = [self stepWithIdentifier:nextStepIdentifier];
             
-            #if defined(DEBUG) && DEBUG
             if (step && nextStep && [self indexOfStep:nextStep] <= [self indexOfStep:step]) {
-                ORK_Log_Warning(@"Index of next step (\"%@\") is equal or lower than index of current step (\"%@\") in ordered task. Make sure this is intentional as you could loop idefinitely without appropriate navigation rules.", nextStep.identifier, step.identifier);
+                ORK_Log_Warning(@"Index of next step (\"%@\") is equal or lower than index of current step (\"%@\") in ordered task. Make sure this is intentional as you could loop idefinitely without appropriate navigation rules. Also please note that you'll get duplicate result entries each time you loop over the same step.", nextStep.identifier, step.identifier);
             }
-            #endif
         } else {
             nextStep = [super stepAfterStep:step withResult:result];
         }
@@ -96,9 +94,10 @@
 - (ORKStep *)stepBeforeStep:(ORKStep *)step withResult:(ORKTaskResult *)result {
     ORKStep *previousStep = nil;
     __block NSInteger indexOfCurrentStepResult = -1;
-    [result.results enumerateObjectsUsingBlock:^(ORKResult *result, NSUInteger idx, BOOL * _Nonnull stop) {
+    [result.results enumerateObjectsWithOptions:NSEnumerationReverse usingBlock:^(ORKResult *result, NSUInteger idx, BOOL *stop) {
         if ([result.identifier isEqualToString:step.identifier]) {
             indexOfCurrentStepResult = idx;
+            *stop = YES;
         }
     }];
     if (indexOfCurrentStepResult != -1 && indexOfCurrentStepResult != 0) {

--- a/ResearchKit/Common/ORKNavigableOrderedTask.m
+++ b/ResearchKit/Common/ORKNavigableOrderedTask.m
@@ -41,14 +41,12 @@
 
 @implementation ORKNavigableOrderedTask {
     NSMutableDictionary *_stepNavigationRules;
-    NSMutableOrderedSet *_stepIdentifierStack;
 }
 
 - (instancetype)initWithIdentifier:(NSString *)identifier steps:(NSArray<ORKStep *> *)steps {
     self = [super initWithIdentifier:identifier steps:steps];
     if (self) {
         _stepNavigationRules = nil;
-        _stepIdentifierStack = nil;
     }
     return self;
 }
@@ -91,52 +89,20 @@
         } else {
             nextStep = [super stepAfterStep:step withResult:result];
         }
-        if (nextStep) {
-            [self updateStepIdentifierStackWithSourceIdentifier:step.identifier destinationIdentifier:nextStep.identifier];
-        }
     }
     return nextStep;
-}
-    
-- (void)updateStepIdentifierStackWithSourceIdentifier:(NSString *)sourceIdentifier destinationIdentifier:(NSString *)destinationIdentifier {
-    NSParameterAssert(destinationIdentifier);
-    
-    if (!_stepIdentifierStack) {
-        _stepIdentifierStack = [NSMutableOrderedSet new];
-        // sourceIdentifier is nil if the task starts fresh,
-        // but can have a value if the task is being restored to a specific step
-        if (sourceIdentifier) {
-            [_stepIdentifierStack addObject:sourceIdentifier];
-        }
-        [_stepIdentifierStack addObject:destinationIdentifier];
-        return;
-    }
-    
-    NSUInteger indexOfSource = [_stepIdentifierStack indexOfObject:sourceIdentifier];
-    if (indexOfSource == NSNotFound) {
-        ORK_Log_Warning(@"You are calling an out of on order step in an ongoing task (\"%@\" -> \"%@\"). Clearing navigation stack.", sourceIdentifier, destinationIdentifier);
-        [_stepIdentifierStack removeAllObjects];
-        if (sourceIdentifier) {
-            [_stepIdentifierStack addObject:sourceIdentifier];
-        }
-        [_stepIdentifierStack addObject:destinationIdentifier];
-        return;
-    }
-    
-    NSUInteger stackCount = _stepIdentifierStack.count;
-    if (indexOfSource != stackCount - 1) {
-        [_stepIdentifierStack removeObjectsInRange:NSMakeRange(indexOfSource + 1, stackCount - (indexOfSource + 1))];
-    }
-    [_stepIdentifierStack addObject:destinationIdentifier];
 }
 
 - (ORKStep *)stepBeforeStep:(ORKStep *)step withResult:(ORKTaskResult *)result {
     ORKStep *previousStep = nil;
-    if (_stepIdentifierStack) {
-        NSUInteger indexOfSource = [_stepIdentifierStack indexOfObject:step.identifier];
-        if (indexOfSource != NSNotFound && indexOfSource >= 1) {
-            previousStep = [self stepWithIdentifier:_stepIdentifierStack[indexOfSource - 1]];
+    __block NSInteger indexOfCurrentStepResult = -1;
+    [result.results enumerateObjectsUsingBlock:^(ORKResult *result, NSUInteger idx, BOOL * _Nonnull stop) {
+        if ([result.identifier isEqualToString:step.identifier]) {
+            indexOfCurrentStepResult = idx;
         }
+    }];
+    if (indexOfCurrentStepResult != -1 && indexOfCurrentStepResult != 0) {
+        previousStep = [self stepWithIdentifier:result.results[indexOfCurrentStepResult - 1].identifier];
     }
     return previousStep;
 }
@@ -161,7 +127,6 @@
     self = [super initWithCoder:aDecoder];
     if (self) {
         ORK_DECODE_OBJ_MUTABLE_DICTIONARY(aDecoder, stepNavigationRules, NSString, ORKStepNavigationRule);
-        ORK_DECODE_OBJ_MUTABLE_ORDERED_SET(aDecoder, stepIdentifierStack, NSString);
     }
     return self;
 }
@@ -170,7 +135,6 @@
     [super encodeWithCoder:aCoder];
     
     ORK_ENCODE_OBJ(aCoder, stepNavigationRules);
-    ORK_ENCODE_OBJ(aCoder, stepIdentifierStack);
 }
 
 #pragma mark NSCopying
@@ -178,11 +142,9 @@
 - (instancetype)copyWithZone:(NSZone *)zone {
     typeof(self) task = [super copyWithZone:zone];
     task->_stepNavigationRules = ORKMutableDictionaryCopyObjects(_stepNavigationRules);
-    task->_stepIdentifierStack = ORKMutableOrderedSetCopyObjects(_stepIdentifierStack);
     return task;
 }
 
-// Note: 'isEqual:' and 'hash' ignore _stepIdentifierStack
 - (BOOL)isEqual:(id)object {
     BOOL isParentSame = [super isEqual:object];
     

--- a/ResearchKit/Common/ORKResult.m
+++ b/ResearchKit/Common/ORKResult.m
@@ -32,12 +32,6 @@
 #import "ORKResult.h"
 #import "ORKTask.h"
 #import "ORKResult_Private.h"
-#include <sys/socket.h> // Per msqr
-#include <sys/sysctl.h>
-#include <net/if.h>
-#include <net/if_dl.h>
-#import <CoreMotion/CoreMotion.h>
-#import <CoreLocation/CoreLocation.h>
 #import "ORKRecorder.h"
 #import "ORKStep.h"
 #import "ORKHelpers.h"
@@ -47,6 +41,15 @@
 #import "ORKAnswerFormat_Internal.h"
 #import "ORKConsentDocument.h"
 #import "ORKConsentSignature.h"
+#import <CoreMotion/CoreMotion.h>
+#import <CoreLocation/CoreLocation.h>
+
+
+@interface ORKResult ()
+
+@property (nonatomic, readonly) NSString *descriptionPrefix;
+
+@end
 
 
 @implementation ORKResult
@@ -121,6 +124,14 @@
     return self;
 }
 
+- (NSString *)descriptionPrefix {
+    return [NSString stringWithFormat:@"%@: %p; identifier: %@", self.class.description, self, self.identifier];
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<%@>", self.descriptionPrefix];
+}
+
 @end
 
 
@@ -168,7 +179,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"%@ %@ %.03f %@", super.description, @(self.buttonIdentifier), self.timestamp, NSStringFromCGPoint(self.location)];
+    return [NSString stringWithFormat:@"<%@: %p; button: %@; timestamp: %.03f; location: %@>", self.class.description, self, @(self.buttonIdentifier), self.timestamp, NSStringFromCGPoint(self.location)];
 }
 
 @end
@@ -208,7 +219,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"%@ %d", [super description], self.isPasscodeSaved];
+    return [NSString stringWithFormat:@"<%@; passcodeSaved: %d>", self.descriptionPrefix, self.isPasscodeSaved];
 }
 
 @end
@@ -255,7 +266,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"%@, %d, %@", super.description, self.puzzleWasSolved, self.moves];
+    return [NSString stringWithFormat:@"<%@; puzzleSolved: %d; moves: %@>", self.descriptionPrefix, self.puzzleWasSolved, self.moves];
 }
 
 @end
@@ -305,7 +316,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"%@ %@ %@ %@", super.description, @(self.timestamp), @(self.donorTowerIndex), @(self.recipientTowerIndex)];
+    return [NSString stringWithFormat:@"<%@: %p; timestamp: %@; donorTower: %@; recipientTower: %@>", self.class.description, self, @(self.timestamp), @(self.donorTowerIndex), @(self.recipientTowerIndex)];
 }
 
 @end
@@ -353,7 +364,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"%@ %@ %@", super.description, self.outputVolume, self.samples];
+    return [NSString stringWithFormat:@"<%@; outputvolume: %@; samples: %@>", self.descriptionPrefix, self.outputVolume, self.samples];
 }
 
 @end
@@ -402,7 +413,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"%@ %.1lf %@ %.4lf", super.description, self.frequency, @(self.channel), self.amplitude];
+    return [NSString stringWithFormat:@"<%@: %p; frequency: %.1lf; channel %@; amplitude: %.4lf>", self.class.description, self, self.frequency, @(self.channel), self.amplitude];
 }
 
 @end
@@ -459,7 +470,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"%@ %@ %@ %@ %@", super.description, @(self.timestamp), @(self.targetIndex), NSStringFromCGPoint(self.location), @(self.isCorrect)];
+    return [NSString stringWithFormat:@"<%@: %p; timestamp: %@; targetIndex: %@; location: %@; correct: %@>", self.class.description, self, @(self.timestamp), @(self.targetIndex), NSStringFromCGPoint(self.location), @(self.isCorrect)];
 }
 
 @end
@@ -527,7 +538,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"%@ %@ %@ %@ %@ %@", super.description, @(self.seed), self.sequence, @(self.gameSize), @(self.gameStatus), @(self.score)];
+    return [NSString stringWithFormat:@"<%@: %p; seed: %@; sequence: %@; gameSize: %@; gameStatus: %@; score: %@>", self.class.description, self, @(self.seed), self.sequence, @(self.gameSize), @(self.gameStatus), @(self.score)];
 }
 
 @end
@@ -585,7 +596,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"%@ score=%@", super.description, @(self.score)];
+    return [NSString stringWithFormat:@"<%@: %p; score: %@>", self.class.description, self, @(self.score)];
 }
 
 @end
@@ -641,7 +652,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"%@ %@", super.description, self.samples];
+    return [NSString stringWithFormat:@"<%@; samples: %@>", self.descriptionPrefix, self.samples];
 }
 
 @end
@@ -693,7 +704,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"%@ %@ (%lld bytes)", super.description, self.fileURL, [[[NSFileManager defaultManager] attributesOfItemAtPath:[self.fileURL path] error:nil] fileSize]];
+    return [NSString stringWithFormat:@"<%@; fileURL: %@ (%lld bytes)>", self.descriptionPrefix, self.fileURL, [[[NSFileManager defaultManager] attributesOfItemAtPath:[self.fileURL path] error:nil] fileSize]];
 }
 
 @end
@@ -741,10 +752,11 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"%@ %f %@", super.description, self.timestamp, self.fileResult.description];
+    return [NSString stringWithFormat:@"<%@; timestamp: %f; fileResult: %@>", self.descriptionPrefix, self.timestamp, self.fileResult.description];
 }
 
 @end
+
 
 @implementation ORKTimedWalkResult
 
@@ -793,10 +805,11 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"%@ %@ %@ %@", [super description], @(self.distanceInMeters), @(self.timeLimit), @(self.duration)];
+    return [NSString stringWithFormat:@"<%@; distance: %@; timeLimit: %@; duration: %@>", self.descriptionPrefix, @(self.distanceInMeters), @(self.timeLimit), @(self.duration)];
 }
 
 @end
+
 
 @implementation ORKPSATSample
 
@@ -845,7 +858,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"%@ %@ %@ %@ %@", [super description], @(self.isCorrect), @(self.digit), @(self.answer), @(self.time)];
+    return [NSString stringWithFormat:@"<%@: %p; correct: %@; digit: %@; answer: %@; time: %@>", self.class.description, self, @(self.isCorrect), @(self.digit), @(self.answer), @(self.time)];
 }
 
 @end
@@ -922,10 +935,11 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"%@ total correct=%@/%@ %@", [super description], @(self.totalCorrect), @(self.length),self.samples];
+    return [NSString stringWithFormat:@"<%@; correct: %@/%@; samples: %@>", self.descriptionPrefix, @(self.totalCorrect), @(self.length), self.samples];
 }
 
 @end
+
 
 @implementation ORKHolePegTestResult
 
@@ -1001,7 +1015,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"%@ %@ %@ %@", [super description], @(self.totalSuccesses), @(self.totalTime), self.samples];
+    return [NSString stringWithFormat:@"<%@; successes: %@; time: %@; samples: %@>", self.descriptionPrefix, @(self.totalSuccesses), @(self.totalTime), self.samples];
 }
 
 @end
@@ -1046,7 +1060,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"%@ %@ %@", [super description], @(self.time), @(self.distance)];
+    return [NSString stringWithFormat:@"<%@: %p; time: %@; distance: %@>", self.class.description, self, @(self.time), @(self.distance)];
 }
 
 @end
@@ -1101,7 +1115,11 @@
 
     return result;
 }
-                                
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<%@; data: %@; filename: %@; contentType: %@>", self.descriptionPrefix, self.data, self.filename, self.contentType];
+}
+
 @end
 
 
@@ -1161,6 +1179,10 @@
         signatures[indexToBeReplaced] = [_signature copy];
         document.signatures = signatures;
     }
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<%@; signature: %@; consented: %d>", self.descriptionPrefix, self.signature, self.consented];
 }
 
 @end
@@ -1224,6 +1246,10 @@
 
 - (id)answer {
     return nil;
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<%@; answer: %@>", self.descriptionPrefix, self.answer];
 }
 
 @end
@@ -1771,6 +1797,24 @@
 - (ORKResult *)firstResult {
     
     return self.results.firstObject;
+}
+
+- (NSString *)description {
+    NSMutableString *description = [NSMutableString stringWithFormat:@"<%@: %p; identifier: %@; results: {", self.class.description, self, self.identifier];
+    
+    NSUInteger indexOfLastResult = self.results.count - 1;
+    [self.results enumerateObjectsUsingBlock:^(ORKResult * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        if (idx != 0) {
+            [description appendString:@", "];
+        }
+        [description appendFormat:@"%@", obj.description];
+        if (idx == indexOfLastResult) {
+            [description appendString:@" "];
+        }
+    }];
+    
+    [description appendString:@"} >"];
+    return [description copy];
 }
 
 @end

--- a/ResearchKit/Common/ORKResult.m
+++ b/ResearchKit/Common/ORKResult.m
@@ -125,7 +125,7 @@
 }
 
 - (NSString *)descriptionPrefix {
-    return [NSString stringWithFormat:@"%@: %p; identifier: %@", self.class.description, self, self.identifier];
+    return [NSString stringWithFormat:@"%@: %p; identifier: \"%@\"", self.class.description, self, self.identifier];
 }
 
 - (NSString *)description {
@@ -1800,7 +1800,7 @@
 }
 
 - (NSString *)description {
-    NSMutableString *description = [NSMutableString stringWithFormat:@"<%@: %p; identifier: %@; results: {", self.class.description, self, self.identifier];
+    NSMutableString *description = [NSMutableString stringWithFormat:@"<%@; results: {", self.descriptionPrefix];
     
     [self.results enumerateObjectsUsingBlock:^(ORKResult * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
         if (idx != 0) {

--- a/ResearchKit/Common/ORKResult.m
+++ b/ResearchKit/Common/ORKResult.m
@@ -1830,7 +1830,8 @@
         if (idx == 0) {
             [description appendString:@"\n"];
         }
-        [description appendFormat:@"%@", [result descriptionWithNumberOfPaddingSpaces:numberOfPaddingSpaces + 4]];
+        const NSUInteger numberOfPaddingSpacesForIndentationLevel = 4;
+        [description appendFormat:@"%@", [result descriptionWithNumberOfPaddingSpaces:numberOfPaddingSpaces + numberOfPaddingSpacesForIndentationLevel]];
         if (idx != numberOfResults - 1) {
             [description appendString:@",\n"];
         } else {

--- a/ResearchKit/Common/ORKResult.m
+++ b/ResearchKit/Common/ORKResult.m
@@ -1802,18 +1802,14 @@
 - (NSString *)description {
     NSMutableString *description = [NSMutableString stringWithFormat:@"<%@: %p; identifier: %@; results: {", self.class.description, self, self.identifier];
     
-    NSUInteger indexOfLastResult = self.results.count - 1;
     [self.results enumerateObjectsUsingBlock:^(ORKResult * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
         if (idx != 0) {
             [description appendString:@", "];
         }
         [description appendFormat:@"%@", obj.description];
-        if (idx == indexOfLastResult) {
-            [description appendString:@" "];
-        }
     }];
     
-    [description appendString:@"} >"];
+    [description appendString:@"}>"];
     return [description copy];
 }
 

--- a/ResearchKit/Common/ORKResult.m
+++ b/ResearchKit/Common/ORKResult.m
@@ -45,6 +45,8 @@
 #import <CoreLocation/CoreLocation.h>
 
 
+const NSUInteger NumberOfPaddingSpacesForIndentationLevel = 4;
+
 @interface ORKResult ()
 
 - (NSString *)descriptionPrefixWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces;
@@ -1267,7 +1269,18 @@
         || [answer isKindOfClass:[NSDictionary class]]
         || [answer isKindOfClass:[NSSet class]]
         || [answer isKindOfClass:[NSOrderedSet class]]) {
-        [description appendFormat:@"\n%@\n%@>", answer, ORKPaddingWithNumberOfSpaces(numberOfPaddingSpaces)];
+        NSMutableString *indentatedAnswerDescription = [NSMutableString new];
+        NSString *answerDescription = [answer description];
+        NSArray *answerLines = [answerDescription componentsSeparatedByString:@"\n"];
+        const NSUInteger numberOfAnswerLines = answerLines.count;
+        [answerLines enumerateObjectsUsingBlock:^(NSString *answerLineString, NSUInteger idx, BOOL *stop) {
+            [indentatedAnswerDescription appendFormat:@"%@%@", ORKPaddingWithNumberOfSpaces(numberOfPaddingSpaces + NumberOfPaddingSpacesForIndentationLevel), answerLineString];
+            if (idx != numberOfAnswerLines - 1) {
+                [indentatedAnswerDescription appendString:@"\n"];
+            }
+        }];
+        
+        [description appendFormat:@"\n%@>", indentatedAnswerDescription];
     } else {
         [description appendFormat:@" %@%@", answer, self.descriptionSuffix];
     }
@@ -1830,8 +1843,7 @@
         if (idx == 0) {
             [description appendString:@"\n"];
         }
-        const NSUInteger numberOfPaddingSpacesForIndentationLevel = 4;
-        [description appendFormat:@"%@", [result descriptionWithNumberOfPaddingSpaces:numberOfPaddingSpaces + numberOfPaddingSpacesForIndentationLevel]];
+        [description appendFormat:@"%@", [result descriptionWithNumberOfPaddingSpaces:numberOfPaddingSpaces + NumberOfPaddingSpacesForIndentationLevel]];
         if (idx != numberOfResults - 1) {
             [description appendString:@",\n"];
         } else {

--- a/ResearchKit/Common/ORKResult.m
+++ b/ResearchKit/Common/ORKResult.m
@@ -47,7 +47,11 @@
 
 @interface ORKResult ()
 
-@property (nonatomic, readonly) NSString *descriptionPrefix;
+- (NSString *)descriptionPrefixWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces;
+
+@property (nonatomic) NSString *descriptionSuffix;
+
+- (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces;
 
 @end
 
@@ -124,12 +128,20 @@
     return self;
 }
 
-- (NSString *)descriptionPrefix {
-    return [NSString stringWithFormat:@"%@: %p; identifier: \"%@\"", self.class.description, self, self.identifier];
+- (NSString *)descriptionPrefixWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
+    return [NSString stringWithFormat:@"%@<%@: %p; identifier: \"%@\"", ORKPaddingWithNumberOfSpaces(numberOfPaddingSpaces), self.class.description, self, self.identifier];
+}
+
+- (NSString *)descriptionSuffix {
+    return @">";
+}
+
+- (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
+    return [NSString stringWithFormat:@"%@%@", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces], self.descriptionSuffix];
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"<%@>", self.descriptionPrefix];
+    return [self descriptionWithNumberOfPaddingSpaces:0];
 }
 
 @end
@@ -218,8 +230,8 @@
     return result;
 }
 
-- (NSString *)description {
-    return [NSString stringWithFormat:@"<%@; passcodeSaved: %d>", self.descriptionPrefix, self.isPasscodeSaved];
+- (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
+    return [NSString stringWithFormat:@"%@; passcodeSaved: %d%@", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces], self.isPasscodeSaved, self.descriptionSuffix];
 }
 
 @end
@@ -265,8 +277,8 @@
     return result;
 }
 
-- (NSString *)description {
-    return [NSString stringWithFormat:@"<%@; puzzleSolved: %d; moves: %@>", self.descriptionPrefix, self.puzzleWasSolved, self.moves];
+- (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
+    return [NSString stringWithFormat:@"%@; puzzleSolved: %d; moves: %@%@", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces], self.puzzleWasSolved, self.moves, self.descriptionSuffix];
 }
 
 @end
@@ -363,8 +375,8 @@
     return result;
 }
 
-- (NSString *)description {
-    return [NSString stringWithFormat:@"<%@; outputvolume: %@; samples: %@>", self.descriptionPrefix, self.outputVolume, self.samples];
+- (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
+    return [NSString stringWithFormat:@"%@; outputvolume: %@; samples: %@%@", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces], self.outputVolume, self.samples, self.descriptionSuffix];
 }
 
 @end
@@ -595,8 +607,8 @@
     return result;
 }
 
-- (NSString *)description {
-    return [NSString stringWithFormat:@"<%@: %p; score: %@>", self.class.description, self, @(self.score)];
+- (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
+    return [NSString stringWithFormat:@"%@; score: %@%@", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces], @(self.score), self.descriptionSuffix];
 }
 
 @end
@@ -651,8 +663,8 @@
     return result;
 }
 
-- (NSString *)description {
-    return [NSString stringWithFormat:@"<%@; samples: %@>", self.descriptionPrefix, self.samples];
+- (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
+    return [NSString stringWithFormat:@"%@; samples: %@%@", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces], self.samples, self.descriptionSuffix];
 }
 
 @end
@@ -703,8 +715,8 @@
     return result;
 }
 
-- (NSString *)description {
-    return [NSString stringWithFormat:@"<%@; fileURL: %@ (%lld bytes)>", self.descriptionPrefix, self.fileURL, [[[NSFileManager defaultManager] attributesOfItemAtPath:[self.fileURL path] error:nil] fileSize]];
+- (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
+    return [NSString stringWithFormat:@"%@; fileURL: %@ (%lld bytes)%@", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces], self.fileURL, [[NSFileManager defaultManager] attributesOfItemAtPath:self.fileURL.path error:nil].fileSize, self.descriptionSuffix];
 }
 
 @end
@@ -751,8 +763,8 @@
     return result;
 }
 
-- (NSString *)description {
-    return [NSString stringWithFormat:@"<%@; timestamp: %f; fileResult: %@>", self.descriptionPrefix, self.timestamp, self.fileResult.description];
+- (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
+    return [NSString stringWithFormat:@"%@; timestamp: %f; fileResult: %@%@", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces], self.timestamp, self.fileResult.description, self.descriptionSuffix];
 }
 
 @end
@@ -804,8 +816,8 @@
     return result;
 }
 
-- (NSString *)description {
-    return [NSString stringWithFormat:@"<%@; distance: %@; timeLimit: %@; duration: %@>", self.descriptionPrefix, @(self.distanceInMeters), @(self.timeLimit), @(self.duration)];
+- (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
+    return [NSString stringWithFormat:@"%@; distance: %@; timeLimit: %@; duration: %@%@", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces], @(self.distanceInMeters), @(self.timeLimit), @(self.duration), self.descriptionSuffix];
 }
 
 @end
@@ -934,8 +946,8 @@
     return result;
 }
 
-- (NSString *)description {
-    return [NSString stringWithFormat:@"<%@; correct: %@/%@; samples: %@>", self.descriptionPrefix, @(self.totalCorrect), @(self.length), self.samples];
+- (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
+    return [NSString stringWithFormat:@"%@; correct: %@/%@; samples: %@%@", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces], @(self.totalCorrect), @(self.length), self.samples, self.descriptionSuffix];
 }
 
 @end
@@ -1014,8 +1026,8 @@
     return result;
 }
 
-- (NSString *)description {
-    return [NSString stringWithFormat:@"<%@; successes: %@; time: %@; samples: %@>", self.descriptionPrefix, @(self.totalSuccesses), @(self.totalTime), self.samples];
+- (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
+    return [NSString stringWithFormat:@"%@; successes: %@; time: %@; samples: %@%@", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces], @(self.totalSuccesses), @(self.totalTime), self.samples, self.descriptionSuffix];
 }
 
 @end
@@ -1116,8 +1128,8 @@
     return result;
 }
 
-- (NSString *)description {
-    return [NSString stringWithFormat:@"<%@; data: %@; filename: %@; contentType: %@>", self.descriptionPrefix, self.data, self.filename, self.contentType];
+- (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
+    return [NSString stringWithFormat:@"%@; data: %@; filename: %@; contentType: %@%@", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces], self.data, self.filename, self.contentType, self.descriptionSuffix];
 }
 
 @end
@@ -1181,8 +1193,8 @@
     }
 }
 
-- (NSString *)description {
-    return [NSString stringWithFormat:@"<%@; signature: %@; consented: %d>", self.descriptionPrefix, self.signature, self.consented];
+- (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
+    return [NSString stringWithFormat:@"%@; signature: %@; consented: %d%@", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces], self.signature, self.consented, self.descriptionSuffix];
 }
 
 @end
@@ -1248,8 +1260,19 @@
     return nil;
 }
 
-- (NSString *)description {
-    return [NSString stringWithFormat:@"<%@; answer: %@>", self.descriptionPrefix, self.answer];
+- (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
+    NSMutableString *description = [NSMutableString stringWithFormat:@"%@; answer:", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces]];
+    id answer = self.answer;
+    if ([answer isKindOfClass:[NSArray class]]
+        || [answer isKindOfClass:[NSDictionary class]]
+        || [answer isKindOfClass:[NSSet class]]
+        || [answer isKindOfClass:[NSOrderedSet class]]) {
+        [description appendFormat:@"\n%@\n%@>", answer, ORKPaddingWithNumberOfSpaces(numberOfPaddingSpaces)];
+    } else {
+        [description appendFormat:@" %@%@", answer, self.descriptionSuffix];
+    }
+    
+    return [description copy];
 }
 
 @end
@@ -1799,17 +1822,23 @@
     return self.results.firstObject;
 }
 
-- (NSString *)description {
-    NSMutableString *description = [NSMutableString stringWithFormat:@"<%@; results: {", self.descriptionPrefix];
+- (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
+    NSMutableString *description = [NSMutableString stringWithFormat:@"%@; results: (", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces]];
     
-    [self.results enumerateObjectsUsingBlock:^(ORKResult * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-        if (idx != 0) {
-            [description appendString:@", "];
+    NSUInteger numberOfResults = self.results.count;
+    [self.results enumerateObjectsUsingBlock:^(ORKResult *result, NSUInteger idx, BOOL * _Nonnull stop) {
+        if (idx == 0) {
+            [description appendString:@"\n"];
         }
-        [description appendFormat:@"%@", obj.description];
+        [description appendFormat:@"%@", [result descriptionWithNumberOfPaddingSpaces:numberOfPaddingSpaces + 4]];
+        if (idx != numberOfResults - 1) {
+            [description appendString:@",\n"];
+        } else {
+            [description appendString:@"\n"];
+        }
     }];
     
-    [description appendString:@"}>"];
+    [description appendFormat:@"%@)%@", ORKPaddingWithNumberOfSpaces((numberOfResults == 0) ? 0 : numberOfPaddingSpaces), self.descriptionSuffix];
     return [description copy];
 }
 

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -160,7 +160,7 @@ static void *_ORKViewControllerToolbarObserverContext = &_ORKViewControllerToolb
 
 @interface ORKTaskViewController () <ORKViewControllerToolbarObserverDelegate, ORKScrollViewObserverDelegate> {
     NSMutableDictionary *_managedResults;
-    NSMutableOrderedSet *_managedStepIdentifiers;
+    NSMutableArray *_managedStepIdentifiers;
     ORKViewControllerToolbarObserver *_stepViewControllerObserver;
     ORKScrollViewObserver *_scrollViewObserver;
     BOOL _hasSetProgressLabel;
@@ -264,7 +264,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     self.showsProgressInNavigationBar = YES;
     
     _managedResults = [NSMutableDictionary dictionary];
-    _managedStepIdentifiers = [NSMutableOrderedSet orderedSet];
+    _managedStepIdentifiers = [NSMutableArray array];
     
     self.taskRunUUID = taskRunUUID;
     
@@ -893,16 +893,8 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
         }
     }
     
-    NSString *stepIdentifier = step.identifier;
-    if (stepIdentifier) {
-        NSUInteger indexOfStep = [_managedStepIdentifiers indexOfObject:stepIdentifier];
-        if (indexOfStep == NSNotFound) {
-            [_managedStepIdentifiers addObject:stepIdentifier];
-        } else {
-            // If the step being shown has been visited before, remove all the managed step identifiers visited after it
-            NSUInteger numberManagedOfStepIdentifiers = _managedStepIdentifiers.count;
-            [_managedStepIdentifiers removeObjectsInRange:NSMakeRange(indexOfStep + 1, numberManagedOfStepIdentifiers - (indexOfStep + 1))];
-        }
+    if (step.identifier && ![_managedStepIdentifiers.lastObject isEqualToString:step.identifier]) {
+        [_managedStepIdentifiers addObject:step.identifier];
     }
 
     if ([step isRestorable]) {
@@ -1141,7 +1133,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     [self finishWithReason:ORKTaskViewControllerFinishReasonFailed error:error];
 }
 
-- (IBAction)flipToNextPageFrom:(ORKStepViewController *)fromController {
+- (void)flipToNextPageFrom:(ORKStepViewController *)fromController {
     if (fromController != _currentStepViewController) {
         return;
     }
@@ -1162,7 +1154,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     
 }
 
-- (IBAction)flipToPreviousPageFrom:(ORKStepViewController *)fromController {
+- (void)flipToPreviousPageFrom:(ORKStepViewController *)fromController {
     if (fromController != _currentStepViewController) {
         return;
     }
@@ -1171,8 +1163,15 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     ORKStepViewController *stepViewController = nil;
     
     if ([self shouldPresentStep:step]) {
+        ORKStep *currentStep = _currentStepViewController.step;
+        NSString *itemId = currentStep.identifier;
+        
         stepViewController = [self viewControllerForStep:step];
         if (stepViewController) {
+            // Remove the identifier from the list
+            assert([itemId isEqualToString:_managedStepIdentifiers.lastObject]);
+            [_managedStepIdentifiers removeLastObject];
+            
             [self showViewController:stepViewController goForward:NO animated:YES];
         }
     }
@@ -1302,7 +1301,7 @@ static NSString *const _ORKPresentedDate = @"presentedDate";
         
         // Recover partially entered results, even if we may not be able to jump to the desired step.
         _managedResults = [coder decodeObjectOfClass:[NSMutableDictionary class] forKey:_ORKManagedResultsRestoreKey];
-        _managedStepIdentifiers = [coder decodeObjectOfClass:[NSMutableOrderedSet class] forKey:_ORKManagedStepIdentifiersRestoreKey];
+        _managedStepIdentifiers = [coder decodeObjectOfClass:[NSMutableArray class] forKey:_ORKManagedStepIdentifiersRestoreKey];
         
         _restoredTaskIdentifier = [coder decodeObjectOfClass:[NSString class] forKey:_ORKTaskIdentifierRestoreKey];
         if (_restoredTaskIdentifier) {

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -58,20 +58,22 @@ DefineStringKey(ActiveStepTaskIdentifier);
 DefineStringKey(AudioTaskIdentifier);
 DefineStringKey(FitnessTaskIdentifier);
 DefineStringKey(GaitTaskIdentifier);
-DefineStringKey(TwoFingerTapTaskIdentifier);
-DefineStringKey(MemoryTaskIdentifier);
-DefineStringKey(ScreeningTaskIdentifier);
-DefineStringKey(ToneAudiometryTaskIdentifier);
-DefineStringKey(ReactionTimeTaskIdentifier);
-DefineStringKey(TowerOfHanoiTaskIdentifier);
-DefineStringKey(PSATTaskIdentifier);
-DefineStringKey(TimedWalkTaskIdentifier);
 DefineStringKey(HolePegTestTaskIdentifier);
+DefineStringKey(MemoryTaskIdentifier);
+DefineStringKey(PSATTaskIdentifier);
+DefineStringKey(ReactionTimeTaskIdentifier);
+DefineStringKey(TwoFingerTapTaskIdentifier);
+DefineStringKey(TimedWalkTaskIdentifier);
+DefineStringKey(ToneAudiometryTaskIdentifier);
+DefineStringKey(TowerOfHanoiTaskIdentifier);
+
 DefineStringKey(CreatePasscodeTaskIdentifier);
 
 DefineStringKey(CustomNavigationItemTaskIdentifier);
 DefineStringKey(DynamicTaskIdentifier);
-DefineStringKey(StepNavigationTaskIdentifier);
+DefineStringKey(InterruptibleTaskIdentifier);
+DefineStringKey(NavigableOrderedTaskIdentifier);
+DefineStringKey(NavigableLoopTaskIdentifier);
 
 DefineStringKey(CollectionViewHeaderReuseIdentifier);
 DefineStringKey(CollectionViewCellReuseIdentifier);
@@ -298,6 +300,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                            @"Dynamic Task",
                            @"Interruptible Task",
                            @"Navigable Ordered Task",
+                           @"Navigable Loop Task",
                            @"Test Charts",
                            @"Toggle Tint Color",
                            ],
@@ -422,8 +425,8 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                                                            options:ORKPredefinedTaskOptionNone];
     } else if ([identifier isEqualToString:DynamicTaskIdentifier]) {
         return [DynamicTask new];
-    } else if ([identifier isEqualToString:ScreeningTaskIdentifier]) {
-        return [self makeScreeningTask];
+    } else if ([identifier isEqualToString:InterruptibleTaskIdentifier]) {
+        return [self makeInterruptibleTask];
     } else if ([identifier isEqualToString:ScalesTaskIdentifier]) {
         return [self makeScalesTask];
     } else if ([identifier isEqualToString:ImageChoicesTaskIdentifier]) {
@@ -475,8 +478,10 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                                                               rotated:NO
                                                             timeLimit:300.0
                                                               options:ORKPredefinedTaskOptionNone];
-    } else if ([identifier isEqualToString:StepNavigationTaskIdentifier]) {
+    } else if ([identifier isEqualToString:NavigableOrderedTaskIdentifier]) {
         return [self makeNavigableOrderedTask];
+    } else if ([identifier isEqualToString:NavigableLoopTaskIdentifier]) {
+        return [self makeNavigableLoopTask];
     } else if ([identifier isEqualToString:CustomNavigationItemTaskIdentifier]) {
         return [self makeCustomNavigationItemTask];
     } else if ([identifier isEqualToString:CreatePasscodeTaskIdentifier]) {
@@ -506,8 +511,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
 
     id<ORKTask> task = nil;
     NSData *taskData = _savedTasks[identifier];
-    if (taskData)
-    {
+    if (taskData) {
         /*
          We assume any restored task is of the ORKNavigableOrderedTask since that's the only kind
          we're archiving in this example. You have to make sure your are unarchiving a task of the proper class.
@@ -521,8 +525,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         task = [self makeTaskWithIdentifier:identifier];
     }
     
-    if (_savedViewControllers[identifier])
-    {
+    if (_savedViewControllers[identifier]) {
         NSData *data = _savedViewControllers[identifier];
         self.taskViewController = [[ORKTaskViewController alloc] initWithTask:task restorationData:data delegate:self];
     } else {
@@ -552,8 +555,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
      For the dynamic task, we remember the last result and use it as a source
      of default values for any optional questions.
      */
-    if ([task isKindOfClass:[DynamicTask class]])
-    {
+    if ([task isKindOfClass:[DynamicTask class]]) {
         self.taskViewController.defaultResultSource = _lastRouteResult;
     }
     
@@ -688,7 +690,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     return task;
 }
 
-- (IBAction)datePickersButtonTapped:(id)sender {
+- (void)datePickersButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:DatePickingTaskIdentifier];
 }
 
@@ -1017,7 +1019,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     return task;
 }
 
-- (IBAction)selectionSurveyButtonTapped:(id)sender {
+- (void)selectionSurveyButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:SelectionSurveyTaskIdentifier];
 }
 
@@ -1118,7 +1120,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     return task;
 }
 
-- (IBAction)activeStepTaskButtonTapped:(id)sender {
+- (void)activeStepTaskButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:ActiveStepTaskIdentifier];
 }
 
@@ -1161,7 +1163,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     return task;
 }
 
-- (IBAction)consentReviewButtonTapped:(id)sender {
+- (void)consentReviewButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:ConsentReviewTaskIdentifier];
 }
 
@@ -1191,7 +1193,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     return task;
 }
 
-- (IBAction)consentButtonTapped:(id)sender {
+- (void)consentButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:ConsentTaskIdentifier];
 }
 
@@ -1298,7 +1300,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     return task;
 }
 
-- (IBAction)eligibilityFormButtonTapped:(id)sender {
+- (void)eligibilityFormButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:EligibilityFormTaskIdentifier];
 }
 
@@ -1356,7 +1358,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     return task;
 }
 
-- (IBAction)eligibilitySurveyButtonTapped:(id)sender {
+- (void)eligibilitySurveyButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:EligibilitySurveyTaskIdentifier];
 }
 
@@ -1750,7 +1752,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     return task;
 }
 
-- (IBAction)miniFormButtonTapped:(id)sender {
+- (void)miniFormButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:MiniFormTaskIdentifier];
 }
 
@@ -2042,53 +2044,53 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     return task;
 }
 
-- (IBAction)optionalFormButtonTapped:(id)sender {
+- (void)optionalFormButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:OptionalFormTaskIdentifier];
 }
 
 #pragma mark - Active tasks
 
-- (IBAction)fitnessTaskButtonTapped:(id)sender {
+- (void)fitnessTaskButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:FitnessTaskIdentifier];
 }
 
-- (IBAction)gaitTaskButtonTapped:(id)sender {
+- (void)gaitTaskButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:GaitTaskIdentifier];
 }
 
-- (IBAction)memoryGameTaskButtonTapped:(id)sender {
+- (void)memoryGameTaskButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:MemoryTaskIdentifier];
 }
 
-- (IBAction)audioTaskButtonTapped:(id)sender {
+- (void)audioTaskButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:AudioTaskIdentifier];
 }
 
-- (IBAction)toneAudiometryTaskButtonTapped:(id)sender {
+- (void)toneAudiometryTaskButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:ToneAudiometryTaskIdentifier];
 }
 
-- (IBAction)twoFingerTappingTaskButtonTapped:(id)sender {
+- (void)twoFingerTappingTaskButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:TwoFingerTapTaskIdentifier];
 }
 
-- (IBAction)reactionTimeTaskButtonTapped:(id)sender {
+- (void)reactionTimeTaskButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:ReactionTimeTaskIdentifier];
 }
 
-- (IBAction)towerOfHanoiTaskButtonTapped:(id)sender {
+- (void)towerOfHanoiTaskButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:TowerOfHanoiTaskIdentifier];
 }
 
-- (IBAction)timedWalkTaskButtonTapped:(id)sender {
+- (void)timedWalkTaskButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:TimedWalkTaskIdentifier];
 }
 
-- (IBAction)psatTaskButtonTapped:(id)sender {
+- (void)psatTaskButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:PSATTaskIdentifier];
 }
 
-- (IBAction)holePegTestTaskButtonTapped:(id)sender {
+- (void)holePegTestTaskButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:HolePegTestTaskIdentifier];
 }
 
@@ -2097,7 +2099,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
 /*
  See the `DynamicTask` class for a definition of this task.
  */
-- (IBAction)dynamicTaskButtonTapped:(id)sender {
+- (void)dynamicTaskButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:DynamicTaskIdentifier];
 }
 
@@ -2111,7 +2113,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
  See the implementation of the task view controller delegate methods for specific
  handling of this task.
  */
-- (id<ORKTask>)makeScreeningTask {
+- (id<ORKTask>)makeInterruptibleTask {
     NSMutableArray *steps = [NSMutableArray new];
     
     {
@@ -2137,12 +2139,12 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         [steps addObject:step];
     }
     
-    ORKOrderedTask *task = [[ORKOrderedTask alloc] initWithIdentifier:ScreeningTaskIdentifier steps:steps];
+    ORKOrderedTask *task = [[ORKOrderedTask alloc] initWithIdentifier:InterruptibleTaskIdentifier steps:steps];
     return task;
 }
 
-- (IBAction)interruptibleTaskButtonTapped:(id)sender {
-    [self beginTaskWithIdentifier:ScreeningTaskIdentifier];
+- (void)interruptibleTaskButtonTapped:(id)sender {
+    [self beginTaskWithIdentifier:InterruptibleTaskIdentifier];
 }
 
 #pragma mark - Scales task
@@ -2444,7 +2446,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     
 }
 
-- (IBAction)scaleButtonTapped:(id)sender {
+- (void)scaleButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:ScalesTaskIdentifier];
 }
 
@@ -2568,7 +2570,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     
 }
 
-- (IBAction)imageChoicesButtonTapped:(id)sender {
+- (void)imageChoicesButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:ImageChoicesTaskIdentifier];
 }
 
@@ -2581,8 +2583,6 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
      take your instructions literally. So, be cautious. Make sure your template image
      is high contrast and very visible against a variety of backgrounds.
      */
-     
-    
     {
         ORKInstructionStep *step = [[ORKInstructionStep alloc] initWithIdentifier:@"begin"];
         step.title = @"Hands";
@@ -2590,6 +2590,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         step.detailText = @"In this step we will capture images of both of your hands";
         [steps addObject:step];
     }
+    
     {
         ORKInstructionStep *step = [[ORKInstructionStep alloc] initWithIdentifier:@"right1"];
         step.title = @"Right Hand";
@@ -2597,6 +2598,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         step.detailText = @"Let's start by capturing an image of your right hand";
         [steps addObject:step];
     }
+    
     {
         ORKInstructionStep *step = [[ORKInstructionStep alloc] initWithIdentifier:@"right2"];
         step.title = @"Right Hand";
@@ -2604,6 +2606,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         step.detailText = @"Align your right hand with the on-screen outline and capture the image.  Be sure to place your hand over a contrasting background.  You can re-capture the image as many times as you need.";
         [steps addObject:step];
     }
+    
     {
         ORKImageCaptureStep *step = [[ORKImageCaptureStep alloc] initWithIdentifier:@"right3"];
         step.templateImage = [UIImage imageNamed:@"right_hand_outline_big"];
@@ -2612,6 +2615,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         step.accessibilityHint = @"Captures the image visible in the preview";
         [steps addObject:step];
     }
+    
     {
         ORKInstructionStep *step = [[ORKInstructionStep alloc] initWithIdentifier:@"left1"];
         step.title = @"Left Hand";
@@ -2619,6 +2623,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         step.detailText = @"Now let's capture an image of your left hand";
         [steps addObject:step];
     }
+    
     {
         ORKInstructionStep *step = [[ORKInstructionStep alloc] initWithIdentifier:@"left2"];
         step.title = @"Left Hand";
@@ -2626,6 +2631,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         step.detailText = @"Align your left hand with the on-screen outline and capture the image.  Be sure to place your hand over a contrasting background.  You can re-capture the image as many times as you need.";
         [steps addObject:step];
     }
+    
     {
         ORKImageCaptureStep *step = [[ORKImageCaptureStep alloc] initWithIdentifier:@"left3"];
         step.templateImage = [UIImage imageNamed:@"left_hand_outline_big"];
@@ -2634,24 +2640,31 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         step.accessibilityHint = @"Captures the image visible in the preview";
         [steps addObject:step];
     }
+    
     {
         ORKInstructionStep *step = [[ORKInstructionStep alloc] initWithIdentifier:@"end"];
         step.title = @"Complete";
         step.detailText = @"Hand image capture complete";
         [steps addObject:step];
     }
+    
     ORKOrderedTask *task = [[ORKOrderedTask alloc] initWithIdentifier:ImageCaptureTaskIdentifier steps:steps];
     return task;
-    
-}
-- (IBAction)imageCaptureButtonTapped:(id)sender {
-    [self beginTaskWithIdentifier:ImageCaptureTaskIdentifier];
-}
-- (IBAction)navigableOrderedTaskButtonTapped:(id)sender {
-    [self beginTaskWithIdentifier:StepNavigationTaskIdentifier];
 }
 
-- (IBAction)toggleTintColorButtonTapped:(id)sender {
+- (void)imageCaptureButtonTapped:(id)sender {
+    [self beginTaskWithIdentifier:ImageCaptureTaskIdentifier];
+}
+
+- (void)navigableOrderedTaskButtonTapped:(id)sender {
+    [self beginTaskWithIdentifier:NavigableOrderedTaskIdentifier];
+}
+
+- (void)navigableLoopTaskButtonTapped:(id)sender {
+    [self beginTaskWithIdentifier:NavigableLoopTaskIdentifier];
+}
+
+- (void)toggleTintColorButtonTapped:(id)sender {
     static UIColor *defaultTintColor = nil;
     if (!defaultTintColor) {
         defaultTintColor = self.view.tintColor;
@@ -2742,7 +2755,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     step.title = @"This step is intentionally left blank (you should not see it)";
     [steps addObject:step];
 
-    ORKNavigableOrderedTask *task = [[ORKNavigableOrderedTask alloc] initWithIdentifier:StepNavigationTaskIdentifier
+    ORKNavigableOrderedTask *task = [[ORKNavigableOrderedTask alloc] initWithIdentifier:NavigableOrderedTaskIdentifier
                                                                                   steps:steps];
     
     // Build navigation rules
@@ -2831,6 +2844,66 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     return task;
 }
 
+#pragma mark - Navigable Loop Task
+
+- (id<ORKTask>)makeNavigableLoopTask {
+    NSMutableArray *steps = [NSMutableArray new];
+    
+    ORKAnswerFormat *answerFormat = nil;
+    ORKStep *step = nil;
+    
+    // Intro step
+    step = [[ORKInstructionStep alloc] initWithIdentifier:@"intro"];
+    step.title = @"This task demonstrates an optional loop within a navigable ordered task";
+    [steps addObject:step];
+
+    // Target step
+    step = [[ORKInstructionStep alloc] initWithIdentifier:@"loop_a"];
+    step.title = @"Later on, we'll return to this step";
+    [steps addObject:step];
+
+    // One intermediate step
+    ORKContinuousScaleAnswerFormat *scaleAnswerFormat =  [ORKAnswerFormat continuousScaleAnswerFormatWithMaximumValue:10
+                                                                                                         minimumValue:1
+                                                                                                         defaultValue:8.725
+                                                                                                maximumFractionDigits:3
+                                                                                                             vertical:YES
+                                                                                              maximumValueDescription:nil
+                                                                                              minimumValueDescription:nil];
+    
+    step = [ORKQuestionStep questionStepWithIdentifier:@"scale"
+                                                 title:@"On a scale of 1 to 10, what is your mood?"
+                                                answer:scaleAnswerFormat];
+    [steps addObject:step];
+
+    // Question steps
+    answerFormat = [ORKAnswerFormat booleanAnswerFormat];
+    step = [ORKQuestionStep questionStepWithIdentifier:@"loop_b" title:@"Do you want to repeat the survey?" answer:answerFormat];
+    step.optional = NO;
+    [steps addObject:step];
+    
+    step = [[ORKInstructionStep alloc] initWithIdentifier:@"end"];
+    step.title = @"You have finished the task";
+    [steps addObject:step];
+    
+    ORKNavigableOrderedTask *task = [[ORKNavigableOrderedTask alloc] initWithIdentifier:NavigableLoopTaskIdentifier
+                                                                                  steps:steps];
+    
+    // Build navigation rules
+    ORKPredicateStepNavigationRule *predicateRule = nil;
+    ORKResultSelector *resultSelector = nil;
+    
+    // From the feel/mood form step, skip the survey if the user is feeling okay and has a good mood
+    resultSelector = [ORKResultSelector selectorWithResultIdentifier:@"loop_b"];
+    NSPredicate *predicateRepeatYes = [ORKResultPredicate predicateForBooleanQuestionResultWithResultSelector:resultSelector
+                                                                                                 expectedAnswer:YES];
+    predicateRule = [[ORKPredicateStepNavigationRule alloc] initWithResultPredicates:@[ predicateRepeatYes ]
+                                                          destinationStepIdentifiers:@[ @"loop_a" ] ];
+    [task setNavigationRule:predicateRule forTriggerStepIdentifier:@"loop_b"];
+    
+    return task;
+}
+
 #pragma mark - Custom navigation item task
 
 - (id<ORKTask>)makeCustomNavigationItemTask {
@@ -2844,7 +2917,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     return [[ORKOrderedTask alloc] initWithIdentifier: CustomNavigationItemTaskIdentifier steps:steps];
 }
 
-- (IBAction)customNavigationItemButtonTapped:(id)sender {
+- (void)customNavigationItemButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:CustomNavigationItemTaskIdentifier];
 }
 
@@ -2866,11 +2939,11 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     return [[ORKOrderedTask alloc] initWithIdentifier: CreatePasscodeTaskIdentifier steps:steps];
 }
 
-- (IBAction)createPasscodeButtonTapped:(id)sender {
+- (void)createPasscodeButtonTapped:(id)sender {
     [self beginTaskWithIdentifier:CreatePasscodeTaskIdentifier];
 }
 
-- (IBAction)removePasscodeButtonTapped:(id)sender {
+- (void)removePasscodeButtonTapped:(id)sender {
     if ([ORKPasscodeViewController isPasscodeStoredInKeychain]) {
         if ([ORKPasscodeViewController removePasscodeFromKeychain]) {
             [self showAlertWithTitle:@"Success" message:@"Passcode removed."];
@@ -2882,7 +2955,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     }
 }
 
-- (IBAction)authenticatePasscodeButtonTapped:(id)sender {
+- (void)authenticatePasscodeButtonTapped:(id)sender {
     if ([ORKPasscodeViewController isPasscodeStoredInKeychain]) {
         ORKPasscodeViewController *viewController = [ORKPasscodeViewController
                                                      passcodeAuthenticationViewControllerWithText:@"Authenticate your passcode in order to proceed."
@@ -2893,7 +2966,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     }
 }
 
-- (IBAction)editPasscodeButtonTapped:(id)sender {
+- (void)editPasscodeButtonTapped:(id)sender {
     if ([ORKPasscodeViewController isPasscodeStoredInKeychain]) {
         ORKPasscodeViewController *viewController = [ORKPasscodeViewController passcodeEditingViewControllerWithText:nil
                                                                                                             delegate:self
@@ -3124,7 +3197,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     NSString *task_identifier = taskViewController.task.identifier;
 
     return ([step isKindOfClass:[ORKInstructionStep class]]
-            && NO == [@[AudioTaskIdentifier, FitnessTaskIdentifier, GaitTaskIdentifier, TwoFingerTapTaskIdentifier, StepNavigationTaskIdentifier] containsObject:task_identifier]);
+            && NO == [@[AudioTaskIdentifier, FitnessTaskIdentifier, GaitTaskIdentifier, TwoFingerTapTaskIdentifier, NavigableOrderedTaskIdentifier, NavigableLoopTaskIdentifier] containsObject:task_identifier]);
 }
 
 /*

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -3399,39 +3399,7 @@ stepViewControllerWillAppear:(ORKStepViewController *)stepViewController {
  */
 - (void)taskViewControllerDidComplete:(ORKTaskViewController *)taskViewController {
     
-    NSLog(@"%@", taskViewController.result);
-    for (ORKStepResult *sResult in taskViewController.result.results) {
-        NSLog(@"--%@", sResult);
-        for (ORKResult *result in sResult.results) {
-            if ([result isKindOfClass:[ORKDateQuestionResult class]]) {
-                ORKDateQuestionResult *dateQuestionResult = (ORKDateQuestionResult *)result;
-                NSLog(@"    %@:   %@  %@  %@", result.identifier, dateQuestionResult.answer, dateQuestionResult.timeZone, dateQuestionResult.calendar);
-            } else if ([result isKindOfClass:[ORKQuestionResult class]]) {
-                ORKQuestionResult *qr = (ORKQuestionResult *)result;
-                NSLog(@"    %@:   %@", result.identifier, qr.answer);
-            } else if ([result isKindOfClass:[ORKTappingIntervalResult class]]) {
-                ORKTappingIntervalResult *tir = (ORKTappingIntervalResult *)result;
-                NSLog(@"    %@:     %@\n    %@ %@", tir.identifier, tir.samples, NSStringFromCGRect(tir.buttonRect1), NSStringFromCGRect(tir.buttonRect2));
-            } else if ([result isKindOfClass:[ORKFileResult class]]) {
-                ORKFileResult *fileResult = (ORKFileResult *)result;
-                NSLog(@"    File: %@", fileResult.fileURL);
-            } else if ([result isKindOfClass:[ORKToneAudiometryResult class]]) {
-                ORKToneAudiometryResult *tor = (ORKToneAudiometryResult *)result;
-                NSLog(@"    %@:     %@", tor.identifier, tor.samples);
-            } else if ([result isKindOfClass:[ORKPSATResult class]]) {
-                ORKPSATResult *pr = (ORKPSATResult *)result;
-                NSLog(@"    %@:     %@\n    Total correct:     %@/%@", pr.identifier, pr.samples, @(pr.totalCorrect), @(pr.length));
-            } else if ([result isKindOfClass:[ORKTimedWalkResult class]]) {
-                ORKTimedWalkResult *twr = (ORKTimedWalkResult *)result;
-                NSLog(@"%@ %@ %@ %@", twr.identifier, @(twr.distanceInMeters), @(twr.timeLimit), @(twr.duration));
-            } else if ([result isKindOfClass:[ORKHolePegTestResult class]]) {
-                ORKHolePegTestResult *hptr = (ORKHolePegTestResult *)result;
-                NSLog(@"    %@:   totalTime: %@     %@", hptr.identifier, @(hptr.totalTime), hptr.samples);
-            } else {
-                NSLog(@"    %@:   userInfo: %@", result.identifier, result.userInfo);
-            }
-        }
-    }
+    NSLog(@"[ORKTest] task results: %@", taskViewController.result);
     
     if (_currentDocument)
     {

--- a/Testing/ORKTest/ORKTest/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTest/ORKESerialization.m
@@ -357,7 +357,6 @@ ret =
              return task;
          },(@{
               PROPERTY(stepNavigationRules, ORKStepNavigationRule, NSMutableDictionary, YES, nil, nil),
-              PROPERTY(stepIdentifierStack, NSMutableOrderedSet, NSObject, YES, nil, nil),
               })),
    ENTRY(ORKStep,
          ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -330,7 +330,7 @@ ORK_MAKE_TEST_INIT(ORKDeviceMotionRecorderConfiguration, ^{ return [super initWi
     // Predefined exception
     NSArray *propertyExclusionList = @[@"superclass",
                                        @"description",
-                                       @"descriptionPrefix",
+                                       @"descriptionSuffix",
                                        @"debugDescription",
                                        @"hash",
                                        @"requestedHealthKitTypesForReading",
@@ -541,7 +541,7 @@ ORK_MAKE_TEST_INIT(ORKDeviceMotionRecorderConfiguration, ^{ return [super initWi
     // Predefined exception
     NSArray *propertyExclusionList = @[@"superclass",
                                        @"description",
-                                       @"descriptionPrefix",
+                                       @"descriptionSuffix",
                                        @"debugDescription",
                                        @"hash",
                                        @"requestedHealthKitTypesForReading",
@@ -715,7 +715,7 @@ ORK_MAKE_TEST_INIT(ORKDeviceMotionRecorderConfiguration, ^{ return [super initWi
     // Predefined exception
     NSArray *propertyExclusionList = @[@"superclass",
                                        @"description",
-                                       @"descriptionPrefix",
+                                       @"descriptionSuffix",
                                        @"debugDescription",
                                        @"hash",
                                        @"requestedHealthKitTypesForReading",

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -330,6 +330,7 @@ ORK_MAKE_TEST_INIT(ORKDeviceMotionRecorderConfiguration, ^{ return [super initWi
     // Predefined exception
     NSArray *propertyExclusionList = @[@"superclass",
                                        @"description",
+                                       @"descriptionPrefix",
                                        @"debugDescription",
                                        @"hash",
                                        @"requestedHealthKitTypesForReading",
@@ -540,6 +541,7 @@ ORK_MAKE_TEST_INIT(ORKDeviceMotionRecorderConfiguration, ^{ return [super initWi
     // Predefined exception
     NSArray *propertyExclusionList = @[@"superclass",
                                        @"description",
+                                       @"descriptionPrefix",
                                        @"debugDescription",
                                        @"hash",
                                        @"requestedHealthKitTypesForReading",
@@ -713,6 +715,7 @@ ORK_MAKE_TEST_INIT(ORKDeviceMotionRecorderConfiguration, ^{ return [super initWi
     // Predefined exception
     NSArray *propertyExclusionList = @[@"superclass",
                                        @"description",
+                                       @"descriptionPrefix",
                                        @"debugDescription",
                                        @"hash",
                                        @"requestedHealthKitTypesForReading",


### PR DESCRIPTION
This PR improves the situation described on [Issue #502](https://github.com/ResearchKit/ResearchKit/issues/502).

It removes the `ORKNavigableOrderedTask`'s `_stepIdentifierStack` ivar (used for backwards navigation) and uses the *managed task result* instead. The *managed task result* will only show results for the steps that have been previously visited, so it can be used to simulate the backwards navigation stack.

The `ORKTaskViewController`'s `_managedStepIdentifiers` ivar has been converted into an `NSMutableOrderedSet`. When an already visited step is shown (either by going back, or by following a loop in a navigable ordered task), all the managed step identifiers which come later than the step being shown are removed.

This commit also updates `ORKTest` by removing the *Save For Later* navigable ordered task archiving (which is no longer needed) and adds an `Ordered Loop Task` example which can be used to test backwards navigation when looping.

Some minor style refactor was also done on `ORKTest`, and `ORKResult` `description` methods were extended and homogenized for easier debugging.