### PR TITLE
Add includeAssistiveDeviceForm parameter to timed walk task

### DIFF
--- a/ResearchKit/Common/ORKOrderedTask.h
+++ b/ResearchKit/Common/ORKOrderedTask.h
@@ -452,13 +452,15 @@ typedef NS_OPTIONS(NSUInteger, ORKPredefinedTaskOption) {
  
  Data collected by the task is in the form of an `ORKTimedWalkResult` object.
  
- @param identifier              The task identifier to use for this task, appropriate to the study.
- @param intendedUseDescription  A localized string describing the intended use of the data
- collected. If the value of this parameter is `nil`, the default
- localized text is displayed.
- @param distanceInMeters        The timed walk distance in meters.
- @param timeLimit               The time limit to complete the trials.
- @param options                 Options that affect the features of the predefined task.
+ @param identifier                  The task identifier to use for this task, appropriate to the study.
+ @param intendedUseDescription      A localized string describing the intended use of the data
+                                      collected. If the value of this parameter is `nil`, the default
+                                      localized text is displayed.
+ @param distanceInMeters            The timed walk distance in meters.
+ @param timeLimit                   The time limit to complete the trials.
+ @param includeAssistiveDeviceForm  A Boolean value that indicates whether to inlude the form step
+                                      about the usage of an assistive device.
+ @param options                     Options that affect the features of the predefined task.
  
  @return An active Timed Walk task that can be presented with an `ORKTaskViewController` object.
  */
@@ -466,6 +468,7 @@ typedef NS_OPTIONS(NSUInteger, ORKPredefinedTaskOption) {
                          intendedUseDescription:(nullable NSString *)intendedUseDescription
                                distanceInMeters:(double)distanceInMeters
                                       timeLimit:(NSTimeInterval)timeLimit
+                     includeAssistiveDeviceForm:(BOOL)includeAssistiveDeviceForm
                                         options:(ORKPredefinedTaskOption)options;
 
 /**

--- a/ResearchKit/Common/ORKOrderedTask.m
+++ b/ResearchKit/Common/ORKOrderedTask.m
@@ -992,6 +992,7 @@ void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
                          intendedUseDescription:(nullable NSString *)intendedUseDescription
                                distanceInMeters:(double)distanceInMeters
                                       timeLimit:(NSTimeInterval)timeLimit
+                     includeAssistiveDeviceForm:(BOOL)includeAssistiveDeviceForm
                                         options:(ORKPredefinedTaskOption)options {
     
     NSMutableArray *steps = [NSMutableArray array];
@@ -1013,7 +1014,7 @@ void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
         }
     }
     
-    {
+    if (includeAssistiveDeviceForm) {
         ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:ORKTimedWalkFormStepIdentifier
                                                               title:ORKLocalizedString(@"TIMED_WALK_FORM_TITLE", nil)
                                                                text:ORKLocalizedString(@"TIMED_WALK_FORM_TEXT", nil)];
@@ -1022,6 +1023,7 @@ void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
         ORKFormItem *formItem1 = [[ORKFormItem alloc] initWithIdentifier:ORKTimedWalkFormAFOStepIdentifier
                                                                     text:ORKLocalizedString(@"TIMED_WALK_QUESTION_TEXT", nil)
                                                             answerFormat:answerFormat1];
+        formItem1.optional = NO;
         
         NSArray *textChoices = @[ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE", nil),
                                  ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_2", nil),
@@ -1034,6 +1036,8 @@ void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
                                                                     text:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_TITLE", nil)
                                                             answerFormat:answerFormat2];
         formItem2.placeholder = ORKLocalizedString(@"TIMED_WALK_QUESTION_2_TEXT", nil);
+        formItem2.optional = NO;
+
         step.formItems = @[formItem1, formItem2];
         step.optional = NO;
         

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -531,6 +531,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                                     intendedUseDescription:nil
                                           distanceInMeters:100
                                                  timeLimit:180
+                                includeAssistiveDeviceForm:YES
                                                    options:ORKPredefinedTaskOptionNone];
     } else if ([identifier isEqualToString:HolePegTestTaskIdentifier]) {
         return [ORKNavigableOrderedTask holePegTestTaskWithIdentifier:HolePegTestTaskIdentifier

--- a/samples/ORKCatalog/ORKCatalog/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/TaskListRow.swift
@@ -646,7 +646,7 @@ enum TaskListRow: Int, Printable {
     
     /// This task presents the Timed Walk pre-defined active task.
     private var timedWalkTask: ORKTask {
-        return ORKOrderedTask.timedWalkTaskWithIdentifier(String(Identifier.TimedWalkTask), intendedUseDescription: exampleDescription, distanceInMeters: 100.0, timeLimit: 180.0, options: [])
+        return ORKOrderedTask.timedWalkTaskWithIdentifier(String(Identifier.TimedWalkTask), intendedUseDescription: exampleDescription, distanceInMeters: 100.0, timeLimit: 180.0, includeAssistiveDeviceForm: true, options: [])
     }
     
     /// This task presents the Hole Peg Test pre-defined active task.

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -1157,7 +1157,7 @@ enum TaskListRow: Int, CustomStringConvertible {
 
     /// This task presents the Timed Walk pre-defined active task.
     private var timedWalkTask: ORKTask {
-        return ORKOrderedTask.timedWalkTaskWithIdentifier(String(Identifier.TimedWalkTask), intendedUseDescription: exampleDescription, distanceInMeters: 100.0, timeLimit: 180.0, options: [])
+        return ORKOrderedTask.timedWalkTaskWithIdentifier(String(Identifier.TimedWalkTask), intendedUseDescription: exampleDescription, distanceInMeters: 100.0, timeLimit: 180.0, includeAssistiveDeviceForm: true, options: [])
     }
     
     /// This task presents the Tone Audiometry pre-defined active task.


### PR DESCRIPTION
This pull-request addresses two (related) problems with the Timed Walk Active Task:

- The “Assistive Device” form items are now non-optional. These questions are mandatory in the context of the MSFC score (Multiple Sclerosis Functional Composite measure).
- The “Assistive Device” form step itself is now optional, by adding a `includeAssistiveDeviceForm` Boolean parameter to the factory method. This Timed Walk activity can be useful outside of the MSFC measurement, but then you probably don’t need the “Assistive Device” form details, so we think it’s nice to let the developer choose if he wants to include it or not.