### PR TITLE
[ORKStepNavigationRule] Improve documentation

### DIFF
--- a/ResearchKit/Common/ORKStepNavigationRule.h
+++ b/ResearchKit/Common/ORKStepNavigationRule.h
@@ -65,7 +65,8 @@ ORK_CLASS_AVAILABLE
 /*
  The `init` and `new` methods are unavailable.
  
- `ORKStepNavigationRule` classes should be initialized with custom designated initializers on each subclass.
+ `ORKStepNavigationRule` classes should be initialized with custom designated initializers on each
+ subclass.
  */
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
@@ -87,18 +88,20 @@ ORK_CLASS_AVAILABLE
 
 
 /**
- The `ORKPredicateStepNavigationRule` can be used to match any answer combination in the results of the ongoing task (or in those of
- previously completed tasks) and jump accordingly. You must provide one or more result predicates
- (each predicate can match one or more step results within the task).
+ The `ORKPredicateStepNavigationRule` can be used to match any answer combination in the results of
+ the ongoing task (or in those of previously completed tasks) and jump accordingly. You must provide
+ one or more result predicates (each predicate can match one or more step results within the task).
  
  Predicate step navigation rules contain an arbitrary number of result predicates with a
- corresponding number of destination step identifiers, plus an optional default step identifier that is
- used if none of the result predicates match. One result predicate can match one or more question
- results; if matching several question results, that predicate can belong to the same or to different task
- results). This rule allows you to define arbitrarily complex task navigation behaviors.
+ corresponding number of destination step identifiers, plus an optional default step identifier that
+ is used if none of the result predicates match. One result predicate can match one or more question
+ results; if matching several question results, that predicate can belong to the same or to
+ different task results). This rule allows you to define arbitrarily complex task navigation
+ behaviors.
  
  The `ORKResultPredicate` class provides convenience class methods to build predicates for all the
- `ORKQuestionResult` subtypes. Predicates must supply both the task result identifier and the question result identifier, in addition to one or more expected answers.
+ `ORKQuestionResult` subtypes. Predicates must supply both the task result identifier and the
+ question result identifier, in addition to one or more expected answers.
  */
 ORK_CLASS_AVAILABLE
 @interface ORKPredicateStepNavigationRule : ORKStepNavigationRule
@@ -112,12 +115,14 @@ ORK_CLASS_AVAILABLE
                                         in any of the additional task results.
  @param destinationStepIdentifiers  An array of possible destination step identifiers. This array
                                         must contain one step identifier for each of the predicates
-                                        in the result predicates parameters.
+                                        in the result predicates parameters. If you want for a
+                                        certain predicate match to end te task, you achieve that by
+                                        using the `ORKNullStepIdentifier` constant.
  @param defaultStepIdentifier       The identifier of the step, which is used if none of the
                                         result predicates match. If this argument is `nil` and none
                                         of the predicates match, the default ordered task navigation
-                                        behavior takes place (that is, the task goes to the next step in
-                                        order).
+                                        behavior takes place (that is, the task goes to the next
+                                        step in order).
  
  @return An initialized predicate step navigation rule.
  */
@@ -142,7 +147,8 @@ ORK_CLASS_AVAILABLE
               destinationStepIdentifiers:(NSArray<NSString *> *)destinationStepIdentifiers NS_SWIFT_UNAVAILABLE("Use the Swift init(resultPredicatesAndDestinationStepIdentifiers: [(NSPredicate, String)], defaultStepIdentifierOrNil: String?) initializer instead.");
 
 /**
- Returns a new predicate step navigation rule that was initialized from data in the given unarchiver.
+ Returns a new predicate step navigation rule that was initialized from data in the given 
+ unarchiver.
  
  @param aDecoder    The coder from which to initialize the step navigation rule.
  
@@ -153,15 +159,15 @@ ORK_CLASS_AVAILABLE
 /**
  An optional array of additional task results.
  
- With this property, a task can have different navigation behavior depending on the results of related
- tasks that the user may have already completed. The predicate step navigation rule can use the
- question results within these tasks, in addition to the current task question results, to match the
- result predicates.
+ With this property, a task can have different navigation behavior depending on the results of
+ related tasks that the user may have already completed. The predicate step navigation rule can use
+ the question results within these tasks, in addition to the current task question results, to match
+ the result predicates.
  
  You must ensure that all the task result identifiers are unique and that they are different from
  the ongoing task result identifier. Also ensure that no task result contains question
- results with duplicate identifiers. Question results *can have* equal identifiers provided that they
- belong to different task results.
+ results with duplicate identifiers. Question results *can have* equal identifiers provided that
+ they belong to different task results.
  
  Each object in the array should be of the `ORKTaskResult` class.
  */
@@ -170,8 +176,8 @@ ORK_CLASS_AVAILABLE
 /**
  The array of result predicates. 
  
- @discussion This property contains one result predicate for each of the step identifiers
- in the `destinationStepIdentifiers` property.
+ @discussion This property contains one result predicate for each of the step identifiers in the
+ `destinationStepIdentifiers` property.
 */
 @property (nonatomic, copy, readonly) NSArray<NSPredicate *> *resultPredicates;
 
@@ -190,7 +196,8 @@ ORK_CLASS_AVAILABLE
 
 
 /**
- The `ORKDirectStepNavigationRule` class can be used to unconditionally jump to a destination step specified by its identifier or to finish the task early.
+ The `ORKDirectStepNavigationRule` class can be used to unconditionally jump to a destination step
+ specified by its identifier or to finish the task early.
  */
 ORK_CLASS_AVAILABLE
 @interface ORKDirectStepNavigationRule : ORKStepNavigationRule
@@ -198,9 +205,10 @@ ORK_CLASS_AVAILABLE
 /**
  Returns an initialized direct-step navigation rule using the specified destination step identifier.
  
- @param destinationStepIdentifier   The identifier of the destination step. Pass `nil` if you want
-                                        to finish the ongoing task when the direct-step navigation
-                                        rule is triggered.
+ @param destinationStepIdentifier   The identifier of the destination step. Pass the
+                                        `ORKNullStepIdentifier` constant if you want to finish the
+                                        ongoing task when the direct-step navigation rule is
+                                        triggered.
  
  @return A direct-step navigation rule.
  */


### PR DESCRIPTION
Deals with [Issue #603](https://github.com/ResearchKit/ResearchKit/issues/603).

- Improve whitespace
- Specify that passing `ORKNullStepIdentifier` (instead of `nil`) ends the task for *direct* and *predicate step navigation rules*.