### PR TITLE
[ORKGraphChartView] Fix wrong selector check on accessibility (convergence)

### DIFF
--- a/ResearchKit/Charts/ORKGraphChartView.m
+++ b/ResearchKit/Charts/ORKGraphChartView.m
@@ -1070,7 +1070,7 @@ inline static CALayer *graphPointLayerWithColor(UIColor *color) {
             }
         }
         
-        if ([_dataSource respondsToSelector:@selector(pieChartView:titleForSegmentAtIndex:)]) {
+        if ([_dataSource respondsToSelector:@selector(graphChartView:titleForXAxisAtPointIndex:)]) {
             element.accessibilityLabel = [self.dataSource graphChartView:self titleForXAxisAtPointIndex:pointIndex];
         } else {
             element.accessibilityLabel = [NSString stringWithFormat:ORKLocalizedString(@"AX_CHART_POINT_%@", nil), ORKLocalizedStringFromNumber(@(pointIndex))];


### PR DESCRIPTION
Actually, probably this should go to `convergence`, since it's a safe but critical bugfix. Feel free to close the other PR.

Fixes [Issue #589](https://github.com/ResearchKit/ResearchKit/issues/589).