### PR TITLE
Expose NSRegularExpressionOptions for ORKTextAnswerFormat, ORKRegistrationStep

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -1229,6 +1229,13 @@ ORK_CLASS_AVAILABLE
 @property (nonatomic, copy, nullable) NSString *validationRegex;
 
 /**
+ The options flag used with NSRegularExpression and the validationRegex to validate user's input.
+
+ The default value is NSRegularExpressionCaseInsensitive. Has no effect if validationRegex is not set.
+ */
+@property (nonatomic, assign) NSRegularExpressionOptions validationRegexOptions;
+
+/**
  The text presented to the user when invalid input is received.
  
  The default value is nil.

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1896,6 +1896,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     _spellCheckingType = UITextSpellCheckingTypeDefault;
     _keyboardType = UIKeyboardTypeDefault;
     _multipleLines = YES;
+    _validationRegexOptions = NSRegularExpressionCaseInsensitive;
 }
 
 - (instancetype)initWithMaximumLength:(NSInteger)maximumLength {
@@ -1938,7 +1939,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     
     NSError *error;
     if (self.validationRegex && ![[NSRegularExpression alloc] initWithPattern:self.validationRegex
-                                                                      options:NSRegularExpressionCaseInsensitive
+                                                                      options:self.validationRegexOptions
                                                                         error:&error]) {
         @throw [NSException exceptionWithName:NSInvalidArgumentException
                                        reason:@"Validation regex is not valid."
@@ -1951,6 +1952,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     ORKTextAnswerFormat *fmt = [[[self class] allocWithZone:zone] init];
     fmt->_maximumLength = _maximumLength;
     fmt->_validationRegex = [_validationRegex copy];
+    fmt->_validationRegexOptions = _validationRegexOptions;
     fmt->_invalidMessage = [_invalidMessage copy];
     fmt->_autocapitalizationType = _autocapitalizationType;
     fmt->_autocorrectionType = _autocorrectionType;
@@ -1986,7 +1988,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     if (self.validationRegex) {
         if (!_cachedRegEx) {
             NSString *regExPattern = self.validationRegex;
-            _cachedRegEx = [[NSRegularExpression alloc] initWithPattern:regExPattern options:NSRegularExpressionCaseInsensitive error:nil];
+            _cachedRegEx = [[NSRegularExpression alloc] initWithPattern:regExPattern options:self.validationRegexOptions error:nil];
         }
 
         NSUInteger regExMatches = [_cachedRegEx numberOfMatchesInString:text options:0 range:NSMakeRange(0, [text length])];
@@ -2017,6 +2019,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         _multipleLines = YES;
         ORK_DECODE_INTEGER(aDecoder, maximumLength);
         ORK_DECODE_OBJ_CLASS(aDecoder, validationRegex, NSString);
+        ORK_DECODE_INTEGER(aDecoder, validationRegexOptions);
         ORK_DECODE_OBJ_CLASS(aDecoder, invalidMessage, NSString);
         ORK_DECODE_ENUM(aDecoder, autocapitalizationType);
         ORK_DECODE_ENUM(aDecoder, autocorrectionType);
@@ -2032,6 +2035,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     [super encodeWithCoder:aCoder];
     ORK_ENCODE_INTEGER(aCoder, maximumLength);
     ORK_ENCODE_OBJ(aCoder, validationRegex);
+    ORK_ENCODE_INTEGER(aCoder, validationRegexOptions);
     ORK_ENCODE_OBJ(aCoder, invalidMessage);
     ORK_ENCODE_ENUM(aCoder, autocapitalizationType);
     ORK_ENCODE_ENUM(aCoder, autocorrectionType);
@@ -2052,6 +2056,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     return (isParentSame &&
             (self.maximumLength == castObject.maximumLength &&
              ORKEqualObjects(self.validationRegex, castObject.validationRegex) &&
+             self.validationRegexOptions == castObject.validationRegexOptions &&
              ORKEqualObjects(self.invalidMessage, castObject.invalidMessage) &&
              self.autocapitalizationType == castObject.autocapitalizationType &&
              self.autocorrectionType == castObject.autocorrectionType &&

--- a/ResearchKit/Onboarding/ORKRegistrationStep.h
+++ b/ResearchKit/Onboarding/ORKRegistrationStep.h
@@ -111,6 +111,15 @@ ORK_CLASS_AVAILABLE
 @property (nonatomic, copy, nullable) NSString *passcodeValidationRegex;
 
 /**
+ The regex options to use when validating the passcode form item.
+ This is a transparent property pointing to its definition in `ORKTextAnswerFormat`.
+
+ The passcodeValidationRegex property must also be set along with this property.
+ By default, this uses the default ORKTextAnswerFormat value.
+ */
+@property (nonatomic, assign) NSRegularExpressionOptions passcodeValidationRegexOptions;
+
+/**
  The invalid message displayed if the passcode does not match the validation regex.
  This is a transparent property pointing to its definition in `ORKTextAnswerFormat`.
  

--- a/ResearchKit/Onboarding/ORKRegistrationStep.m
+++ b/ResearchKit/Onboarding/ORKRegistrationStep.m
@@ -223,12 +223,20 @@ static id ORKFindInArrayByFormItemId(NSArray *array, NSString *formItemIdentifie
     return [self passwordAnswerFormat].invalidMessage;
 }
 
+- (NSRegularExpressionOptions)passcodeValidationRegexOptions {
+    return [self passwordAnswerFormat].validationRegexOptions;
+}
+
 - (void)setPasscodeValidationRegex:(NSString *)passcodeValidationRegex {
     [self passwordAnswerFormat].validationRegex = passcodeValidationRegex;
 }
 
 - (void)setPasscodeInvalidMessage:(NSString *)passcodeInvalidMessage {
     [self passwordAnswerFormat].invalidMessage = passcodeInvalidMessage;
+}
+
+- (void)setPasscodeValidationRegexOptions:(NSRegularExpressionOptions)passcodeValidationRegexOptions {
+    [self passwordAnswerFormat].validationRegexOptions = passcodeValidationRegexOptions;
 }
 
 + (BOOL)supportsSecureCoding {
@@ -239,9 +247,10 @@ static id ORKFindInArrayByFormItemId(NSArray *array, NSString *formItemIdentifie
     self = [super initWithCoder:aDecoder];
     if (self) {
         
-        // The `passcodeValidationRegex` and `passcodeInvalidMessage` properties
-        // are transparent properties. The `initWithCoder:` for these properties is
-        // defined in the answer format (super).
+        // The `passcodeValidationRegex`, `passcodeInvalidMessage`, and
+        // `passcodeValidationRegexOptions` properties are transparent properties.
+        // The `initWithCoder:` for these properties is defined in the answer
+        // format (super).
         ORK_DECODE_INTEGER(aDecoder, options);
     }
     return self;
@@ -250,18 +259,19 @@ static id ORKFindInArrayByFormItemId(NSArray *array, NSString *formItemIdentifie
 - (void)encodeWithCoder:(NSCoder *)aCoder {
     [super encodeWithCoder:aCoder];
     
-    // The `passcodeValidationRegex` and `passcodeInvalidMessage` properties
-    // are transparent properties. The `encodeWithCoder:` for these properties is
-    // defined in the answer format (super).
+    // The `passcodeValidationRegex`, `passcodeInvalidMessage`, and
+    // `passcodeValidationRegexOptions` properties are transparent properties.
+    // The `encodeWithCoder:` for these properties is defined in the answer
+    // format (super).
     ORK_ENCODE_INTEGER(aCoder, options);
 }
 
 - (instancetype)copyWithZone:(NSZone *)zone {
     ORKRegistrationStep *step = [super copyWithZone:zone];
     
-    // The `passcodeValidationRegex` and `passcodeInvalidMessage` properties
-    // are transparent properties. The `copyWithZone:` for these properties is
-    // defined in the answer format (super).
+    // The `passcodeValidationRegex`, `passcodeInvalidMessage`, and
+    // `passcodeValidationRegexOptions` properties are transparent properties.
+    // The `copyWithZone:` for these properties is defined in the answer format (super).
     step->_options = self.options;
     return step;
 }
@@ -269,9 +279,9 @@ static id ORKFindInArrayByFormItemId(NSArray *array, NSString *formItemIdentifie
 - (BOOL)isEqual:(id)object {
     BOOL isParentSame = [super isEqual:object];
     
-    // The `passcodeValidationRegex` and `passcodeInvalidMessage` properties
-    // are transparent properties. The `isEqual:` for these properties is
-    // defined in the answer format (super).
+    // The `passcodeValidationRegex`, `passcodeInvalidMessage`, and
+    // `passcodeValidationRegexOptions` properties are transparent properties.
+    // The `isEqual:` for these properties is defined in the answer format (super).
     __typeof(self) castObject = object;
     return (isParentSame &&
             self.options == castObject.options);

--- a/Testing/ORKTest/ORKTest/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTest/ORKESerialization.m
@@ -864,6 +864,7 @@ ret =
         (@{
           PROPERTY(maximumLength, NSNumber, NSObject, NO, nil, nil),
           PROPERTY(validationRegex, NSString, NSObject, YES, nil, nil),
+          PROPERTY(validationRegexOptions, NSNumber, NSObject, YES, nil, nil),
           PROPERTY(invalidMessage, NSString, NSObject, YES, nil, nil),
           PROPERTY(autocapitalizationType, NSNumber, NSObject, YES, nil, nil),
           PROPERTY(autocorrectionType, NSNumber, NSObject, YES, nil, nil),

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -377,6 +377,7 @@ ORK_MAKE_TEST_INIT(ORKLocation, (^{
                                               @"ORKVerificationStep.verificationViewControllerClass",
                                               @"ORKLoginStep.loginViewControllerClass",
                                               @"ORKRegistrationStep.passcodeValidationRegex",
+                                              @"ORKRegistrationStep.passcodeValidationRegexOptions",
                                               @"ORKRegistrationStep.passcodeInvalidMessage"];
     NSArray *allowedUnTouchedKeys = @[@"_class"];
     


### PR DESCRIPTION
For Issue #566 

Currently text field validation can take a regex for validation, but the NSRegularExpression always uses the NSRegularExpressionCaseInsensitive option, making it impossible to have case sensitive password validation (e.g. password must contain one uppercase letter and one lowercase letter).

This change exposes a new NSRegularExpressionOptions property on ORKTextAnswerFormat (and transparently via ORKRegistrationStep) which could be used to change that option. By default the new validationRegexOptions is set to NSRegularExpressionCaseInsensitive for backwards compatibility.
