### PR TITLE
ORKGraphChartView - Remove the "No Data" label when there is data

### DIFF
--- a/ResearchKit/Charts/ORKGraphChartView.m
+++ b/ResearchKit/Charts/ORKGraphChartView.m
@@ -628,7 +628,7 @@ inline static CALayer *graphPointLayerWithColor(UIColor *color) {
         _noDataLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
         _noDataLabel.textColor = [UIColor lightGrayColor];
         [_plotView addSubview:_noDataLabel];
-    } else if (!_hasDataPoints && _noDataLabel) {
+    } else if (_hasDataPoints && _noDataLabel) {
         [_noDataLabel removeFromSuperview];
         _noDataLabel = nil;
     }


### PR DESCRIPTION
The "No Data" label continued to appear in ORKGraphChartView after data was loaded because of a reversed boolean check.

![image](https://cloud.githubusercontent.com/assets/9200271/12587233/576c196a-c408-11e5-83c2-7f4061c53e91.png)
