### PR TITLE
Refractor scale answer format

### DIFF
--- a/ResearchKit/ActiveTasks/ORKPSATStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKPSATStepViewController.m
@@ -43,7 +43,7 @@
 
 @property (nonatomic, strong) NSMutableArray *samples;
 @property (nonatomic, strong) ORKPSATContentView *psatContentView;
-@property (nonatomic, strong) NSArray *digits;
+@property (nonatomic, strong) NSArray<NSNumber *> *digits;
 @property (nonatomic, assign) NSUInteger currentDigitIndex;
 @property (nonatomic, assign) NSInteger currentAnswer;
 @property (nonatomic, strong) ORKActiveStepTimer *clearDigitsTimer;
@@ -116,7 +116,7 @@
         PSATResult.stimulusDuration = 0.0;
     }
     PSATResult.length = [self psatStep].seriesLength;
-    PSATResult.initialDigit = [(NSNumber *)[self.digits objectAtIndex:0] integerValue];
+    PSATResult.initialDigit = self.digits[0].integerValue;
     NSInteger totalCorrect = 0;
     BOOL previousAnswerCorrect = NO;
     NSInteger totalDyad = 0;
@@ -146,7 +146,7 @@
 - (void)start {
     self.digits = [self arrayWithPSATDigits];
     self.currentDigitIndex = 0;
-    [self.psatContentView setAddition:self.currentDigitIndex forTotal:[self psatStep].seriesLength withDigit:[self.digits objectAtIndex:self.currentDigitIndex]];
+    [self.psatContentView setAddition:self.currentDigitIndex forTotal:[self psatStep].seriesLength withDigit:self.digits[self.currentDigitIndex]];
     [self.psatContentView setProgress:0.001 animated:NO];
     self.currentAnswer = -1;
     self.samples = [NSMutableArray array];
@@ -198,7 +198,7 @@
     self.answerEnd = 0;
     
     if (self.currentDigitIndex <= [self psatStep].seriesLength) {
-        [self.psatContentView setAddition:self.currentDigitIndex forTotal:[self psatStep].seriesLength withDigit:[self.digits objectAtIndex:self.currentDigitIndex]];
+        [self.psatContentView setAddition:self.currentDigitIndex forTotal:[self psatStep].seriesLength withDigit:self.digits[self.currentDigitIndex]];
     }
     
     self.currentAnswer = -1;
@@ -215,8 +215,8 @@
 
 - (void)saveSample {
     ORKPSATSample *sample = [[ORKPSATSample alloc] init];
-    NSInteger previousDigit = [(NSNumber *)[self.digits objectAtIndex:self.currentDigitIndex - 1] integerValue];
-    NSInteger currentDigit = [(NSNumber *)[self.digits objectAtIndex:self.currentDigitIndex] integerValue];
+    NSInteger previousDigit = self.digits[self.currentDigitIndex - 1].integerValue;
+    NSInteger currentDigit = self.digits[self.currentDigitIndex].integerValue;;
     sample.correct = previousDigit + currentDigit == self.currentAnswer ? YES : NO;
     sample.digit = currentDigit;
     sample.answer = self.currentAnswer;

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -556,9 +556,8 @@ ORK_CLASS_AVAILABLE
  The `ORKTextScaleAnswerFormat` represents an answer format that includes a discrete slider control
  with a text label next to each step.
  
- The scale answer format produces an `ORKChoiceQuestionResult` object that contains a number whose
- value is the selected slider value.
- */
+ The scale answer format produces an `ORKChoiceQuestionResult` object that contains the selected text 
+ choice's value. */
 ORK_CLASS_AVAILABLE
 @interface ORKTextScaleAnswerFormat : ORKAnswerFormat
 

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -556,7 +556,7 @@ ORK_CLASS_AVAILABLE
  The `ORKTextScaleAnswerFormat` represents an answer format that includes a discrete slider control
  with a text label next to each step.
  
- The scale answer format produces an `ORKScaleQuestionResult` object that contains a number whose
+ The scale answer format produces an `ORKChoiceQuestionResult` object that contains a number whose
  value is the selected slider value.
  */
 ORK_CLASS_AVAILABLE

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1394,7 +1394,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         return nil;
     }
     
-    NSInteger integer = round((double)(_defaultValue-_minimum)/(double)_step)*_step + _minimum;
+    NSInteger integer = round( (double)( _defaultValue - _minimum ) / (double)_step ) * _step + _minimum;
     
     return @(integer);
 }
@@ -1767,10 +1767,10 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     return [self.numberFormatter stringFromNumber:number];
 }
 - (NSString *)minimumValueDescription {
-    return ((ORKTextChoice *)[self.textChoices firstObject]).text;
+    return ([self.textChoices firstObject]).text;
 }
 - (NSString *)maximumValueDescription {
-    return ((ORKTextChoice *)[self.textChoices lastObject]).text;
+    return ([self.textChoices lastObject]).text;
 }
 - (UIImage *)minimumImage {
     return nil;

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1721,7 +1721,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 }
 
 - (Class)questionResultClass {
-    return [ORKScaleQuestionResult class];
+    return [ORKChoiceQuestionResult class];
 }
 
 - (instancetype)init {
@@ -1760,7 +1760,8 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     if (_defaultIndex < 0 || _defaultIndex >= _textChoices.count) {
         return nil;
     }
-    return @(_defaultIndex);
+    // slider's minimumNumber is 1
+    return @(_defaultIndex + 1);
 }
 - (NSString *)localizedStringForNumber:(NSNumber *)number {
     return [self.numberFormatter stringFromNumber:number];
@@ -1794,6 +1795,32 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 
 - (NSNumber *)normalizedValueForNumber:(NSNumber *)number {
     return @([number integerValue]);
+}
+
+- (ORKTextChoice *)textChoiceForIndex:(NSUInteger)index {
+    
+    if (index >= _textChoices.count) {
+        return nil;
+    }
+    return _textChoices[index];
+}
+
+- (ORKTextChoice *)textChoiceForValue:(id<NSCopying, NSCoding, NSObject>)value {
+    __block ORKTextChoice *choice = nil;
+    
+    [_textChoices enumerateObjectsUsingBlock:^(ORKTextChoice * _Nonnull textChoice, NSUInteger idx, BOOL * _Nonnull stop) {
+        if ([textChoice.value isEqual:value]) {
+            choice = textChoice;
+            *stop = YES;
+        }
+    }];
+    
+    return choice;
+}
+
+- (NSUInteger)textChoiceIndexForValue:(id<NSCopying, NSCoding, NSObject>)value {
+   ORKTextChoice *choice = [self textChoiceForValue:value];
+   return choice ? [_textChoices indexOfObject:choice] : NSNotFound;
 }
 
 - (void)validateParameters {

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -539,11 +539,11 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     
     __typeof(self) castObject = object;
     return (isParentSame &&
-            ORKEqualObjects(self.textChoices, castObject.textChoices));
+            ORKEqualObjects(_textChoices, castObject.textChoices));
 }
 
 - (NSUInteger)hash {
-    return [super hash] ^ [self.textChoices hash];
+    return [super hash] ^ [_textChoices hash];
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
@@ -681,12 +681,12 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     
     __typeof(self) castObject = object;
     return (isParentSame &&
-            ORKEqualObjects(self.textChoices, castObject.textChoices) &&
+            ORKEqualObjects(_textChoices, castObject.textChoices) &&
             (_style == castObject.style));
 }
 
 - (NSUInteger)hash {
-    return [super hash] ^ [self.textChoices hash] ^ _style;
+    return [super hash] ^ [_textChoices hash] ^ _style;
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
@@ -1754,23 +1754,23 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     return @(1);
 }
 - (NSNumber *)maximumNumber {
-    return @(self.textChoices.count);
+    return @(_textChoices.count);
 }
 - (id<NSObject, NSCopying, NSCoding>)defaultAnswer {
     if (_defaultIndex < 0 || _defaultIndex >= _textChoices.count) {
         return nil;
     }
    
-    return @[[self.textChoices objectAtIndex:_defaultIndex].value];
+    return @[[_textChoices objectAtIndex:_defaultIndex].value];
 }
 - (NSString *)localizedStringForNumber:(NSNumber *)number {
     return [self.numberFormatter stringFromNumber:number];
 }
 - (NSString *)minimumValueDescription {
-    return self.textChoices.firstObject.text;
+    return _textChoices.firstObject.text;
 }
 - (NSString *)maximumValueDescription {
-    return self.textChoices.lastObject.text;
+    return _textChoices.lastObject.text;
 }
 - (UIImage *)minimumImage {
     return nil;
@@ -1790,7 +1790,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 }
 
 - (NSInteger)numberOfSteps {
-    return self.textChoices.count - 1;
+    return _textChoices.count - 1;
 }
 
 - (NSNumber *)normalizedValueForNumber:(NSNumber *)number {

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1767,10 +1767,10 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     return [self.numberFormatter stringFromNumber:number];
 }
 - (NSString *)minimumValueDescription {
-    return ([self.textChoices firstObject]).text;
+    return self.textChoices.firstObject.text;
 }
 - (NSString *)maximumValueDescription {
-    return ([self.textChoices lastObject]).text;
+    return self.textChoices.lastObject.text;
 }
 - (UIImage *)minimumImage {
     return nil;

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1389,7 +1389,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 - (NSNumber *)maximumNumber {
     return @(_maximum);
 }
-- (NSNumber *)defaultNumber {
+- (NSNumber *)defaultAnswer {
     if ( _defaultValue > _maximum || _defaultValue < _minimum) {
         return nil;
     }
@@ -1594,7 +1594,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 - (NSNumber *)maximumNumber {
     return @(_maximum);
 }
-- (NSNumber *)defaultNumber {
+- (NSNumber *)defaultAnswer {
     if ( _defaultValue > _maximum || _defaultValue < _minimum) {
         return nil;
     }
@@ -1756,12 +1756,12 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 - (NSNumber *)maximumNumber {
     return @(self.textChoices.count);
 }
-- (NSNumber *)defaultNumber {
+- (id<NSObject, NSCopying, NSCoding>)defaultAnswer {
     if (_defaultIndex < 0 || _defaultIndex >= _textChoices.count) {
         return nil;
     }
-    // slider's minimumNumber is 1
-    return @(_defaultIndex + 1);
+   
+    return @[[self.textChoices objectAtIndex:_defaultIndex].value];
 }
 - (NSString *)localizedStringForNumber:(NSNumber *)number {
     return [self.numberFormatter stringFromNumber:number];

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1761,7 +1761,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         return nil;
     }
    
-    return @[[_textChoices objectAtIndex:_defaultIndex].value];
+    return @[[self textChoiceAtIndex:_defaultIndex].value];
 }
 - (NSString *)localizedStringForNumber:(NSNumber *)number {
     return [self.numberFormatter stringFromNumber:number];
@@ -1797,7 +1797,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     return @([number integerValue]);
 }
 
-- (ORKTextChoice *)textChoiceForIndex:(NSUInteger)index {
+- (ORKTextChoice *)textChoiceAtIndex:(NSUInteger)index {
     
     if (index >= _textChoices.count) {
         return nil;

--- a/ResearchKit/Common/ORKAnswerFormat_Internal.h
+++ b/ResearchKit/Common/ORKAnswerFormat_Internal.h
@@ -151,6 +151,7 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTimeIntervalAnswerFormat)
 
 @end
 
+
 @interface ORKTextScaleAnswerFormat () <ORKScaleAnswerFormatProvider>
 
 @end
@@ -209,6 +210,7 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTimeIntervalAnswerFormat)
 - (void)updateHealthKitUnitForAnswerFormat:(ORKAnswerFormat *)answerFormat force:(BOOL)force;
 
 @end
+
 
 NS_ASSUME_NONNULL_END
 

--- a/ResearchKit/Common/ORKAnswerFormat_Internal.h
+++ b/ResearchKit/Common/ORKAnswerFormat_Internal.h
@@ -133,9 +133,13 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTimeIntervalAnswerFormat)
 - (NSString *)minimumValueDescription;
 - (UIImage *)maximumImage;
 - (UIImage *)minimumImage;
-- (NSArray<ORKTextChoice *> *)textChoices;
 
-@optional
+@end
+
+
+@protocol ORKTextScaleAnswerFormatProvider <ORKScaleAnswerFormatProvider>
+
+- (NSArray<ORKTextChoice *> *)textChoices;
 - (ORKTextChoice *)textChoiceForIndex:(NSUInteger)index;
 - (NSUInteger)textChoiceIndexForValue:(id<NSCopying, NSCoding, NSObject>)value;
 
@@ -152,7 +156,7 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTimeIntervalAnswerFormat)
 @end
 
 
-@interface ORKTextScaleAnswerFormat () <ORKScaleAnswerFormatProvider>
+@interface ORKTextScaleAnswerFormat () <ORKTextScaleAnswerFormatProvider>
 
 @end
 

--- a/ResearchKit/Common/ORKAnswerFormat_Internal.h
+++ b/ResearchKit/Common/ORKAnswerFormat_Internal.h
@@ -124,7 +124,7 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTimeIntervalAnswerFormat)
 
 - (nullable NSNumber *)minimumNumber;
 - (nullable NSNumber *)maximumNumber;
-- (nullable NSNumber *)defaultNumber;
+- (nullable id)defaultAnswer;
 - (nullable NSString *)localizedStringForNumber:(nullable NSNumber *)number;
 - (NSInteger)numberOfSteps;
 - (nullable NSNumber *)normalizedValueForNumber:(nullable NSNumber *)number;

--- a/ResearchKit/Common/ORKAnswerFormat_Internal.h
+++ b/ResearchKit/Common/ORKAnswerFormat_Internal.h
@@ -140,7 +140,7 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTimeIntervalAnswerFormat)
 @protocol ORKTextScaleAnswerFormatProvider <ORKScaleAnswerFormatProvider>
 
 - (NSArray<ORKTextChoice *> *)textChoices;
-- (ORKTextChoice *)textChoiceForIndex:(NSUInteger)index;
+- (ORKTextChoice *)textChoiceAtIndex:(NSUInteger)index;
 - (NSUInteger)textChoiceIndexForValue:(id<NSCopying, NSCoding, NSObject>)value;
 
 @end

--- a/ResearchKit/Common/ORKAnswerFormat_Internal.h
+++ b/ResearchKit/Common/ORKAnswerFormat_Internal.h
@@ -135,6 +135,10 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTimeIntervalAnswerFormat)
 - (UIImage *)minimumImage;
 - (NSArray<ORKTextChoice *> *)textChoices;
 
+@optional
+- (ORKTextChoice *)textChoiceForIndex:(NSUInteger)index;
+- (NSUInteger)textChoiceIndexForValue:(id<NSCopying, NSCoding, NSObject>)value;
+
 @end
 
 
@@ -144,6 +148,10 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTimeIntervalAnswerFormat)
 
 
 @interface ORKContinuousScaleAnswerFormat () <ORKScaleAnswerFormatProvider>
+
+@end
+
+@interface ORKTextScaleAnswerFormat () <ORKScaleAnswerFormatProvider>
 
 @end
 

--- a/ResearchKit/Common/ORKFormItemCell.h
+++ b/ResearchKit/Common/ORKFormItemCell.h
@@ -54,11 +54,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithReuseIdentifier:(NSString *)reuseIdentifier
                                formItem:(ORKFormItem *)formItem
                                  answer:(nullable id)answer
-                          maxLabelWidth:(CGFloat)maxLabelWidth;
+                          maxLabelWidth:(CGFloat)maxLabelWidth
+                               delegate:(id<ORKFormItemCellDelegate>)delegate;
 
-@property (nonatomic, weak, nullable) id<ORKFormItemCellDelegate> delegate;
+@property (nonatomic, weak, readonly) id<ORKFormItemCellDelegate> delegate;
 @property (nonatomic, copy, nullable) id answer;
-@property (nonatomic, strong, nullable) ORKFormItem *formItem;
+@property (nonatomic, strong) ORKFormItem *formItem;
 @property (nonatomic, copy, nullable) id defaultAnswer;
 @property (nonatomic) CGFloat maxLabelWidth;
 @property (nonatomic) CGFloat expectedLayoutWidth;

--- a/ResearchKit/Common/ORKFormItemCell.m
+++ b/ResearchKit/Common/ORKFormItemCell.m
@@ -107,8 +107,8 @@ static const CGFloat HorizontalMargin = 15.0;
                                delegate:(id<ORKFormItemCellDelegate>)delegate {
     self = [super initWithStyle:UITableViewCellStyleDefault reuseIdentifier:reuseIdentifier];
     if (self) {
-        // Setting `delegate` during init is required.
-        // Some question need this to report its default answer to ORKFormStepViewController;
+        // Setting the 'delegate' on init is required, as some questions (such as the scale questions)
+        // need it when they wish to report their default answers to 'ORKFormStepViewController'.
         _delegate = delegate;
         
         _maxLabelWidth = maxLabelWidth;
@@ -986,6 +986,7 @@ static const CGFloat HorizontalMargin = 15.0;
 @interface ORKFormItemScaleCell () <ORKScaleSliderViewDelegate>
 
 @end
+
 
 @implementation ORKFormItemScaleCell {
     ORKScaleSliderView *_sliderView;

--- a/ResearchKit/Common/ORKFormItemCell.m
+++ b/ResearchKit/Common/ORKFormItemCell.m
@@ -1042,11 +1042,11 @@ static const CGFloat HorizontalMargin = 15.0;
         [_sliderView setCurrentAnswerValue:answer];
 
     } else {
-        if (answer == nil && [formatProvider defaultNumber]) {
-            [_sliderView setCurrentNumberValue:[formatProvider defaultNumber]];
+        if (answer == nil && [formatProvider defaultAnswer]) {
+            [_sliderView setCurrentAnswerValue:[formatProvider defaultAnswer]];
             [self ork_setAnswer:_sliderView.currentAnswerValue];
         } else {
-            [_sliderView setCurrentNumberValue:nil];
+            [_sliderView setCurrentAnswerValue:nil];
         }
     }
 }

--- a/ResearchKit/Common/ORKFormItemCell.m
+++ b/ResearchKit/Common/ORKFormItemCell.m
@@ -103,9 +103,14 @@ static const CGFloat HorizontalMargin = 15.0;
 - (instancetype)initWithReuseIdentifier:(NSString *)reuseIdentifier
                                formItem:(ORKFormItem *)formItem
                                  answer:(id)answer
-                          maxLabelWidth:(CGFloat)maxLabelWidth {
+                          maxLabelWidth:(CGFloat)maxLabelWidth
+                               delegate:(id<ORKFormItemCellDelegate>)delegate {
     self = [super initWithStyle:UITableViewCellStyleDefault reuseIdentifier:reuseIdentifier];
     if (self) {
+        // Setting `delegate` during init is required.
+        // Some question need this to report its default answer to ORKFormStepViewController;
+        _delegate = delegate;
+        
         _maxLabelWidth = maxLabelWidth;
         _answer = [answer copy];
         self.formItem = formItem;
@@ -227,8 +232,16 @@ static const CGFloat HorizontalMargin = 15.0;
     NSMutableArray *_variableConstraints;
 }
 
-- (instancetype)initWithReuseIdentifier:(NSString *)reuseIdentifier formItem:(ORKFormItem *)formItem answer:(id)answer maxLabelWidth:(CGFloat)maxLabelWidth {
-    self = [super initWithReuseIdentifier:reuseIdentifier formItem:formItem answer:answer maxLabelWidth:maxLabelWidth];
+- (instancetype)initWithReuseIdentifier:(NSString *)reuseIdentifier
+                               formItem:(ORKFormItem *)formItem
+                                 answer:(id)answer
+                          maxLabelWidth:(CGFloat)maxLabelWidth
+                               delegate:(id<ORKFormItemCellDelegate>)delegate{
+    self = [super initWithReuseIdentifier:reuseIdentifier
+                                 formItem:formItem
+                                   answer:answer
+                            maxLabelWidth:maxLabelWidth
+                                 delegate:delegate];
     if (self != nil) {
         UILabel *label = self.labelLabel;
         label.isAccessibilityElement = NO;
@@ -970,6 +983,10 @@ static const CGFloat HorizontalMargin = 15.0;
 
 #pragma mark - ORKFormItemScaleCell
 
+@interface ORKFormItemScaleCell () <ORKScaleSliderViewDelegate>
+
+@end
+
 @implementation ORKFormItemScaleCell {
     ORKScaleSliderView *_sliderView;
     id<ORKScaleAnswerFormatProvider> _formatProvider;
@@ -985,8 +1002,7 @@ static const CGFloat HorizontalMargin = 15.0;
 - (void)cellInit {
     self.labelLabel.text = nil;
     
-    _sliderView = [[ORKScaleSliderView alloc] initWithFormatProvider:(ORKScaleAnswerFormat *)self.formItem.answerFormat];
-    [_sliderView.slider addTarget:self action:@selector(inputValueDidChange) forControlEvents:UIControlEventValueChanged];
+    _sliderView = [[ORKScaleSliderView alloc] initWithFormatProvider:(ORKScaleAnswerFormat *)self.formItem.answerFormat delegate:self];
     
     [self.contentView addSubview:_sliderView];
     [self setUpConstraints];
@@ -1021,28 +1037,22 @@ static const CGFloat HorizontalMargin = 15.0;
     id<ORKScaleAnswerFormatProvider> formatProvider = self.formatProvider;
     id answer = self.answer;
     if (answer && answer != ORKNullAnswerValue()) {
-        if (![self.answer isKindOfClass:[NSNumber class]]) {
-            @throw [NSException exceptionWithName:NSGenericException reason:@"Answer should be NSNumber" userInfo:nil];
-        }
         
-        [_sliderView setCurrentValue:answer];
+        [_sliderView setCurrentAnswerValue:answer];
+
     } else {
         if (answer == nil && [formatProvider defaultNumber]) {
-            [_sliderView setCurrentValue:[formatProvider defaultNumber]];
+            [_sliderView setCurrentNumberValue:[formatProvider defaultNumber]];
+            [self ork_setAnswer:_sliderView.currentAnswerValue];
         } else {
-            [_sliderView setCurrentValue:nil];
+            [_sliderView setCurrentNumberValue:nil];
         }
     }
 }
 
-- (void)inputValueDidChange {
-    NSArray *textChoices = [self.formatProvider textChoices];
-    if (textChoices) {
-        ORKTextChoice *textChoice = textChoices[[_sliderView.currentValue intValue] - 1];
-        [self ork_setAnswer:textChoice.value];
-    } else {
-        [self ork_setAnswer:_sliderView.currentValue];
-    }
+- (void)scaleSliderViewCurrentValueDidChange:(ORKScaleSliderView *)sliderView {
+    
+    [self ork_setAnswer:sliderView.currentAnswerValue];
     [super inputValueDidChange];
 }
 

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -820,10 +820,9 @@
                         NSAssert(NO, @"SHOULD NOT FALL IN HERE");
                     } else {
                         ORKFormItemCell *formCell = nil;
-                        formCell = [[class alloc] initWithReuseIdentifier:identifier formItem:formItem answer:answer maxLabelWidth:section.maxLabelWidth];
+                        formCell = [[class alloc] initWithReuseIdentifier:identifier formItem:formItem answer:answer maxLabelWidth:section.maxLabelWidth delegate:self];
                         [_formItemCells addObject:formCell];
                         [formCell setExpectedLayoutWidth:self.tableView.bounds.size.width];
-                        formCell.delegate  = self;
                         formCell.selectionStyle = UITableViewCellSelectionStyleNone;
                         formCell.defaultAnswer = _savedDefaults[formItem.identifier];
                         cell = formCell;

--- a/ResearchKit/Common/ORKQuestionStepViewController.m
+++ b/ResearchKit/Common/ORKQuestionStepViewController.m
@@ -309,7 +309,7 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
 
 - (void)defaultAnswerDidChange {
     id defaultAnswer = _defaultAnswer;
-    if (![self hasAnswer] && (self.answer != ORKNullAnswerValue()) && defaultAnswer && !self.hasChangedAnswer) {
+    if (![self hasAnswer] && defaultAnswer && !self.hasChangedAnswer) {
         _answer = defaultAnswer;
         
         [self answerDidChange];

--- a/ResearchKit/Common/ORKScaleSliderView.h
+++ b/ResearchKit/Common/ORKScaleSliderView.h
@@ -72,8 +72,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, readonly) ORKScaleValueLabel *valueLabel;
 
-- (void)setCurrentNumberValue:(nullable NSNumber *)number;
-
 // Accepts NSNumber for continous scale or discrete scale.
 // Accepts NSArray<id<NSCopying, NSCoding, NSObject>> for text scale.
 @property (nonatomic, strong, nullable) id currentAnswerValue;

--- a/ResearchKit/Common/ORKScaleSliderView.h
+++ b/ResearchKit/Common/ORKScaleSliderView.h
@@ -41,12 +41,19 @@ NS_ASSUME_NONNULL_BEGIN
 @class ORKScaleValueLabel;
 @class ORKScaleRangeDescriptionLabel;
 @class ORKScaleRangeImageView;
+@class ORKScaleSliderView;
+
+@protocol ORKScaleSliderViewDelegate <NSObject>
+
+- (void)scaleSliderViewCurrentValueDidChange:(ORKScaleSliderView *)sliderView;
+
+@end
 
 @interface ORKScaleSliderView : UIView
 
-- (instancetype)initWithFormatProvider:(id<ORKScaleAnswerFormatProvider>)formatProvider;
+- (instancetype)initWithFormatProvider:(id<ORKScaleAnswerFormatProvider>)formatProvider delegate:(id<ORKScaleSliderViewDelegate>)delegate;
 
-@property (nonatomic, strong, readonly) ORKScaleSlider *slider;
+@property (nonatomic, weak, readonly) id<ORKScaleSliderViewDelegate> delegate;
 
 @property (nonatomic, strong, readonly) id<ORKScaleAnswerFormatProvider> formatProvider;
 
@@ -64,7 +71,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, readonly) ORKScaleValueLabel *valueLabel;
 
-@property (nonatomic, strong, nullable) NSNumber *currentValue;
+- (void)setCurrentNumberValue:(nullable NSNumber *)number;
+
+// Accepts NSNumber for continous scale or discrete scale.
+// Accepts NSArray<id<NSCopying, NSCoding, NSObject>> for text scale.
+@property (nonatomic, strong, nullable) id currentAnswerValue;
 
 @end
 

--- a/ResearchKit/Common/ORKScaleSliderView.h
+++ b/ResearchKit/Common/ORKScaleSliderView.h
@@ -49,6 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+
 @interface ORKScaleSliderView : UIView
 
 - (instancetype)initWithFormatProvider:(id<ORKScaleAnswerFormatProvider>)formatProvider delegate:(id<ORKScaleSliderViewDelegate>)delegate;

--- a/ResearchKit/Common/ORKScaleSliderView.m
+++ b/ResearchKit/Common/ORKScaleSliderView.m
@@ -503,6 +503,8 @@
         NSUInteger index = [[self textScaleFormatProvider] textChoiceIndexForValue:currentTextChoiceValue];
         if (index != NSNotFound) {
             [self setCurrentNumberValue:@(index + 1)];
+        } else {
+            [self setCurrentNumberValue:nil];
         }
     } else {
         [self setCurrentNumberValue:nil];

--- a/ResearchKit/Common/ORKScaleSliderView.m
+++ b/ResearchKit/Common/ORKScaleSliderView.m
@@ -77,7 +77,7 @@
         BOOL isVertical = [formatProvider isVertical];
         _slider.vertical = isVertical;
 
-        NSArray<ORKTextChoice *> *textChoices = [_formatProvider textChoices];
+        NSArray<ORKTextChoice *> *textChoices = [[self textScaleFormatProvider] textChoices];
         _slider.textChoices = textChoices;
         
         if (isVertical && textChoices) {
@@ -448,6 +448,13 @@
     [NSLayoutConstraint activateConstraints:constraints];
 }
 
+- (id<ORKTextScaleAnswerFormatProvider>)textScaleFormatProvider {
+    if ([[_formatProvider class] conformsToProtocol:@protocol(ORKTextScaleAnswerFormatProvider)]) {
+        return (id<ORKTextScaleAnswerFormatProvider>)_formatProvider;
+    }
+    return nil;
+}
+
 - (void)setCurrentNumberValue:(NSNumber *)value {
     
     _currentNumberValue = value ? [_formatProvider normalizedValueForNumber:value] : nil;
@@ -465,8 +472,8 @@
 - (void)updateCurrentValueLabel {
     
     if (_currentNumberValue) {
-        if ([_formatProvider textChoices]) {
-            ORKTextChoice *textChoice = [_formatProvider textChoiceForIndex:[self currentTextChoiceIndex]];
+        if ([self textScaleFormatProvider]) {
+            ORKTextChoice *textChoice = [[self textScaleFormatProvider] textChoiceForIndex:[self currentTextChoiceIndex]];
             self.valueLabel.text = textChoice.text;
         } else {
             NSNumber *newValue = [_formatProvider normalizedValueForNumber:_currentNumberValue];
@@ -494,7 +501,7 @@
 - (void)setCurrentTextChoiceValue:(id<NSCopying, NSCoding, NSObject>)currentTextChoiceValue {
     
     if (currentTextChoiceValue) {
-        NSUInteger index = [_formatProvider textChoiceIndexForValue:currentTextChoiceValue];
+        NSUInteger index = [[self textScaleFormatProvider] textChoiceIndexForValue:currentTextChoiceValue];
         if (index != NSNotFound) {
             [self setCurrentNumberValue: @(index + 1)];
         }
@@ -504,12 +511,12 @@
 }
 
 - (id<NSCopying, NSCoding, NSObject>)currentTextChoiceValue {
-    id<NSCopying, NSCoding, NSObject> value = [_formatProvider textChoiceForIndex:[self currentTextChoiceIndex]].value;
+    id<NSCopying, NSCoding, NSObject> value = [[self textScaleFormatProvider] textChoiceForIndex:[self currentTextChoiceIndex]].value;
     return value;
 }
 
 - (id)currentAnswerValue {
-    if ([_formatProvider textChoices]) {
+    if ([self textScaleFormatProvider]) {
         id<NSCopying, NSCoding, NSObject> value = [self currentTextChoiceValue];
         return value ? @[value] : @[];
     } else {
@@ -518,7 +525,7 @@
 }
 
 - (void)setCurrentAnswerValue:(id)currentAnswerValue {
-    if ([_formatProvider textChoices]) {
+    if ([self textScaleFormatProvider]) {
         
         if (ORKIsAnswerEmpty(currentAnswerValue)) {
             [self setCurrentTextChoiceValue:nil];

--- a/ResearchKit/Common/ORKScaleSliderView.m
+++ b/ResearchKit/Common/ORKScaleSliderView.m
@@ -462,7 +462,6 @@
     
     [self updateCurrentValueLabel];
     _slider.value = _currentNumberValue.floatValue;
-
 }
 
 - (NSUInteger)currentTextChoiceIndex {
@@ -503,10 +502,10 @@
     if (currentTextChoiceValue) {
         NSUInteger index = [[self textScaleFormatProvider] textChoiceIndexForValue:currentTextChoiceValue];
         if (index != NSNotFound) {
-            [self setCurrentNumberValue: @(index + 1)];
+            [self setCurrentNumberValue:@(index + 1)];
         }
     } else {
-        [self setCurrentNumberValue: nil];
+        [self setCurrentNumberValue:nil];
     }
 }
 

--- a/ResearchKit/Common/ORKScaleSliderView.m
+++ b/ResearchKit/Common/ORKScaleSliderView.m
@@ -459,7 +459,7 @@
 }
 
 - (NSUInteger)currentTextChoiceIndex {
-    return [_currentNumberValue unsignedIntegerValue] - 1;
+    return _currentNumberValue.unsignedIntegerValue - 1;
 }
 
 - (void)updateCurrentValueLabel {

--- a/ResearchKit/Common/ORKScaleSliderView.m
+++ b/ResearchKit/Common/ORKScaleSliderView.m
@@ -51,12 +51,15 @@
     UIView *_rightRangeView;
     ORKScaleValueLabel *_valueLabel;
     NSMutableArray<ORKScaleRangeLabel *> *_textChoiceLabels;
+    NSNumber *_currentNumberValue;
 }
 
-- (instancetype)initWithFormatProvider:(id<ORKScaleAnswerFormatProvider>)formatProvider {
+- (instancetype)initWithFormatProvider:(id<ORKScaleAnswerFormatProvider>)formatProvider
+                              delegate:(id<ORKScaleSliderViewDelegate>)delegate {
     self = [self initWithFrame:CGRectZero];
     if (self) {
         _formatProvider = formatProvider;
+        _delegate = delegate;
         
         _slider = [[ORKScaleSlider alloc] initWithFrame:CGRectZero];
         _slider.userInteractionEnabled = YES;
@@ -75,7 +78,7 @@
         _slider.vertical = isVertical;
 
         NSArray<ORKTextChoice *> *textChoices = [_formatProvider textChoices];
-        self.slider.textChoices = textChoices;
+        _slider.textChoices = textChoices;
         
         if (isVertical && textChoices) {
             // Generate an array of labels for all the text choices
@@ -445,18 +448,28 @@
     [NSLayoutConstraint activateConstraints:constraints];
 }
 
-- (void)setCurrentValue:(NSNumber *)value {
-    _currentValue = value;
-    _slider.showThumb = value? YES : NO;
+- (void)setCurrentNumberValue:(NSNumber *)value {
     
-    if (value) {
-        NSArray<ORKTextChoice *> *textChoices = [_formatProvider textChoices];
-        if (textChoices) {
-            ORKTextChoice *textChoice = textChoices[MAX(0, [value intValue] - 1)];
+    _currentNumberValue = value ? [_formatProvider normalizedValueForNumber:value] : nil;
+    _slider.showThumb = _currentNumberValue ? YES : NO;
+    
+    [self updateCurrentValueLabel];
+    _slider.value = _currentNumberValue.floatValue;
+
+}
+
+- (NSUInteger)currentTextChoiceIndex {
+    return [_currentNumberValue unsignedIntegerValue] - 1;
+}
+
+- (void)updateCurrentValueLabel {
+    
+    if (_currentNumberValue) {
+        if ([_formatProvider textChoices]) {
+            ORKTextChoice *textChoice = [_formatProvider textChoiceForIndex:[self currentTextChoiceIndex]];
             self.valueLabel.text = textChoice.text;
         } else {
-            NSNumber *newValue = [_formatProvider normalizedValueForNumber:value];
-            _slider.value = newValue.floatValue;
+            NSNumber *newValue = [_formatProvider normalizedValueForNumber:_currentNumberValue];
             _valueLabel.text = [_formatProvider localizedStringForNumber:newValue];
         }
     } else {
@@ -465,8 +478,56 @@
 }
 
 - (IBAction)sliderValueChanged:(id)sender {
-    NSNumber *newValue = [_formatProvider normalizedValueForNumber:@(_slider.value)];
-    [self setCurrentValue:newValue];
+    
+    _currentNumberValue = [_formatProvider normalizedValueForNumber:@(_slider.value)];
+    [self updateCurrentValueLabel];
+    [self notifyDelegate];
+}
+
+- (void)notifyDelegate {
+    
+    if (self.delegate && [self.delegate respondsToSelector:@selector(scaleSliderViewCurrentValueDidChange:)]) {
+        [self.delegate scaleSliderViewCurrentValueDidChange:self];
+    }
+}
+
+- (void)setCurrentTextChoiceValue:(id<NSCopying, NSCoding, NSObject>)currentTextChoiceValue {
+    
+    if (currentTextChoiceValue) {
+        NSUInteger index = [_formatProvider textChoiceIndexForValue:currentTextChoiceValue];
+        if (index != NSNotFound) {
+            [self setCurrentNumberValue: @(index + 1)];
+        }
+    } else {
+        [self setCurrentNumberValue: nil];
+    }
+}
+
+- (id<NSCopying, NSCoding, NSObject>)currentTextChoiceValue {
+    id<NSCopying, NSCoding, NSObject> value = [_formatProvider textChoiceForIndex:[self currentTextChoiceIndex]].value;
+    return value;
+}
+
+- (id)currentAnswerValue {
+    if ([_formatProvider textChoices]) {
+        id<NSCopying, NSCoding, NSObject> value = [self currentTextChoiceValue];
+        return value ? @[value] : @[];
+    } else {
+        return _currentNumberValue;
+    }
+}
+
+- (void)setCurrentAnswerValue:(id)currentAnswerValue {
+    if ([_formatProvider textChoices]) {
+        
+        if (ORKIsAnswerEmpty(currentAnswerValue)) {
+            [self setCurrentTextChoiceValue:nil];
+        } else {
+            [self setCurrentTextChoiceValue:[currentAnswerValue firstObject]];
+        }
+    } else {
+        return [self setCurrentNumberValue:currentAnswerValue];
+    }
 }
 
 #pragma mark - Accessibility

--- a/ResearchKit/Common/ORKScaleSliderView.m
+++ b/ResearchKit/Common/ORKScaleSliderView.m
@@ -472,7 +472,7 @@
     
     if (_currentNumberValue) {
         if ([self textScaleFormatProvider]) {
-            ORKTextChoice *textChoice = [[self textScaleFormatProvider] textChoiceForIndex:[self currentTextChoiceIndex]];
+            ORKTextChoice *textChoice = [[self textScaleFormatProvider] textChoiceAtIndex:[self currentTextChoiceIndex]];
             self.valueLabel.text = textChoice.text;
         } else {
             NSNumber *newValue = [_formatProvider normalizedValueForNumber:_currentNumberValue];
@@ -510,7 +510,7 @@
 }
 
 - (id<NSCopying, NSCoding, NSObject>)currentTextChoiceValue {
-    id<NSCopying, NSCoding, NSObject> value = [[self textScaleFormatProvider] textChoiceForIndex:[self currentTextChoiceIndex]].value;
+    id<NSCopying, NSCoding, NSObject> value = [[self textScaleFormatProvider] textChoiceAtIndex:[self currentTextChoiceIndex]].value;
     return value;
 }
 

--- a/ResearchKit/Common/ORKStepViewController.m
+++ b/ResearchKit/Common/ORKStepViewController.m
@@ -265,11 +265,11 @@
 
 - (ORKStepResult *)result {
     
-    ORKStepResult *sResult = [[ORKStepResult alloc] initWithStepIdentifier:self.step.identifier results:@[]];
-    sResult.startDate = self.presentedDate;
-    sResult.endDate = self.dismissedDate? :[NSDate date];
+    ORKStepResult *stepResult = [[ORKStepResult alloc] initWithStepIdentifier:self.step.identifier results:@[]];
+    stepResult.startDate = self.presentedDate;
+    stepResult.endDate = self.dismissedDate? :[NSDate date];
     
-    return sResult;
+    return stepResult;
 }
 
 - (void)notifyDelegateOnResultChange {

--- a/ResearchKit/Common/ORKSurveyAnswerCellForScale.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForScale.m
@@ -85,11 +85,11 @@
     if (answer && answer != ORKNullAnswerValue()) {
         [_sliderView setCurrentAnswerValue:answer];
     } else {
-        if (answer == nil && [formatProvider defaultNumber]) {
-            [self.sliderView setCurrentNumberValue:[formatProvider defaultNumber]];
+        if (answer == nil && [formatProvider defaultAnswer]) {
+            [self.sliderView setCurrentAnswerValue:[formatProvider defaultAnswer]];
             [self ork_setAnswer:self.sliderView.currentAnswerValue];
         } else {
-           [self.sliderView setCurrentNumberValue:nil];
+           [self.sliderView setCurrentAnswerValue:nil];
         }
     }
 }

--- a/ResearchKit/Common/ORKSurveyAnswerCellForScale.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForScale.m
@@ -37,7 +37,7 @@
 #import "ORKScaleSliderView.h"
 
 
-@interface ORKSurveyAnswerCellForScale ()
+@interface ORKSurveyAnswerCellForScale () <ORKScaleSliderViewDelegate>
 
 @property (nonatomic, strong) ORKScaleSliderView *sliderView;
 @property (nonatomic, strong) id<ORKScaleAnswerFormatProvider> formatProvider;
@@ -60,8 +60,7 @@
     id<ORKScaleAnswerFormatProvider> formatProvider = self.formatProvider;
     
     if (_sliderView == nil) {
-        _sliderView = [[ORKScaleSliderView alloc] initWithFormatProvider:formatProvider];
-        [_sliderView.slider addTarget:self action:@selector(sliderValueChanged:) forControlEvents:UIControlEventValueChanged];
+        _sliderView = [[ORKScaleSliderView alloc] initWithFormatProvider:formatProvider delegate:self];
         
         [self addSubview:_sliderView];
         
@@ -84,32 +83,23 @@
     id<ORKScaleAnswerFormatProvider> formatProvider = self.formatProvider;
     id answer = self.answer;
     if (answer && answer != ORKNullAnswerValue()) {
-        if (![self.answer isKindOfClass:[NSNumber class]]) {
-            @throw [NSException exceptionWithName:NSGenericException reason:@"Answer should be NSNumber" userInfo:nil];
-        }
-        
-        [_sliderView setCurrentValue:answer];
+        [_sliderView setCurrentAnswerValue:answer];
     } else {
         if (answer == nil && [formatProvider defaultNumber]) {
-            [self.sliderView setCurrentValue:[formatProvider defaultNumber]];
+            [self.sliderView setCurrentNumberValue:[formatProvider defaultNumber]];
+            [self ork_setAnswer:self.sliderView.currentAnswerValue];
         } else {
-           [self.sliderView setCurrentValue:nil];
+           [self.sliderView setCurrentNumberValue:nil];
         }
-    }
-}
-
-- (IBAction)sliderValueChanged:(id)sender {
-    NSArray *textChoices = [self.formatProvider textChoices];
-    if (textChoices) {
-        ORKTextChoice *textChoice = textChoices[[_sliderView.currentValue intValue] - 1];
-        [self ork_setAnswer:textChoice.value];
-    } else {
-        [self ork_setAnswer:_sliderView.currentValue];
     }
 }
 
 - (NSArray *)suggestedCellHeightConstraintsForView:(UIView *)view {
     return @[];
+}
+
+- (void)scaleSliderViewCurrentValueDidChange:(ORKScaleSliderView *)sliderView {
+    [self ork_setAnswer:sliderView.currentAnswerValue];
 }
 
 @end

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -1749,7 +1749,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     
     {
         {
-            ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"scale_form_00" title:@"Optional Form Items" text:@"Optional form with no required items and a default scale value"];
+            ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"scale_form_00" title:@"Optional Form Items" text:@"Optional form with a required scale item with a default value"];
             NSMutableArray *items = [NSMutableArray new];
             [steps addObject:step];
             

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -2397,7 +2397,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         NSArray *textChoices = @[textChoice1, textChoice2, textChoice3, textChoice4, textChoice5];
         
         ORKTextScaleAnswerFormat *scaleAnswerFormat = [ORKAnswerFormat textScaleAnswerFormatWithTextChoices:textChoices
-                                                                                               defaultIndex:NSIntegerMax
+                                                                                               defaultIndex:3
                                                                                                    vertical:NO];
         
         ORKQuestionStep *step = [ORKQuestionStep questionStepWithIdentifier:@"scale_14"

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -1748,6 +1748,24 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     NSMutableArray *steps = [NSMutableArray new];
     
     {
+        {
+            ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"scale_form_00" title:@"Optional Form Items" text:@"Optional form with no required items and a default scale value"];
+            NSMutableArray *items = [NSMutableArray new];
+            [steps addObject:step];
+            
+            {
+                ORKScaleAnswerFormat *format = [ORKScaleAnswerFormat scaleAnswerFormatWithMaximumValue:10 minimumValue:1 defaultValue:4 step:1 vertical:YES maximumValueDescription:nil minimumValueDescription:nil];
+                ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"scale_form"
+                                                                       text:@"Optional scale"
+                                                               answerFormat:format];
+                item.optional = NO;
+                [items addObject:item];
+            }
+                 
+            [step setFormItems:items];
+        }
+
+        
         ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"fid_000" title:@"Optional Form Items" text:@"Optional form with no required items"];
         NSMutableArray *items = [NSMutableArray new];
         [steps addObject:step];

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -66,7 +66,7 @@
         const char * type = property_getAttributes(property);
         NSString * typeString = [NSString stringWithUTF8String:type];
         NSArray * attributes = [typeString componentsSeparatedByString:@","];
-        NSString * typeAttribute = [attributes objectAtIndex:0];
+        NSString * typeAttribute = attributes[0];
         
         _isPrimitiveType = YES;
         if ([typeAttribute hasPrefix:@"T@"]) {

--- a/samples/ORKCatalog/ORKCatalog/Results/ResultTableViewProviders.swift
+++ b/samples/ORKCatalog/ORKCatalog/Results/ResultTableViewProviders.swift
@@ -752,7 +752,7 @@ class TowerOfHanoiResultTableViewProvider: ResultTableViewProvider {
                 ResultRow(text: "moves", detail: "\(towerOfHanoiResult.moves?.count ?? 0 )")]
         }
         // Add a `ResultRow` for each sample.
-        let move = towerOfHanoiResult.moves![section - 1] as! ORKTowerOfHanoiMove
+        let move = towerOfHanoiResult.moves![section - 1]
         return rows + [
             ResultRow(text: "donor tower", detail: "\(move.donorTowerIndex)"),
             ResultRow(text: "recipient tower", detail: "\(move.recipientTowerIndex)"),
@@ -831,7 +831,7 @@ class PSATResultTableViewProvider: ResultTableViewProvider {
         
         // Add a `ResultRow` for each sample.
         return rows + PSATResult.samples!.map { sample in
-            let PSATSample = sample as! ORKPSATSample
+            let PSATSample = sample
             
             let text = String(format: "%@", PSATSample.correct ? "correct" : "error")
             let detail = "\(PSATSample.answer) (digit: \(PSATSample.digit), time: \(PSATSample.time))"


### PR DESCRIPTION
This patch is a fix for #511 "Continue button is disabled on scale with default values"

1. Change `ORKTextScaleAnswerFormat`'s result to `ORKChoiceQuestionResult`. Since `ORKTextChoice` was used to specify selections.
2. Refactor ORKScaleSliderView to work better with three types of scale related answer format.
3. Other minor fixes

@rsanchezsaez I saw your fix #514, but after reviewing the `ORKTextScaleAnswerFormat`'s implementation, I found there are some fundamental issues. I prepared this patch to fix them.

Traditionally this type of default answer relied on cell's self reporting, for example, `dataPicker`. This patch follows it. 

Let me know if you like this one better. Thanks! 

  