### PR TITLE
Make chart and graph IBInspectable/IBDesignable

### DIFF
--- a/ResearchKit/Charts/ORKDiscreteGraphChartView.h
+++ b/ResearchKit/Charts/ORKDiscreteGraphChartView.h
@@ -50,7 +50,7 @@ ORK_CLASS_AVAILABLE
  
  The default value for this property is `YES`.
  */
-@property (nonatomic) BOOL drawsConnectedRanges;
+@property (nonatomic) IBInspectable BOOL drawsConnectedRanges;
 
 @end
 

--- a/ResearchKit/Charts/ORKDiscreteGraphChartView.m
+++ b/ResearchKit/Charts/ORKDiscreteGraphChartView.m
@@ -36,6 +36,12 @@
 #import "ORKHelpers.h"
 #import "ORKRangedPoint.h"
 
+#if TARGET_INTERFACE_BUILDER
+@interface ORKDiscreteGraphChartView ()
+@property (nonatomic, strong, nullable) ORKIBSampleDiscreteGraphDataSource *sampleDataSource;
+@end
+#endif
+
 
 @implementation ORKDiscreteGraphChartView
 
@@ -130,6 +136,15 @@
         canvasYPosition = self.yAxisPoints[plotIndex][pointIndex - 1].maximumValue;
     }
     return canvasYPosition;
+}
+
+#pragma mark - Interface Builder designable
+
+- (void)prepareForInterfaceBuilder {
+#if TARGET_INTERFACE_BUILDER
+    self.sampleDataSource = [ORKIBSampleDiscreteGraphDataSource new];
+    self.dataSource = self.sampleDataSource;
+#endif
 }
 
 @end

--- a/ResearchKit/Charts/ORKGraphChartView.h
+++ b/ResearchKit/Charts/ORKGraphChartView.h
@@ -234,6 +234,7 @@ ORK_AVAILABLE_DECL
  this class directly; use one of the subclasses instead.
 */
 ORK_CLASS_AVAILABLE
+IB_DESIGNABLE
 @interface ORKGraphChartView : UIView
 
 /**

--- a/ResearchKit/Charts/ORKGraphChartView.h
+++ b/ResearchKit/Charts/ORKGraphChartView.h
@@ -246,7 +246,7 @@ ORK_CLASS_AVAILABLE
  smallest value of the `minimumValue` property of all `ORKRangedPoint` instances returned by the
  graph chart view data source.
 */
-@property (nonatomic, readonly) CGFloat minimumValue;
+@property (nonatomic, readonly) IBInspectable CGFloat minimumValue;
 
 /**
  The maximum value of the y-axis.
@@ -258,21 +258,21 @@ ORK_CLASS_AVAILABLE
  largest value of the `maximumValue` property of all `ORKRangedPoint` instances returned by the
  graph chart view data source.
 */
-@property (nonatomic, readonly) CGFloat maximumValue;
+@property (nonatomic, readonly) IBInspectable CGFloat maximumValue;
 
 /**
  A Boolean value indicating whether the graph chart view should draw horizontal reference lines.
 
  The default value of this property is NO.
  */
-@property (nonatomic) BOOL showsHorizontalReferenceLines;
+@property (nonatomic) IBInspectable BOOL showsHorizontalReferenceLines;
 
 /**
  A Boolean value indicating whether the graph chart view should draw vertical reference lines.
 
  The default value of this property is NO.
 */
-@property (nonatomic) BOOL showsVerticalReferenceLines;
+@property (nonatomic) IBInspectable BOOL showsVerticalReferenceLines;
 
 /**
  The delegate is notified of pan gesture events occuring within the bounds of the graph chart
@@ -295,7 +295,7 @@ ORK_CLASS_AVAILABLE
  The default value for this property is a light gray color. Setting this property to `nil`
  resets it to its default value.
 */
-@property (nonatomic, strong, null_resettable) UIColor *axisColor;
+@property (nonatomic, strong, null_resettable) IBInspectable UIColor *axisColor;
 
 /**
  The color of the vertical axis titles.
@@ -305,7 +305,7 @@ ORK_CLASS_AVAILABLE
 
  @note The horizontal axis titles use the current `tintColor`.
 */
-@property (nonatomic, strong, null_resettable) UIColor *verticalAxisTitleColor;
+@property (nonatomic, strong, null_resettable) IBInspectable UIColor *verticalAxisTitleColor;
 
 /**
  The color of the reference lines.
@@ -313,7 +313,7 @@ ORK_CLASS_AVAILABLE
  The default value for this property is a light gray color. Setting this property to `nil` resets it
  to its default value.
 */
-@property (nonatomic, strong, null_resettable) UIColor *referenceLineColor;
+@property (nonatomic, strong, null_resettable) IBInspectable UIColor *referenceLineColor;
 
 /**
  The background color of the thumb on the scrubber line.
@@ -321,7 +321,7 @@ ORK_CLASS_AVAILABLE
  The default value for this property is a white color. Setting this property to `nil` resets it to
  its default value.
 */
-@property (nonatomic, strong, null_resettable) UIColor *scrubberThumbColor;
+@property (nonatomic, strong, null_resettable) IBInspectable UIColor *scrubberThumbColor;
 
 /**
  The color of the scrubber line.
@@ -329,7 +329,7 @@ ORK_CLASS_AVAILABLE
  The default value for this property is a gray color. Setting this property to `nil` resets it to
  its default value.
 */
-@property (nonatomic, strong, null_resettable) UIColor *scrubberLineColor;
+@property (nonatomic, strong, null_resettable) IBInspectable UIColor *scrubberLineColor;
 
 /**
  The string that is displayed if no data points are provided by the data source.
@@ -337,21 +337,21 @@ ORK_CLASS_AVAILABLE
  The default value for this property is an appropriate message string. Setting this property to
  `nil` resets it to its default value.
 */
-@property (nonatomic, copy, null_resettable) NSString *noDataText;
+@property (nonatomic, copy, null_resettable) IBInspectable NSString *noDataText;
 
 /**
  An image to be optionally displayed in place of the maximum value label on the y-axis.
  
  The default value for this property is `nil`.
 */
-@property (nonatomic, strong, nullable) UIImage *maximumValueImage;
+@property (nonatomic, strong, nullable) IBInspectable UIImage *maximumValueImage;
 
 /**
  An image to be optionally displayed in place of the minimum value label on the y-axis.
  
  The default value for this property is `nil`.
 */
-@property (nonatomic, strong, nullable) UIImage *minimumValueImage;
+@property (nonatomic, strong, nullable) IBInspectable UIImage *minimumValueImage;
 
 /**
  The gesture recognizer that is used for scrubbing by the graph chart view.

--- a/ResearchKit/Charts/ORKGraphChartView.h
+++ b/ResearchKit/Charts/ORKGraphChartView.h
@@ -246,7 +246,7 @@ ORK_CLASS_AVAILABLE
  smallest value of the `minimumValue` property of all `ORKRangedPoint` instances returned by the
  graph chart view data source.
 */
-@property (nonatomic, readonly) IBInspectable CGFloat minimumValue;
+@property (nonatomic, readonly) CGFloat minimumValue;
 
 /**
  The maximum value of the y-axis.
@@ -258,7 +258,7 @@ ORK_CLASS_AVAILABLE
  largest value of the `maximumValue` property of all `ORKRangedPoint` instances returned by the
  graph chart view data source.
 */
-@property (nonatomic, readonly) IBInspectable CGFloat maximumValue;
+@property (nonatomic, readonly) CGFloat maximumValue;
 
 /**
  A Boolean value indicating whether the graph chart view should draw horizontal reference lines.

--- a/ResearchKit/Charts/ORKGraphChartView.m
+++ b/ResearchKit/Charts/ORKGraphChartView.m
@@ -1101,3 +1101,96 @@ inline static CALayer *graphPointLayerWithColor(UIColor *color) {
 }
 
 @end
+
+
+#if TARGET_INTERFACE_BUILDER
+
+@implementation ORKIBSampleDiscreteGraphDataSource
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.plotPoints = @[@[[[ORKRangedPoint alloc] initWithMinimumValue: 0 maximumValue: 2],
+                              [[ORKRangedPoint alloc] initWithMinimumValue: 1 maximumValue: 4],
+                              [[ORKRangedPoint alloc] initWithMinimumValue: 2 maximumValue: 6],
+                              [[ORKRangedPoint alloc] initWithMinimumValue: 3 maximumValue: 8],
+                              [[ORKRangedPoint alloc] initWithMinimumValue: 5 maximumValue: 10],
+                              [[ORKRangedPoint alloc] initWithMinimumValue: 8 maximumValue: 13]],
+                            @[[[ORKRangedPoint alloc] initWithValue: 1],
+                              [[ORKRangedPoint alloc] initWithMinimumValue: 2 maximumValue: 6],
+                              [[ORKRangedPoint alloc] initWithMinimumValue: 3 maximumValue: 10],
+                              [[ORKRangedPoint alloc] initWithMinimumValue: 5 maximumValue: 11],
+                              [[ORKRangedPoint alloc] initWithMinimumValue: 7 maximumValue: 13],
+                              [[ORKRangedPoint alloc] initWithMinimumValue: 10 maximumValue: 13]
+                              ]];
+    }
+    return self;
+}
+
+- (NSInteger)numberOfPlotsInGraphChartView:(ORKGraphChartView *)graphChartView {
+    return self.plotPoints.count;
+}
+
+- (NSInteger)graphChartView:(ORKGraphChartView *)graphChartView numberOfPointsForPlotIndex:(NSInteger)plotIndex {
+    return self.plotPoints[plotIndex].count;
+}
+
+- (ORKRangedPoint *)graphChartView:(ORKGraphChartView *)graphChartView pointForPointIndex:(NSInteger)pointIndex plotIndex:(NSInteger)plotIndex {
+    return self.plotPoints[plotIndex][pointIndex];
+}
+
+- (NSString *)graphChartView:(ORKGraphChartView *)graphChartView titleForXAxisAtPointIndex:(NSInteger)pointIndex {
+    return [@(pointIndex + 1) stringValue];
+}
+
+@end
+
+
+@implementation ORKIBSampleLineGraphDataSource
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.plotPoints = @[@[[[ORKRangedPoint alloc] initWithValue: 10],
+                              [[ORKRangedPoint alloc] initWithValue: 20],
+                              [[ORKRangedPoint alloc] initWithValue: 25],
+                              [[ORKRangedPoint alloc] init],
+                              [[ORKRangedPoint alloc] initWithValue: 30],
+                              [[ORKRangedPoint alloc] initWithValue: 40]],
+                            @[[[ORKRangedPoint alloc] initWithValue: 2],
+                              [[ORKRangedPoint alloc] initWithValue: 4],
+                              [[ORKRangedPoint alloc] initWithValue: 8],
+                              [[ORKRangedPoint alloc] initWithValue: 16],
+                              [[ORKRangedPoint alloc] initWithValue: 32],
+                              [[ORKRangedPoint alloc] initWithValue: 64]
+                              ]];
+    }
+    return self;
+}
+
+- (NSInteger)numberOfPlotsInGraphChartView:(ORKGraphChartView *)graphChartView {
+    return self.plotPoints.count;
+}
+
+- (NSInteger)graphChartView:(ORKGraphChartView *)graphChartView numberOfPointsForPlotIndex:(NSInteger)plotIndex {
+    return self.plotPoints[plotIndex].count;
+}
+
+- (ORKRangedPoint *)graphChartView:(ORKGraphChartView *)graphChartView pointForPointIndex:(NSInteger)pointIndex plotIndex:(NSInteger)plotIndex {
+    return self.plotPoints[plotIndex][pointIndex];
+}
+
+- (NSString *)graphChartView:(ORKGraphChartView *)graphChartView titleForXAxisAtPointIndex:(NSInteger)pointIndex {
+    return [@(pointIndex + 1) stringValue];
+}
+
+- (CGFloat)minimumValueForGraphChartView:(ORKGraphChartView *)graphChartView {
+    return 0;
+}
+
+- (CGFloat)maximumValueForGraphChartView:(ORKGraphChartView *)graphChartView {
+    return 70;
+}
+
+@end
+#endif

--- a/ResearchKit/Charts/ORKGraphChartView.m
+++ b/ResearchKit/Charts/ORKGraphChartView.m
@@ -1094,4 +1094,10 @@ inline static CALayer *graphPointLayerWithColor(UIColor *color) {
     self.accessibilityElements = accessibilityElements;
 }
 
+#pragma mark - Interface Builder designable
+
+- (void)prepareForInterfaceBuilder {
+    [self reloadData];
+}
+
 @end

--- a/ResearchKit/Charts/ORKGraphChartView_Internal.h
+++ b/ResearchKit/Charts/ORKGraphChartView_Internal.h
@@ -62,6 +62,15 @@ static inline CGFloat xAxisPoint(NSInteger pointIndex, NSInteger numberOfXAxisPo
     return round((canvasWidth / MAX(1, numberOfXAxisPoints - 1)) * pointIndex);
 }
 
+#if TARGET_INTERFACE_BUILDER
+@interface ORKIBSampleDiscreteGraphDataSource : NSObject <ORKGraphChartViewDataSource>
+@property (nonatomic, strong, nullable) NSArray <NSArray *> *plotPoints;
+@end
+
+@interface ORKIBSampleLineGraphDataSource : NSObject <ORKGraphChartViewDataSource>
+@property (nonatomic, strong, nullable) NSArray <NSArray *> *plotPoints;
+@end
+#endif
 
 @interface ORKGraphChartView ()
 

--- a/ResearchKit/Charts/ORKLineGraphChartView.m
+++ b/ResearchKit/Charts/ORKLineGraphChartView.m
@@ -37,6 +37,12 @@
 #import "ORKRangedPoint.h"
 
 
+#if TARGET_INTERFACE_BUILDER
+@interface ORKLineGraphChartView ()
+@property (nonatomic, strong, nullable) ORKIBSampleLineGraphDataSource *sampleDataSource;
+@end
+#endif
+
 const CGFloat FillColorAlpha = 0.4;
 
 @implementation ORKLineGraphChartView {
@@ -264,6 +270,15 @@ const CGFloat FillColorAlpha = 0.4;
                 startDelay:duration * (2.0 / 3.0)
             timingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear]];
     }];
+}
+
+#pragma mark - Interface Builder designable
+
+- (void)prepareForInterfaceBuilder {
+#if TARGET_INTERFACE_BUILDER
+    self.sampleDataSource = [ORKIBSampleLineGraphDataSource new];
+    self.dataSource = self.sampleDataSource;
+#endif
 }
 
 @end

--- a/ResearchKit/Charts/ORKPieChartView.h
+++ b/ResearchKit/Charts/ORKPieChartView.h
@@ -111,6 +111,7 @@ ORK_AVAILABLE_DECL
  `ORKPieChartViewDataSource` protocol as a pie chart.
 */
 ORK_CLASS_AVAILABLE
+IB_DESIGNABLE
 @interface ORKPieChartView : UIView
 
 /**

--- a/ResearchKit/Charts/ORKPieChartView.h
+++ b/ResearchKit/Charts/ORKPieChartView.h
@@ -125,14 +125,14 @@ ORK_CLASS_AVAILABLE
  you set a number higher than the radius of the pie chart, the pie chart draws a completely
  filled pie.
 */
-@property (nonatomic) CGFloat lineWidth;
+@property (nonatomic) IBInspectable CGFloat lineWidth;
 
 /**
  The text to display as a title in the pie chart view.
  
  If you do not set a value for this property, the pie chart does not display a title.
 */
-@property (nonatomic, copy, nullable) NSString *title;
+@property (nonatomic, copy, nullable) IBInspectable NSString *title;
 
 /**
  The text to display beneath the title in the pie chart view.
@@ -140,7 +140,7 @@ ORK_CLASS_AVAILABLE
  If you do not set a value for this property, the pie chart does not display any text beneath the
  title.
 */
-@property (nonatomic, copy, nullable) NSString *text;
+@property (nonatomic, copy, nullable) IBInspectable NSString *text;
 
 /**
  The color used for the text of the title label.
@@ -148,7 +148,7 @@ ORK_CLASS_AVAILABLE
  The default value for this property is a light gray color. Setting this property to `nil` resets it
  to its default value.
  */
-@property (nonatomic, strong, null_resettable) UIColor *titleColor;
+@property (nonatomic, strong, null_resettable) IBInspectable UIColor *titleColor;
 
 /**
  The color used for the text of the text label.
@@ -156,7 +156,7 @@ ORK_CLASS_AVAILABLE
  The default value for this property is a light gray color. Setting this property to `nil` resets it
  to its default value.
  */
-@property (nonatomic, strong, null_resettable) UIColor *textColor;
+@property (nonatomic, strong, null_resettable) IBInspectable UIColor *textColor;
 
 /**
  A Boolean value indicating whether the title and text labels should be drawn above the chart.
@@ -164,7 +164,7 @@ ORK_CLASS_AVAILABLE
  If this value of this property is `NO`, the title and text are drawn at the center of the chart.
  The default value for this property is `NO`.
  */
-@property (nonatomic) BOOL showsTitleAboveChart;
+@property (nonatomic) IBInspectable BOOL showsTitleAboveChart;
 
 /**
  A Boolean value indicating whether the pie chart should draw percentage labels next to each
@@ -172,7 +172,7 @@ ORK_CLASS_AVAILABLE
  
  The default value for this property is YES.
 */
-@property (nonatomic) BOOL showsPercentageLabels;
+@property (nonatomic) IBInspectable BOOL showsPercentageLabels;
 
 /**
  A Boolean value indicating whether the pie chart drawing animation draws clockwise or
@@ -180,7 +180,7 @@ ORK_CLASS_AVAILABLE
  
  The default value for this property is YES.
 */
-@property (nonatomic) BOOL drawsClockwise;
+@property (nonatomic) IBInspectable BOOL drawsClockwise;
 
 /**
  The string that will be displayed if the sum of the values of all segments is zero.
@@ -188,7 +188,7 @@ ORK_CLASS_AVAILABLE
  The default value for this property is an appropriate message string. Setting this property to
  `nil` resets it to its default value.
 */
-@property (nonatomic, copy, null_resettable) NSString *noDataText;
+@property (nonatomic, copy, null_resettable) IBInspectable NSString *noDataText;
 
 /**
  Animates the pie chart when it is first displayed on the screen.

--- a/ResearchKit/Charts/ORKPieChartView.m
+++ b/ResearchKit/Charts/ORKPieChartView.m
@@ -385,4 +385,10 @@ static const CGFloat PieToLegendPadding = 8.0;
     return accessibilityElements;
 }
 
+#pragma mark - Interface Builder designable
+
+- (void)prepareForInterfaceBuilder {
+    [self reloadData];
+}
+
 @end

--- a/ResearchKit/Charts/ORKPieChartView.m
+++ b/ResearchKit/Charts/ORKPieChartView.m
@@ -44,6 +44,7 @@
 static const CGFloat TitleToPiePadding = 8.0;
 static const CGFloat PieToLegendPadding = 8.0;
 
+
 @implementation ORKPieChartSection
 
 - (instancetype)initWithLabel:(UILabel *)label angle:(CGFloat)angle {
@@ -388,7 +389,60 @@ static const CGFloat PieToLegendPadding = 8.0;
 #pragma mark - Interface Builder designable
 
 - (void)prepareForInterfaceBuilder {
-    [self reloadData];
+#if TARGET_INTERFACE_BUILDER
+    self.sampleDataSource = [ORKIBSamplePieChartDataSource new];
+    self.dataSource = self.sampleDataSource;
+#endif
 }
 
 @end
+
+
+#if TARGET_INTERFACE_BUILDER
+
+@implementation ORKIBSamplePieChartDataSourceSegment
+@end
+
+@implementation ORKIBSamplePieChartDataSource
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        ORKIBSamplePieChartDataSourceSegment *segment1 = [ORKIBSamplePieChartDataSourceSegment new];
+        segment1.title = @"Title 1";
+        segment1.value = 10.0;
+        segment1.color = [UIColor colorWithRed:217.0/225 green:217.0/255 blue:217.0/225 alpha:1];
+
+        ORKIBSamplePieChartDataSourceSegment *segment2 = [ORKIBSamplePieChartDataSourceSegment new];
+        segment2.title = @"Title 2";
+        segment2.value = 25.0;
+        segment2.color = [UIColor colorWithRed:142.0/255 green:142.0/255 blue:147.0/255 alpha:1];
+
+        ORKIBSamplePieChartDataSourceSegment *segment3 = [ORKIBSamplePieChartDataSourceSegment new];
+        segment3.title = @"Title 3";
+        segment3.value = 45.0;
+        segment3.color = [UIColor colorWithRed:244.0/225 green:190.0/255 blue:74.0/225 alpha:1];
+
+        _segments = @[segment1, segment2, segment3];
+    }
+    return self;
+}
+- (NSInteger)numberOfSegmentsInPieChartView:(ORKPieChartView *)pieChartView {
+    return self.segments.count;
+}
+
+- (CGFloat)pieChartView:(ORKPieChartView *)pieChartView valueForSegmentAtIndex:(NSInteger)index {
+    return self.segments[index].value;
+}
+
+- (UIColor *)pieChartView:(ORKPieChartView *)pieChartView colorForSegmentAtIndex:(NSInteger)index {
+    return self.segments[index].color;
+}
+
+- (NSString *)pieChartView:(ORKPieChartView *)pieChartView titleForSegmentAtIndex:(NSInteger)index {
+    return self.segments[index].title;
+}
+
+@end
+
+#endif

--- a/ResearchKit/Charts/ORKPieChartView_Internal.h
+++ b/ResearchKit/Charts/ORKPieChartView_Internal.h
@@ -44,9 +44,26 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 
+#if TARGET_INTERFACE_BUILDER
+@interface ORKIBSamplePieChartDataSourceSegment : NSObject
+@property (nonatomic, strong, nullable) NSString *title;
+@property (nonatomic, assign) CGFloat value;
+@property (nonatomic, strong, nullable) UIColor *color;
+@end
+
+@interface ORKIBSamplePieChartDataSource : NSObject <ORKPieChartViewDataSource>
+@property (nonatomic, strong, nullable) NSArray <ORKIBSamplePieChartDataSourceSegment *> *segments;
+@end
+#endif
+
+
 @interface ORKPieChartView ()
 
 - (UIColor *)colorForSegmentAtIndex:(NSInteger)index;
+
+#if TARGET_INTERFACE_BUILDER
+@property (nonatomic, strong, nullable) ORKIBSamplePieChartDataSource *sampleDataSource;
+#endif
 
 @end
 


### PR DESCRIPTION
Declare customization properties as `IBInspectable` for charts and graphs.

![screen shot 2016-02-26 at 10 45 24 am](https://cloud.githubusercontent.com/assets/886053/13348952/fb855d32-dc76-11e5-90f0-571b750bd9ad.png) ![screen shot 2016-02-26 at 10 47 01 am](https://cloud.githubusercontent.com/assets/886053/13348955/fe7effc0-dc76-11e5-87f2-4dd4cda8f2ce.png)

Also makes these views `IBDesignable`, effectively displaying them as placeholders with no data.

![screen shot 2016-02-26 at 2 38 01 pm](https://cloud.githubusercontent.com/assets/886053/13353776/defa5a12-dc96-11e5-90de-ed7321191416.png)

PS: We could go a step further, and provide a data source sample for Interface Builder. This could be confusing, as IB would display data seemingly out of nowhere; but also useful to configure the `IBInspectable` properties. Any thoughts on this?