### PR TITLE
IOI # 517 - Image capture no permissions bug

### DIFF
--- a/ResearchKit/Common/ORKImageCaptureStep.m
+++ b/ResearchKit/Common/ORKImageCaptureStep.m
@@ -91,9 +91,4 @@
                         && ORKEqualObjects(self.accessibilityInstructions, castObject.accessibilityInstructions);
 }
 
-- (ORKPermissionMask)requestedPermissions {
-    ORKPermissionMask mask = [super requestedPermissions];
-    return mask | ORKPermissionCamera;
-}
-
 @end

--- a/ResearchKit/Common/ORKImageCaptureStepViewController.m
+++ b/ResearchKit/Common/ORKImageCaptureStepViewController.m
@@ -243,10 +243,6 @@
     
     // Show the error in the image capture view
     _imageCaptureView.error = error;
-    
-    // Tell the task view controller that we have failed so that it removes our result
-    STRONGTYPE(self.delegate) strongDelegate = self.delegate;
-    [strongDelegate stepViewControllerDidFail:self withError:error];
 }
 
 - (void)setCapturedImageData:(NSData *)capturedImageData {


### PR DESCRIPTION
The original implementation was implementing `requestedPermissions` on ORKImageCaptureStep which resulted in the delegate call `taskViewControllerDidFinish: withReason:` if camera permission was not granted. Removing that implementation and instead only requesting permission on the actual image step resolved part of the issue.

The second half of the bug was due to the fact that in the error handling of the camera permissions, the delegate callback `taskViewControllerDidFinish: withReason:` was being called also. This caused the image capture step to never appear on the screen and actually show the error message.

Removing both those factors allows the user to navigate through the steps and see the error messages so that they can resolve it by changing privacy in settings or by skipping the question.

Issue #517 