### PR TITLE
Added method to create a copy of a step with a new identifier

### DIFF
--- a/ResearchKit/Common/ORKStep.h
+++ b/ResearchKit/Common/ORKStep.h
@@ -85,7 +85,7 @@ ORK_CLASS_AVAILABLE
 /**
  Returns a copy of this step initialized with the specified identifier.
  
- @param identifier   The unique identifier of the step.
+ @param identifier   The unique identifier for the new step to be returned.
  
  @return A new step.
  */

--- a/ResearchKit/Common/ORKStep.h
+++ b/ResearchKit/Common/ORKStep.h
@@ -83,6 +83,15 @@ ORK_CLASS_AVAILABLE
 - (instancetype)initWithCoder:(NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;
 
 /**
+ Returns a copy of this step initialized with the specified identifier.
+ 
+ @param identifier   The unique identifier of the step.
+ 
+ @return A new step.
+ */
+- (instancetype)copyWithIdentifier:(NSString *)identifier;
+
+/**
  A short string that uniquely identifies the step within the task.
  
  The identifier is reproduced in the results of a step. In fact, the only way to link a result

--- a/ResearchKit/Common/ORKStep.m
+++ b/ResearchKit/Common/ORKStep.m
@@ -59,6 +59,12 @@
     return [[self class] stepViewControllerClass];
 }
 
+- (instancetype)copyWithIdentifier:(NSString *)identifier {
+    ORKStep *step = [self copy];
+    step->_identifier = identifier;
+    return step;
+}
+
 - (instancetype)copyWithZone:(NSZone *)zone {
     ORKStep *step = [[[self class] allocWithZone:zone] initWithIdentifier:[_identifier copy]];
     step.title = _title;

--- a/ResearchKit/Common/ORKStep.m
+++ b/ResearchKit/Common/ORKStep.m
@@ -60,8 +60,9 @@
 }
 
 - (instancetype)copyWithIdentifier:(NSString *)identifier {
+    ORKThrowInvalidArgumentExceptionIfNil(identifier)
     ORKStep *step = [self copy];
-    step->_identifier = identifier;
+    step->_identifier = [identifier copy];
     return step;
 }
 


### PR DESCRIPTION
This will allow a developer to copy a private subclass of ORKStep with a new identifier.

For an example usage, see:

https://github.com/Sage-Bionetworks/AppCore/blob/master/APCAppCore/APCAppCore/Library/Categories/ORKOrderedTask%2BAPCHelper.m

```
ORKInstructionStep *instructionStep = [tappingInstructionStep copyWithIdentifier:
    [NSString stringWithFormat:@"%@.%@", APCTapInstructionStepIdentifier, handIdentifier]];
ORKActiveStep *activeStep = [tappingStep copyWithIdentifier:
    [NSString stringWithFormat:@"%@.%@", APCTapTappingStepIdentifier, handIdentifier]];
```

In this example, 'ORKTappingIntervalStep' is a private class within the ResearchKit SDK so it cannot be instantiated directly with a new identifier used to differentiate tapping with the left hand from the right hand for the case where the research study requires a bilateral tapping test.
