### PR TITLE
Fixed build error in ResultTableViewProviders.swift caused by an outdated property.

### DIFF
--- a/samples/ORKCatalog/ORKCatalog/Results/ResultTableViewProviders.swift
+++ b/samples/ORKCatalog/ORKCatalog/Results/ResultTableViewProviders.swift
@@ -376,7 +376,7 @@ class LocationQuestionResultTableViewProvider: ResultTableViewProvider {
     override func resultRowsForSection(section: Int) -> [ResultRow] {
         let questionResult = result as! ORKLocationQuestionResult
         let location = questionResult.locationAnswer
-        let address = location?.address.stringByReplacingOccurrencesOfString("\n", withString: " ")
+        let address = location?.userInput.stringByReplacingOccurrencesOfString("\n", withString: " ")
         let rows = super.resultRowsForSection(section) + [
             // The latitude of the location the user entered.
             ResultRow(text: "latitude", detail: location?.coordinate.latitude),


### PR DESCRIPTION
Replaced the field "address" with "userInput" in the ORKCatalog project which was causing a build error.