### PR TITLE
Enable 'Continue button' when there is a default scale value

### DIFF
--- a/ResearchKit/Common/ORKQuestionStepViewController.m
+++ b/ResearchKit/Common/ORKQuestionStepViewController.m
@@ -309,7 +309,7 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
 
 - (void)defaultAnswerDidChange {
     id defaultAnswer = _defaultAnswer;
-    if (![self hasAnswer] && (self.answer != ORKNullAnswerValue()) && defaultAnswer && !self.hasChangedAnswer) {
+    if (![self hasAnswer] && defaultAnswer && !self.hasChangedAnswer) {
         _answer = defaultAnswer;
         
         [self answerDidChange];

--- a/ResearchKit/Common/ORKStepViewController.m
+++ b/ResearchKit/Common/ORKStepViewController.m
@@ -264,12 +264,11 @@
 }
 
 - (ORKStepResult *)result {
+    ORKStepResult *stepResult = [[ORKStepResult alloc] initWithStepIdentifier:self.step.identifier results:@[]];
+    stepResult.startDate = self.presentedDate;
+    stepResult.endDate = self.dismissedDate? :[NSDate date];
     
-    ORKStepResult *sResult = [[ORKStepResult alloc] initWithStepIdentifier:self.step.identifier results:@[]];
-    sResult.startDate = self.presentedDate;
-    sResult.endDate = self.dismissedDate? :[NSDate date];
-    
-    return sResult;
+    return stepResult;
 }
 
 - (void)notifyDelegateOnResultChange {

--- a/ResearchKit/Common/ORKSurveyAnswerCellForScale.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForScale.m
@@ -81,7 +81,6 @@
 }
 
 - (void)answerDidChange {
-    id<ORKScaleAnswerFormatProvider> formatProvider = self.formatProvider;
     id answer = self.answer;
     if (answer && answer != ORKNullAnswerValue()) {
         if (![self.answer isKindOfClass:[NSNumber class]]) {
@@ -90,11 +89,7 @@
         
         [_sliderView setCurrentValue:answer];
     } else {
-        if (answer == nil && [formatProvider defaultNumber]) {
-            [self.sliderView setCurrentValue:[formatProvider defaultNumber]];
-        } else {
-           [self.sliderView setCurrentValue:nil];
-        }
+        [self.sliderView setCurrentValue:nil];
     }
 }
 

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -1763,6 +1763,23 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     NSMutableArray *steps = [NSMutableArray new];
     
     {
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"scale_form_00" title:@"Optional Form Items" text:@"Optional form with no required items and a default scale value"];
+        NSMutableArray *items = [NSMutableArray new];
+        [steps addObject:step];
+        
+        {
+            ORKScaleAnswerFormat *format = [ORKScaleAnswerFormat scaleAnswerFormatWithMaximumValue:10 minimumValue:1 defaultValue:4 step:1 vertical:YES maximumValueDescription:nil minimumValueDescription:nil];
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"scale_form"
+                                                                   text:@"Optional scale"
+                                                           answerFormat:format];
+            item.optional = NO;
+            [items addObject:item];
+        }
+        
+        [step setFormItems:items];
+    }
+
+    {
         ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_000" title:@"Optional Form Items" text:@"Optional form with no required items"];
         NSMutableArray *items = [NSMutableArray new];
         [steps addObject:step];


### PR DESCRIPTION
This PR enables the *Continue button* when there is a default value in the scale answer formats.

Also: add a step to `ORKTest`'s `Optional Form` example featuring an optional scale form item with a default value.

Please, review carefully, in case this change produces any side-effects.