### PR TITLE
Allow 2 lines of text on vertical scale sliders

### DIFF
--- a/ResearchKit/Common/ORKScaleSliderView.m
+++ b/ResearchKit/Common/ORKScaleSliderView.m
@@ -88,7 +88,7 @@
                 ORKScaleRangeLabel *stepLabel = [[ORKScaleRangeLabel alloc] initWithFrame:CGRectZero];
                 stepLabel.text = textChoice.text;
                 stepLabel.textAlignment = NSTextAlignmentLeft;
-                stepLabel.numberOfLines = 2;
+                stepLabel.numberOfLines = 0;
                 stepLabel.translatesAutoresizingMaskIntoConstraints = NO;
                 [self addSubview:stepLabel];
                 [_textChoiceLabels addObject:stepLabel];

--- a/ResearchKit/Common/ORKScaleSliderView.m
+++ b/ResearchKit/Common/ORKScaleSliderView.m
@@ -88,6 +88,7 @@
                 ORKScaleRangeLabel *stepLabel = [[ORKScaleRangeLabel alloc] initWithFrame:CGRectZero];
                 stepLabel.text = textChoice.text;
                 stepLabel.textAlignment = NSTextAlignmentLeft;
+                stepLabel.numberOfLines = 2;
                 stepLabel.translatesAutoresizingMaskIntoConstraints = NO;
                 [self addSubview:stepLabel];
                 [_textChoiceLabels addObject:stepLabel];


### PR DESCRIPTION
There's plenty of space for this to fit comfortably, and it allows much more flexibility in defining answer choices.