### PR TITLE
[ORKSample] Allow onboarding to proceed on the Simulator despite HealthKit not being present

### DIFF
--- a/samples/ORKSample/ORKSample/HealthDataStepViewController.swift
+++ b/samples/ORKSample/ORKSample/HealthDataStepViewController.swift
@@ -42,7 +42,8 @@ class HealthDataStepViewController: ORKInstructionStepViewController {
     
     override func goForward() {
         healthDataStep?.getHealthAuthorization() { succeeded, _ in
-            guard succeeded else { return }
+            // The second part of the guard condition allows the app to proceed on the Simulator (where health data is not available)
+            guard succeeded || (TARGET_OS_SIMULATOR != 0) else { return }
             
             NSOperationQueue.mainQueue().addOperationWithBlock {
                 super.goForward()


### PR DESCRIPTION
This PR allows *ORKSample*'s onboarding to be completed on the *Simulator* despite *HealthKit* not being available.