### PR TITLE
Allow user to opt-in to linear progress reporting on ORKNavigableOrderedTask

### DIFF
--- a/ResearchKit/Common/ORKNavigableOrderedTask.h
+++ b/ResearchKit/Common/ORKNavigableOrderedTask.h
@@ -98,6 +98,12 @@ ORK_CLASS_AVAILABLE
  */
 @property (nonatomic, copy, readonly) NSDictionary<NSString *, ORKStepNavigationRule *> *stepNavigationRules;
 
+/**
+ Determines whether the task should report its progress as a linear ordered task or not. 
+ The default value of this property is `NO`.
+ */
+@property (nonatomic) BOOL shouldReportProgress;
+
 @end
 
 

--- a/ResearchKit/Common/ORKNavigableOrderedTask.m
+++ b/ResearchKit/Common/ORKNavigableOrderedTask.m
@@ -47,6 +47,7 @@
     self = [super initWithIdentifier:identifier steps:steps];
     if (self) {
         _stepNavigationRules = nil;
+        _shouldReportProgress = NO;
     }
     return self;
 }
@@ -106,8 +107,12 @@
     return previousStep;
 }
 
-// ORKNavigableOrderedTask doesn't have a linear order
+// Assume ORKNavigableOrderedTask doesn't have a linear order unless user specifically overrides
 - (ORKTaskProgress)progressOfCurrentStep:(ORKStep *)step withResult:(ORKTaskResult *)result {
+    if (_shouldReportProgress) {
+        return [super progressOfCurrentStep:step withResult:result];
+    }
+
     return ORKTaskProgressMake(0, 0);
 }
 


### PR DESCRIPTION
**This change enables a developer to opt into linear progress reporting as implemented on `ORKOrderedTask` by setting a boolean flag on `ORKNavigableOrderedTask`.**

Currently, an `ORKNavigableOrderedTask` does not report any progress through its steps, and there is no way short of subclassing or (gasp!) swizzling to enable it to do so.

This seems reasonable because:
 * A navigable ordered task can not be assumed to have any logical, linear set of steps
 * A developer could implement custom progress reporting by subclassing `ORKOrderedTask` and implementing her own rules for `stepAfterStep:`, etc...

However, after further investigation, it seems desirable to allow a developer to opt into the linear progress reporting of `ORKNavigableOrderedTask`'s super class, `ORKOrderedTask`.

It seems one common use case for `ORKNavigableOrderedTask` would be to implement simple rules where a subclass of `ORKOrderedTask` would be too heavyweight of a solution. For example, imagine a 10 question survey where question 7 can conditionally be skipped based on the answer to question 6. In such a case, it seems reasonable to show the participant a step count, and to allow that step count to go from showing "Step 6 of 10" to "Step 8 of 10" in some cases.

Requiring a developer a to sublcass `ORKOrderedTask` and override several methods just to show step counts to her participants, when an `ORKNavigableOrderedTask` would otherwise meet her needs, seems an unneeded burden, which this patch removes.