### PR TITLE
[Charts] Fix crash when displaying graph chart with no data source 

### DIFF
--- a/ResearchKit/Charts/ORKGraphChartView.h
+++ b/ResearchKit/Charts/ORKGraphChartView.h
@@ -370,6 +370,13 @@ ORK_CLASS_AVAILABLE
  */
 - (void)animateWithDuration:(NSTimeInterval)animationDuration;
 
+/**
+ Reloads the plotted data.
+ 
+ Call this method to reload the data and re-plot the graph. You should call it if the data provided by the dataSource changes.
+*/
+- (void)reloadData;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/Charts/ORKGraphChartView.m
+++ b/ResearchKit/Charts/ORKGraphChartView.m
@@ -93,8 +93,7 @@ static const CGFloat ScrubberLabelVerticalPadding = 4.0;
     return self;
 }
 
-- (void)setDataSource:(id<ORKGraphChartViewDataSource>)dataSource {
-    _dataSource = dataSource;
+- (void)reloadData {
     _numberOfXAxisPoints = -1; // reset cached number of x axis points
     [self updateAndLayoutVerticalReferenceLineLayers];
     [self obtainDataPoints];
@@ -106,6 +105,11 @@ static const CGFloat ScrubberLabelVerticalPadding = 4.0;
     [self updateNoDataLabel];
     
     [self setNeedsLayout];
+}
+
+- (void)setDataSource:(id<ORKGraphChartViewDataSource>)dataSource {
+    _dataSource = dataSource;
+    [self reloadData];
 }
 
 - (void)setAxisColor:(UIColor *)axisColor {

--- a/ResearchKit/Charts/ORKPieChartView.h
+++ b/ResearchKit/Charts/ORKPieChartView.h
@@ -200,6 +200,13 @@ ORK_CLASS_AVAILABLE
 */
 - (void)animateWithDuration:(NSTimeInterval)animationDuration;
 
+/**
+ Reloads the plotted data.
+ 
+ Call this method to reload the data and re-plot the graph. You should call it if the data provided by the dataSource changes.
+ */
+- (void)reloadData;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/Charts/ORKPieChartView.m
+++ b/ResearchKit/Charts/ORKPieChartView.m
@@ -102,13 +102,17 @@ static const CGFloat PieToLegendPadding = 8.0;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (void)setDataSource:(id<ORKPieChartViewDataSource>)dataSource {
-    _dataSource = dataSource;
+- (void)reloadData {
     CGFloat sumOfValues = [_pieView normalizeValues];
     [_pieView updatePieLayers];
     [_pieView updatePercentageLabels];
     [_titleTextView showNoDataLabel:(sumOfValues == 0)];
     [self updateLegendView];
+}
+
+- (void)setDataSource:(id<ORKPieChartViewDataSource>)dataSource {
+    _dataSource = dataSource;
+    [self reloadData];
 }
 
 - (void)setLineWidth:(CGFloat)lineWidth {


### PR DESCRIPTION
This PR fixes [Issue #600](https://github.com/ResearchKit/ResearchKit/issues/600), and also adds `reloadData` methods to both chart types.