### PR TITLE
ORKTest: add 'Test Charts Performance' item

### DIFF
--- a/Testing/ORKTest/ORKTest/Charts/ChartDataSources.swift
+++ b/Testing/ORKTest/ORKTest/Charts/ChartDataSources.swift
@@ -206,3 +206,135 @@ class DiscreteGraphChartDataSource: BaseGraphChartDataSource {
         return 1
     }
 }
+
+class PerformanceLineGraphChartDataSource: BaseGraphChartDataSource {
+    
+    override init() {
+        super.init()
+        plotPoints =
+            [
+                [
+                    ORKRangedPoint(),
+                    ORKRangedPoint(value: 20),
+                    ORKRangedPoint(value: 25),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(value: 30),
+                    ORKRangedPoint(value: 40),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(value: 20),
+                    ORKRangedPoint(value: 25),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(value: 30),
+                    ORKRangedPoint(value: 40),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(value: 20),
+                    ORKRangedPoint(value: 25),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(value: 30),
+                    ORKRangedPoint(value: 40),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(value: 20),
+                    ORKRangedPoint(value: 25),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(value: 30),
+                    ORKRangedPoint(value: 40),
+                    ORKRangedPoint(),
+                ],
+                [
+                    ORKRangedPoint(value: 2),
+                    ORKRangedPoint(value: 4),
+                    ORKRangedPoint(value: 8),
+                    ORKRangedPoint(value: 16),
+                    ORKRangedPoint(value: 32),
+                    ORKRangedPoint(value: 50),
+                    ORKRangedPoint(value: 64),
+                    ORKRangedPoint(value: 2),
+                    ORKRangedPoint(value: 4),
+                    ORKRangedPoint(value: 8),
+                    ORKRangedPoint(value: 16),
+                    ORKRangedPoint(value: 32),
+                    ORKRangedPoint(value: 50),
+                    ORKRangedPoint(value: 64),
+                    ORKRangedPoint(value: 2),
+                    ORKRangedPoint(value: 4),
+                    ORKRangedPoint(value: 8),
+                    ORKRangedPoint(value: 16),
+                    ORKRangedPoint(value: 32),
+                    ORKRangedPoint(value: 50),
+                    ORKRangedPoint(value: 64),
+                    ORKRangedPoint(value: 2),
+                    ORKRangedPoint(value: 4),
+                    ORKRangedPoint(value: 8),
+                    ORKRangedPoint(value: 16),
+                    ORKRangedPoint(value: 32),
+                    ORKRangedPoint(value: 50),
+                    ORKRangedPoint(value: 64),
+                ],
+                [
+                    ORKRangedPoint(),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(value: 20),
+                    ORKRangedPoint(value: 25),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(value: 30),
+                    ORKRangedPoint(value: 40),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(value: 20),
+                    ORKRangedPoint(value: 25),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(value: 30),
+                    ORKRangedPoint(value: 40),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(value: 20),
+                    ORKRangedPoint(value: 25),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(value: 30),
+                    ORKRangedPoint(value: 40),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(value: 20),
+                    ORKRangedPoint(value: 25),
+                    ORKRangedPoint(),
+                    ORKRangedPoint(value: 30),
+                    ORKRangedPoint(value: 40),
+                    ORKRangedPoint(),
+                ],
+        ]
+    }
+    
+    func maximumValueForGraphChartView(graphChartView: ORKGraphChartView) -> CGFloat {
+        return 70
+    }
+    
+    func minimumValueForGraphChartView(graphChartView: ORKGraphChartView) -> CGFloat {
+        return 0
+    }
+    
+    func numberOfDivisionsInXAxisForGraphChartView(graphChartView: ORKGraphChartView) -> Int {
+        return 10
+    }
+    
+    func graphChartView(graphChartView: ORKGraphChartView, titleForXAxisAtPointIndex pointIndex: Int) -> String? {
+        return (pointIndex % 2 == 0) ? nil : "\(pointIndex + 1)"
+    }
+    
+    func graphChartView(graphChartView: ORKGraphChartView, drawsVerticalReferenceLineAtPointIndex pointIndex: Int) -> Bool {
+        return (pointIndex % 2 == 1) ? false : true
+    }
+    
+    func scrubbingPlotIndexForGraphChartView(graphChartView: ORKGraphChartView) -> Int {
+        return 2
+    }
+}

--- a/Testing/ORKTest/ORKTest/Charts/ChartListViewController.swift
+++ b/Testing/ORKTest/ORKTest/Charts/ChartListViewController.swift
@@ -52,8 +52,8 @@ class ChartListViewController: UIViewController, UITableViewDataSource {
     let coloredLineGraphChartDataSource = ColoredLineGraphChartDataSource()
     
     let discreteGraphChartDataSource = DiscreteGraphChartDataSource()
+
     let pieChartIdentifier = "PieChartCell"
-    
     let lineGraphChartIdentifier = "LineGraphChartCell"
     let discreteGraphChartIdentifier = "DiscreteGraphChartCell"
     
@@ -169,5 +169,61 @@ class ChartListViewController: UIViewController, UITableViewDataSource {
         pieChartTableViewCell.pieChartView.animateWithDuration(0.5)
         lineGraphChartTableViewCell.graphChartView.animateWithDuration(0.5)
         discreteGraphChartTableViewCell.graphChartView.animateWithDuration(0.5)
+    }    
+}
+
+class ChartPerformanceListViewController: UIViewController, UITableViewDataSource {
+    
+    @IBOutlet var tableView: UITableView!
+    
+    let lineGraphChartIdentifier = "LineGraphChartCell"
+    let discreteGraphChartIdentifier = "DiscreteGraphChartCell"
+    let graphChartDataSource = PerformanceLineGraphChartDataSource()
+    var lineGraphChartTableViewCell: LineGraphChartTableViewCell!
+    let discreteGraphChartDataSource = DiscreteGraphChartDataSource()
+    var discreteGraphChartTableViewCell: DiscreteGraphChartTableViewCell!
+    var chartTableViewCells: [UITableViewCell]!
+    
+    @IBAction func dimiss(sender: AnyObject) {
+        self.dismissViewControllerAnimated(true, completion: nil)
+    }
+    
+    override func viewDidLoad() {
+        self.tableView.dataSource = self;
+        
+        // ORKLineGraphChartView
+        lineGraphChartTableViewCell = tableView.dequeueReusableCellWithIdentifier(lineGraphChartIdentifier) as! LineGraphChartTableViewCell
+        let lineGraphChartView = lineGraphChartTableViewCell.graphChartView as! ORKLineGraphChartView
+        lineGraphChartView.dataSource = graphChartDataSource
+        // Optional custom configuration
+        lineGraphChartView.showsHorizontalReferenceLines = true
+        lineGraphChartView.showsVerticalReferenceLines = true
+
+        // ORKDiscreteGraphChartView
+        discreteGraphChartTableViewCell = tableView.dequeueReusableCellWithIdentifier(discreteGraphChartIdentifier) as! DiscreteGraphChartTableViewCell
+        let discreteGraphChartView = discreteGraphChartTableViewCell.graphChartView as! ORKDiscreteGraphChartView
+        discreteGraphChartView.dataSource = graphChartDataSource
+        // Optional custom configuration
+        discreteGraphChartView.showsHorizontalReferenceLines = true
+        discreteGraphChartView.showsVerticalReferenceLines = true
+        discreteGraphChartView.drawsConnectedRanges = true
+
+        chartTableViewCells = [lineGraphChartTableViewCell, discreteGraphChartTableViewCell]
+
+        tableView.tableFooterView = UIView(frame: CGRectZero)
+    }
+    
+    func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return chartTableViewCells.count
+    }
+    
+    func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        let cell = chartTableViewCells[indexPath.row];
+        return cell
+    }
+    
+    override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+        lineGraphChartTableViewCell.graphChartView.animateWithDuration(0.5)
     }    
 }

--- a/Testing/ORKTest/ORKTest/Charts/Charts.storyboard
+++ b/Testing/ORKTest/ORKTest/Charts/Charts.storyboard
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8187.4" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="O97-SL-yAO">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="15A284" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="O97-SL-yAO">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8151.3"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
         <!--Chart List View Controller-->
         <scene sceneID="2RM-qU-28x">
             <objects>
-                <viewController id="O97-SL-yAO" customClass="ChartListViewController" customModule="ORKTest" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="ChartListViewController" id="O97-SL-yAO" customClass="ChartListViewController" customModule="ORKTest" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="sHB-Jf-wNn"/>
                         <viewControllerLayoutGuide type="bottom" id="WZ6-mC-IEj"/>
@@ -20,6 +20,7 @@
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vrI-th-aNd">
                                 <rect key="frame" x="520" y="20" width="60" height="30"/>
+                                <animations/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="60" id="QiG-lh-pqr"/>
                                     <constraint firstAttribute="height" constant="30" id="jCv-Es-Krh"/>
@@ -33,6 +34,7 @@
                             </button>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="300" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="igJ-g1-C2g">
                                 <rect key="frame" x="0.0" y="50" width="600" height="550"/>
+                                <animations/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="DiscreteGraphChartCell" rowHeight="250" id="KFi-ZJ-545" customClass="DiscreteGraphChartTableViewCell" customModule="ORKTest" customModuleProvider="target">
@@ -44,15 +46,18 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Discrete Graph" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sip-g6-ysz">
                                                     <rect key="frame" x="8" y="8" width="584" height="23"/>
+                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="19"/>
                                                     <color key="textColor" red="0.01176470588" green="0.62352941179999999" blue="0.8862745098" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lT7-di-t1R" customClass="ORKDiscreteGraphChartView">
                                                     <rect key="frame" x="8" y="39" width="584" height="202"/>
+                                                    <animations/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 </view>
                                             </subviews>
+                                            <animations/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <constraints>
                                                 <constraint firstItem="sip-g6-ysz" firstAttribute="trailing" secondItem="e5L-1y-jED" secondAttribute="trailingMargin" id="3BL-pm-TlY"/>
@@ -64,6 +69,7 @@
                                                 <constraint firstItem="sip-g6-ysz" firstAttribute="leading" secondItem="e5L-1y-jED" secondAttribute="leadingMargin" id="yaq-Oo-xbC"/>
                                             </constraints>
                                         </tableViewCellContentView>
+                                        <animations/>
                                         <connections>
                                             <outlet property="graphChartView" destination="lT7-di-t1R" id="w75-Ly-1tP"/>
                                         </connections>
@@ -77,15 +83,18 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Line Graph" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hR5-cR-Okz">
                                                     <rect key="frame" x="8" y="8" width="584" height="23"/>
+                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="19"/>
                                                     <color key="textColor" red="0.01176470588" green="0.62352941179999999" blue="0.8862745098" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KVp-LO-PWd" customClass="ORKLineGraphChartView">
                                                     <rect key="frame" x="8" y="39" width="584" height="202"/>
+                                                    <animations/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 </view>
                                             </subviews>
+                                            <animations/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <constraints>
                                                 <constraint firstItem="KVp-LO-PWd" firstAttribute="bottom" secondItem="YJs-Dw-TiB" secondAttribute="bottomMargin" id="5Gm-Hf-I0N"/>
@@ -97,6 +106,7 @@
                                                 <constraint firstItem="KVp-LO-PWd" firstAttribute="trailing" secondItem="YJs-Dw-TiB" secondAttribute="trailingMargin" id="qiE-86-gIQ"/>
                                             </constraints>
                                         </tableViewCellContentView>
+                                        <animations/>
                                         <connections>
                                             <outlet property="graphChartView" destination="KVp-LO-PWd" id="xfV-gc-IdN"/>
                                         </connections>
@@ -110,15 +120,18 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Pie Chart" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Drx-as-avJ">
                                                     <rect key="frame" x="8" y="8" width="584" height="23"/>
+                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="19"/>
                                                     <color key="textColor" red="0.01176470588" green="0.62352941179999999" blue="0.8862745098" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yDa-vq-n8q" customClass="ORKPieChartView">
                                                     <rect key="frame" x="8" y="39" width="584" height="352"/>
+                                                    <animations/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 </view>
                                             </subviews>
+                                            <animations/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <constraints>
                                                 <constraint firstItem="yDa-vq-n8q" firstAttribute="bottom" secondItem="r38-NH-vJN" secondAttribute="bottomMargin" id="DZT-CC-84j"/>
@@ -130,6 +143,7 @@
                                                 <constraint firstItem="Drx-as-avJ" firstAttribute="top" secondItem="r38-NH-vJN" secondAttribute="topMargin" id="taR-fa-Vfj"/>
                                             </constraints>
                                         </tableViewCellContentView>
+                                        <animations/>
                                         <connections>
                                             <outlet property="pieChartView" destination="yDa-vq-n8q" id="LFh-1S-Jb5"/>
                                         </connections>
@@ -137,6 +151,7 @@
                                 </prototypes>
                             </tableView>
                         </subviews>
+                        <animations/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="WZ6-mC-IEj" firstAttribute="top" secondItem="igJ-g1-C2g" secondAttribute="bottom" id="3si-iV-C5I"/>
@@ -158,6 +173,176 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="XRP-yS-sh9" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="318" y="516"/>
+        </scene>
+        <!--Chart Performance List View Controller-->
+        <scene sceneID="pY7-cG-J6R">
+            <objects>
+                <viewController storyboardIdentifier="ChartPerformanceListViewController" id="WON-wz-g9B" customClass="ChartPerformanceListViewController" customModule="ORKTest" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="9q3-SN-Abt"/>
+                        <viewControllerLayoutGuide type="bottom" id="6ce-Tx-dm9"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="I6G-lW-PXk">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4ce-iu-oKf">
+                                <rect key="frame" x="520" y="20" width="60" height="30"/>
+                                <animations/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="60" id="G6I-Gp-eCo"/>
+                                    <constraint firstAttribute="height" constant="30" id="uK0-4Y-13j"/>
+                                </constraints>
+                                <state key="normal" title="Close">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="dimiss:" destination="WON-wz-g9B" eventType="touchUpInside" id="gLV-21-gf5"/>
+                                </connections>
+                            </button>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="300" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="KRs-VW-ttd">
+                                <rect key="frame" x="0.0" y="50" width="600" height="550"/>
+                                <animations/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <prototypes>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="DiscreteGraphChartCell" rowHeight="250" id="LFI-dW-bSz" customClass="DiscreteGraphChartTableViewCell" customModule="ORKTest" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="22" width="600" height="250"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="LFI-dW-bSz" id="PHG-DV-yH1">
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="249"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Discrete Graph" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zH8-rf-L09">
+                                                    <rect key="frame" x="8" y="8" width="584" height="23"/>
+                                                    <animations/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="19"/>
+                                                    <color key="textColor" red="0.01176470588" green="0.62352941179999999" blue="0.8862745098" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CAU-HS-4gj" customClass="ORKDiscreteGraphChartView">
+                                                    <rect key="frame" x="8" y="39" width="584" height="202"/>
+                                                    <animations/>
+                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                </view>
+                                            </subviews>
+                                            <animations/>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstItem="zH8-rf-L09" firstAttribute="leading" secondItem="PHG-DV-yH1" secondAttribute="leadingMargin" id="2Hd-BP-ysG"/>
+                                                <constraint firstItem="zH8-rf-L09" firstAttribute="trailing" secondItem="PHG-DV-yH1" secondAttribute="trailingMargin" id="NMW-4N-D2X"/>
+                                                <constraint firstItem="CAU-HS-4gj" firstAttribute="bottom" secondItem="PHG-DV-yH1" secondAttribute="bottomMargin" id="Sxm-sk-vMg"/>
+                                                <constraint firstItem="zH8-rf-L09" firstAttribute="top" secondItem="PHG-DV-yH1" secondAttribute="topMargin" id="V2I-Xz-vrG"/>
+                                                <constraint firstItem="CAU-HS-4gj" firstAttribute="leading" secondItem="PHG-DV-yH1" secondAttribute="leadingMargin" id="Vma-mI-IL0"/>
+                                                <constraint firstItem="CAU-HS-4gj" firstAttribute="trailing" secondItem="PHG-DV-yH1" secondAttribute="trailingMargin" id="X2m-78-do8"/>
+                                                <constraint firstItem="CAU-HS-4gj" firstAttribute="top" secondItem="zH8-rf-L09" secondAttribute="bottom" constant="8" id="hPV-UX-5kY"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <animations/>
+                                        <connections>
+                                            <outlet property="graphChartView" destination="CAU-HS-4gj" id="KDn-l2-Q91"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="LineGraphChartCell" rowHeight="250" id="Iwe-mb-s4M" customClass="LineGraphChartTableViewCell" customModule="ORKTest" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="272" width="600" height="250"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Iwe-mb-s4M" id="Js0-pH-SG6">
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="249"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Line Graph" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IhF-UX-vuT">
+                                                    <rect key="frame" x="8" y="8" width="584" height="23"/>
+                                                    <animations/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="19"/>
+                                                    <color key="textColor" red="0.01176470588" green="0.62352941179999999" blue="0.8862745098" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="C6v-PW-Pax" customClass="ORKLineGraphChartView">
+                                                    <rect key="frame" x="8" y="39" width="584" height="202"/>
+                                                    <animations/>
+                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                </view>
+                                            </subviews>
+                                            <animations/>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstItem="C6v-PW-Pax" firstAttribute="bottom" secondItem="Js0-pH-SG6" secondAttribute="bottomMargin" id="A7f-h6-x91"/>
+                                                <constraint firstItem="C6v-PW-Pax" firstAttribute="leading" secondItem="Js0-pH-SG6" secondAttribute="leadingMargin" id="LBr-ub-yLN"/>
+                                                <constraint firstItem="IhF-UX-vuT" firstAttribute="top" secondItem="Js0-pH-SG6" secondAttribute="topMargin" id="NOA-jl-ERq"/>
+                                                <constraint firstItem="IhF-UX-vuT" firstAttribute="leading" secondItem="Js0-pH-SG6" secondAttribute="leadingMargin" id="TB5-vv-dma"/>
+                                                <constraint firstItem="IhF-UX-vuT" firstAttribute="trailing" secondItem="Js0-pH-SG6" secondAttribute="trailingMargin" id="TCs-Hl-ncL"/>
+                                                <constraint firstItem="C6v-PW-Pax" firstAttribute="top" secondItem="IhF-UX-vuT" secondAttribute="bottom" constant="8" id="sfm-CN-FxL"/>
+                                                <constraint firstItem="C6v-PW-Pax" firstAttribute="trailing" secondItem="Js0-pH-SG6" secondAttribute="trailingMargin" id="zG4-xZ-rgt"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <animations/>
+                                        <connections>
+                                            <outlet property="graphChartView" destination="C6v-PW-Pax" id="Ebx-V8-gpp"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="PieChartCell" rowHeight="400" id="HUN-ei-9hu" customClass="PieChartTableViewCell" customModule="ORKTest" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="522" width="600" height="400"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="HUN-ei-9hu" id="KuS-pu-BMv">
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="399"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Pie Chart" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KIQ-3U-lwS">
+                                                    <rect key="frame" x="8" y="8" width="584" height="23"/>
+                                                    <animations/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="19"/>
+                                                    <color key="textColor" red="0.01176470588" green="0.62352941179999999" blue="0.8862745098" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GSH-Uw-XBG" customClass="ORKPieChartView">
+                                                    <rect key="frame" x="8" y="39" width="584" height="352"/>
+                                                    <animations/>
+                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                </view>
+                                            </subviews>
+                                            <animations/>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstItem="KIQ-3U-lwS" firstAttribute="top" secondItem="KuS-pu-BMv" secondAttribute="topMargin" id="10f-FS-cSk"/>
+                                                <constraint firstItem="KIQ-3U-lwS" firstAttribute="leading" secondItem="KuS-pu-BMv" secondAttribute="leadingMargin" id="8la-Cw-Pvc"/>
+                                                <constraint firstItem="GSH-Uw-XBG" firstAttribute="leading" secondItem="KuS-pu-BMv" secondAttribute="leadingMargin" id="BGD-7r-GLZ"/>
+                                                <constraint firstItem="GSH-Uw-XBG" firstAttribute="trailing" secondItem="KuS-pu-BMv" secondAttribute="trailingMargin" id="ML4-ZY-dGD"/>
+                                                <constraint firstItem="GSH-Uw-XBG" firstAttribute="bottom" secondItem="KuS-pu-BMv" secondAttribute="bottomMargin" id="OdB-ii-rJO"/>
+                                                <constraint firstItem="GSH-Uw-XBG" firstAttribute="top" secondItem="KIQ-3U-lwS" secondAttribute="bottom" constant="8" id="WI7-BL-mF0"/>
+                                                <constraint firstItem="KIQ-3U-lwS" firstAttribute="trailing" secondItem="KuS-pu-BMv" secondAttribute="trailingMargin" id="lTi-RN-gfT"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <animations/>
+                                        <connections>
+                                            <outlet property="pieChartView" destination="GSH-Uw-XBG" id="qWg-cy-R0u"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                        </subviews>
+                        <animations/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="KRs-VW-ttd" firstAttribute="leading" secondItem="I6G-lW-PXk" secondAttribute="leading" id="Ro7-JS-DXV"/>
+                            <constraint firstItem="KRs-VW-ttd" firstAttribute="top" secondItem="I6G-lW-PXk" secondAttribute="top" constant="44" id="W9J-m5-01R"/>
+                            <constraint firstItem="6ce-Tx-dm9" firstAttribute="top" secondItem="KRs-VW-ttd" secondAttribute="bottom" id="WLz-fC-LDz"/>
+                            <constraint firstItem="KRs-VW-ttd" firstAttribute="top" secondItem="9q3-SN-Abt" secondAttribute="bottom" constant="30" id="idA-vg-KP1"/>
+                            <constraint firstItem="4ce-iu-oKf" firstAttribute="top" secondItem="9q3-SN-Abt" secondAttribute="bottom" id="oZc-P7-ySy"/>
+                            <constraint firstAttribute="trailing" secondItem="KRs-VW-ttd" secondAttribute="trailing" id="urT-di-OeQ"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="4ce-iu-oKf" secondAttribute="trailing" id="ylD-Nz-zSC"/>
+                        </constraints>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="W9J-m5-01R"/>
+                            </mask>
+                        </variation>
+                    </view>
+                    <connections>
+                        <outlet property="tableView" destination="KRs-VW-ttd" id="dhK-fd-GzF"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="yeM-KR-rgJ" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="318" y="516"/>
         </scene>

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -300,6 +300,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                            @"Interruptible Task",
                            @"Navigable Ordered Task",
                            @"Test Charts",
+                           @"Test Charts Performance",
                            @"Toggle Tint Color",
                            @"Wait Task",
                            ],
@@ -3427,7 +3428,13 @@ stepViewControllerWillAppear:(ORKStepViewController *)stepViewController {
 
 - (void)testChartsButtonTapped:(id)sender {
     UIStoryboard *chartStoryboard = [UIStoryboard storyboardWithName:@"Charts" bundle:nil];
-    UIViewController *chartListViewController = [chartStoryboard instantiateInitialViewController];
+    UIViewController *chartListViewController = [chartStoryboard instantiateViewControllerWithIdentifier:@"ChartListViewController"];
+    [self presentViewController:chartListViewController animated:YES completion:nil];
+}
+
+- (void)testChartsPerformanceButtonTapped:(id)sender {
+    UIStoryboard *chartStoryboard = [UIStoryboard storyboardWithName:@"Charts" bundle:nil];
+    UIViewController *chartListViewController = [chartStoryboard instantiateViewControllerWithIdentifier:@"ChartPerformanceListViewController"];
     [self presentViewController:chartListViewController animated:YES completion:nil];
 }
 


### PR DESCRIPTION
This PR adds a `Test Charts Performance` item which is meant to be used to test `ORKLineGraphChartView` and `ORKDiscreteGraphChartView` rotation and drawing performance. It (uglily) draws graph charts with lots of points.