### PR TITLE
[ORKNavigableOrderedTask] Implement skip navigation rules

### DIFF
--- a/ResearchKit/Common/ORKNavigableOrderedTask.h
+++ b/ResearchKit/Common/ORKNavigableOrderedTask.h
@@ -89,7 +89,7 @@ ORK_CLASS_AVAILABLE
 
  @return A step navigation rule, or `nil` if the trigger step identifier has none.
  */
-- (ORKStepNavigationRule *)navigationRuleForTriggerStepIdentifier:(NSString *)triggerStepIdentifier;
+- (nullable ORKStepNavigationRule *)navigationRuleForTriggerStepIdentifier:(NSString *)triggerStepIdentifier;
 
 /**
  Removes the navigation rule, if any, associated with the specified trigger step identifier.
@@ -128,7 +128,7 @@ ORK_CLASS_AVAILABLE
  
  @return A skip step navigation rule, or `nil` if the step identifier has none.
  */
-- (ORKSkipStepNavigationRule *)skipNavigationRuleForStepIdentifier:(NSString *)stepIdentifier;
+- (nullable ORKSkipStepNavigationRule *)skipNavigationRuleForStepIdentifier:(NSString *)stepIdentifier;
 
 /**
  Removes the skip step navigation rule, if any, associated with the specified step identifier.

--- a/ResearchKit/Common/ORKNavigableOrderedTask.h
+++ b/ResearchKit/Common/ORKNavigableOrderedTask.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015, Ricardo Sánchez-Sáez.
+ Copyright (c) 2015-2016, Ricardo Sánchez-Sáez.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -36,18 +36,24 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class ORKStepNavigationRule;
+@class ORKSkipStepNavigationRule;
 
 /**
- The `ORKNavigableOrderedTask` class adds conditional step navigation to the behavior inherited from the
- `ORKOrderedTask` class.
+ The `ORKNavigableOrderedTask` class adds conditional step navigation to the behavior inherited from
+ the `ORKOrderedTask` class.
  
  For implementing conditional task navigation, you must instantiate concrete subclasses of
- `ORKStepNavigationRule` and attach them to trigger steps by using the
- `setNavigationRule:forTriggerStepIdentifier:` method.
+ `ORKStepNavigationRule` and `ORKSkipStepNavigationRule` and attach them to trigger steps by using
+ the `setNavigationRule:forTriggerStepIdentifier:` and `setSkipNavigationRule:forStepIdentifier:`
+ methods.
  
  For example, if you want to display a survey question only when the user answered Yes to a previous
  question you can use `ORKPredicateStepNavigationRule`; or if you want to define an arbitrary jump
- between two steps you can use `ORKDirectStepNavigationRule`.
+ between two steps you can use `ORKDirectStepNavigationRule`. You can also optionally omit steps by
+ using `ORKPredicateSkipStepNavigationRule` objects.
+ 
+ Note that each step in the task can have at most one attached navigation rule and one attached skip
+ navigation rule.
  
  Navigable ordered tasks support looping over previously visited steps. Note, however, that results
  for steps that are visited more than once will be ovewritten when you revisit the step on the loop.
@@ -69,14 +75,15 @@ ORK_CLASS_AVAILABLE
  only the most recently added rule is kept.
  
  @param stepNavigationRule      The step navigation rule to be used when navigating forward from the
-                                    trigger step. A strong reference to the rule is maintained by
-                                    the task.
+                                    trigger step. A strong reference to the rule is kept by the
+                                    task.
  @param triggerStepIdentifier   The identifier of the step that triggers the rule.
  */
 - (void)setNavigationRule:(ORKStepNavigationRule *)stepNavigationRule forTriggerStepIdentifier:(NSString *)triggerStepIdentifier;
 
 /**
- Returns the step navigation rule (if any) associated with a trigger step identifier.
+ Returns the step navigation rule associated with a trigger step identifier, or `nil` if there is
+ no rule associated with that step identifier.
  
  @param triggerStepIdentifier   The identifier of the step whose rule you want to retrieve.
 
@@ -85,7 +92,7 @@ ORK_CLASS_AVAILABLE
 - (ORKStepNavigationRule *)navigationRuleForTriggerStepIdentifier:(NSString *)triggerStepIdentifier;
 
 /**
- Removes the navigation rule (if any) associated with the specified trigger step identifier.
+ Removes the navigation rule, if any, associated with the specified trigger step identifier.
  
  @param triggerStepIdentifier   The identifier of the step whose rule is to be removed.
  */
@@ -99,7 +106,46 @@ ORK_CLASS_AVAILABLE
 @property (nonatomic, copy, readonly) NSDictionary<NSString *, ORKStepNavigationRule *> *stepNavigationRules;
 
 /**
- Determines whether the task should report its progress as a linear ordered task or not. 
+ Adds a skip step navigation rule for a step identifier.
+ 
+ The rule will be used to decide if the identified step needs to be skipped. You cannot add two
+ different skip navigation rules to the same step identifier; only the most recently added rule is
+ kept.
+ 
+ @param skipStepNavigationRule      The skip step navigation rule to be used to determine if the
+                                        step should be skipped. A strong reference to the rule is
+                                        kept by the task.
+ @param stepIdentifier              The identifier of the step that is checked against the skip
+                                        rule.
+ */
+- (void)setSkipNavigationRule:(ORKSkipStepNavigationRule *)skipStepNavigationRule forStepIdentifier:(NSString *)stepIdentifier;
+
+/**
+ Returns the skip step navigation rule associated with a step identifier,  or `nil` if there is no
+ skip rule associated with that step identifier.
+ 
+ @param stepIdentifier      The identifier of the step whose skip rule you want to retrieve.
+ 
+ @return A skip step navigation rule, or `nil` if the step identifier has none.
+ */
+- (ORKSkipStepNavigationRule *)skipNavigationRuleForStepIdentifier:(NSString *)stepIdentifier;
+
+/**
+ Removes the skip step navigation rule, if any, associated with the specified step identifier.
+ 
+ @param stepIdentifier   The identifier of the step whose rule is to be removed.
+ */
+- (void)removeSkipNavigationRuleForStepIdentifier:(NSString *)stepIdentifier;
+
+/**
+ A dictionary of step navigation rules in the task, keyed by trigger step identifier.
+ 
+ Each object in the dictionary should be a `ORKStepNavigationRule` subclass.
+ */
+@property (nonatomic, copy, readonly) NSDictionary<NSString *, ORKSkipStepNavigationRule *> *skipStepNavigationRules;
+
+/**
+ Determines whether the task should report its progress as a linear ordered task or not.
  The default value of this property is `NO`.
  */
 @property (nonatomic) BOOL shouldReportProgress;

--- a/ResearchKit/Common/ORKNavigableOrderedTask.m
+++ b/ResearchKit/Common/ORKNavigableOrderedTask.m
@@ -40,8 +40,8 @@
 
 
 @implementation ORKNavigableOrderedTask {
-    NSMutableDictionary *_stepNavigationRules;
-    NSMutableDictionary *_skipStepNavigationRules;
+    NSMutableDictionary<NSString *, ORKStepNavigationRule *> *_stepNavigationRules;
+    NSMutableDictionary<NSString *, ORKSkipStepNavigationRule *> *_skipStepNavigationRules;
 }
 
 - (instancetype)initWithIdentifier:(NSString *)identifier steps:(NSArray<ORKStep *> *)steps {
@@ -76,6 +76,13 @@
     [_stepNavigationRules removeObjectForKey:triggerStepIdentifier];
 }
 
+- (NSDictionary<NSString *, ORKStepNavigationRule *> *)stepNavigationRules {
+    if (!_stepNavigationRules) {
+        return (NSDictionary<NSString *, ORKStepNavigationRule *> *)@[];
+    }
+    return [_stepNavigationRules copy];
+}
+
 - (void)setSkipNavigationRule:(ORKSkipStepNavigationRule *)skipStepNavigationRule forStepIdentifier:(NSString *)stepIdentifier {
     ORKThrowInvalidArgumentExceptionIfNil(skipStepNavigationRule);
     ORKThrowInvalidArgumentExceptionIfNil(stepIdentifier);
@@ -96,6 +103,13 @@
     ORKThrowInvalidArgumentExceptionIfNil(stepIdentifier);
     
     [_skipStepNavigationRules removeObjectForKey:stepIdentifier];
+}
+
+- (NSDictionary<NSString *, ORKSkipStepNavigationRule *> *)skipStepNavigationRules {
+    if (!_skipStepNavigationRules) {
+        return (NSDictionary<NSString *, ORKSkipStepNavigationRule *> *)@[];
+    }
+    return [_skipStepNavigationRules copy];
 }
 
 - (ORKStep *)stepAfterStep:(ORKStep *)step withResult:(ORKTaskResult *)result {

--- a/ResearchKit/Common/ORKNavigableOrderedTask.m
+++ b/ResearchKit/Common/ORKNavigableOrderedTask.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015, Ricardo Sánchez-Sáez.
+ Copyright (c) 2015-2016, Ricardo Sánchez-Sáez.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -41,12 +41,14 @@
 
 @implementation ORKNavigableOrderedTask {
     NSMutableDictionary *_stepNavigationRules;
+    NSMutableDictionary *_skipStepNavigationRules;
 }
 
 - (instancetype)initWithIdentifier:(NSString *)identifier steps:(NSArray<ORKStep *> *)steps {
     self = [super initWithIdentifier:identifier steps:steps];
     if (self) {
         _stepNavigationRules = nil;
+        _skipStepNavigationRules = nil;
         _shouldReportProgress = NO;
     }
     return self;
@@ -74,6 +76,28 @@
     [_stepNavigationRules removeObjectForKey:triggerStepIdentifier];
 }
 
+- (void)setSkipNavigationRule:(ORKSkipStepNavigationRule *)skipStepNavigationRule forStepIdentifier:(NSString *)stepIdentifier {
+    ORKThrowInvalidArgumentExceptionIfNil(skipStepNavigationRule);
+    ORKThrowInvalidArgumentExceptionIfNil(stepIdentifier);
+    
+    if (!_skipStepNavigationRules) {
+        _skipStepNavigationRules = [NSMutableDictionary new];
+    }
+    _skipStepNavigationRules[stepIdentifier] = skipStepNavigationRule;
+}
+
+- (ORKSkipStepNavigationRule *)skipNavigationRuleForStepIdentifier:(NSString *)stepIdentifier {
+    ORKThrowInvalidArgumentExceptionIfNil(stepIdentifier);
+    
+    return _skipStepNavigationRules[stepIdentifier];
+}
+
+- (void)removeSkipNavigationRuleForStepIdentifier:(NSString *)stepIdentifier {
+    ORKThrowInvalidArgumentExceptionIfNil(stepIdentifier);
+    
+    [_skipStepNavigationRules removeObjectForKey:stepIdentifier];
+}
+
 - (ORKStep *)stepAfterStep:(ORKStep *)step withResult:(ORKTaskResult *)result {
     ORKStep *nextStep = nil;
     ORKStepNavigationRule *navigationRule = _stepNavigationRules[step.identifier];
@@ -87,6 +111,11 @@
             }
         } else {
             nextStep = [super stepAfterStep:step withResult:result];
+        }
+        
+        ORKSkipStepNavigationRule *skipNavigationRule = _skipStepNavigationRules[nextStep.identifier];
+        if ([skipNavigationRule stepShouldSkipWithTaskResult:result]) {
+            return [self stepAfterStep:nextStep withResult:result];
         }
     }
     return nextStep;
@@ -116,9 +145,15 @@
     return ORKTaskProgressMake(0, 0);
 }
 
-// This method should only be used by serialization (the stepNavigationRules property is published as readonly)
+#pragma mark Serialization private methods
+
+// These methods should only be used by serialization tests (the stepNavigationRules and skipStepNavigationRules properties are published as readonly)
 - (void)setStepNavigationRules:(NSDictionary *)stepNavigationRules {
     _stepNavigationRules = [stepNavigationRules mutableCopy];
+}
+
+- (void)setSkipStepNavigationRules:(NSDictionary *)skipStepNavigationRules {
+    _skipStepNavigationRules = [skipStepNavigationRules mutableCopy];
 }
 
 #pragma mark NSSecureCoding
@@ -131,6 +166,7 @@
     self = [super initWithCoder:aDecoder];
     if (self) {
         ORK_DECODE_OBJ_MUTABLE_DICTIONARY(aDecoder, stepNavigationRules, NSString, ORKStepNavigationRule);
+        ORK_DECODE_OBJ_MUTABLE_DICTIONARY(aDecoder, skipStepNavigationRules, NSString, ORKSkipStepNavigationRule);
         ORK_DECODE_BOOL(aDecoder, shouldReportProgress);
     }
     return self;
@@ -140,6 +176,7 @@
     [super encodeWithCoder:aCoder];
     
     ORK_ENCODE_OBJ(aCoder, stepNavigationRules);
+    ORK_ENCODE_OBJ(aCoder, skipStepNavigationRules);
     ORK_ENCODE_BOOL(aCoder, shouldReportProgress);
 }
 
@@ -148,6 +185,7 @@
 - (instancetype)copyWithZone:(NSZone *)zone {
     typeof(self) task = [super copyWithZone:zone];
     task->_stepNavigationRules = ORKMutableDictionaryCopyObjects(_stepNavigationRules);
+    task->_skipStepNavigationRules = ORKMutableDictionaryCopyObjects(_skipStepNavigationRules);
     task->_shouldReportProgress = _shouldReportProgress;
     return task;
 }
@@ -157,12 +195,13 @@
     
     __typeof(self) castObject = object;
     return isParentSame
-    && ORKEqualObjects(self->_stepNavigationRules, castObject->_stepNavigationRules)
-    && self->_shouldReportProgress == castObject.shouldReportProgress;
+    && ORKEqualObjects(_stepNavigationRules, castObject->_stepNavigationRules)
+    && ORKEqualObjects(_skipStepNavigationRules, castObject->_skipStepNavigationRules)
+    && _shouldReportProgress == castObject.shouldReportProgress;
 }
 
 - (NSUInteger)hash {
-    return [super hash] ^ [_stepNavigationRules hash] ^ (_shouldReportProgress ? 0xf : 0x0);
+    return [super hash] ^ [_stepNavigationRules hash] ^ [_skipStepNavigationRules hash] ^ (_shouldReportProgress ? 0xf : 0x0);
 }
 
 #pragma mark - Predefined

--- a/ResearchKit/Common/ORKNavigableOrderedTask.m
+++ b/ResearchKit/Common/ORKNavigableOrderedTask.m
@@ -78,7 +78,7 @@
 
 - (NSDictionary<NSString *, ORKStepNavigationRule *> *)stepNavigationRules {
     if (!_stepNavigationRules) {
-        return (NSDictionary<NSString *, ORKStepNavigationRule *> *)@[];
+        return @{};
     }
     return [_stepNavigationRules copy];
 }
@@ -107,7 +107,7 @@
 
 - (NSDictionary<NSString *, ORKSkipStepNavigationRule *> *)skipStepNavigationRules {
     if (!_skipStepNavigationRules) {
-        return (NSDictionary<NSString *, ORKSkipStepNavigationRule *> *)@[];
+        return @{};
     }
     return [_skipStepNavigationRules copy];
 }

--- a/ResearchKit/Common/ORKStepNavigationRule.h
+++ b/ResearchKit/Common/ORKStepNavigationRule.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015, Ricardo Sánchez-Sáez.
+ Copyright (c) 2015-2016, Ricardo Sánchez-Sáez.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -50,7 +50,7 @@ ORK_EXTERN NSString *const ORKNullStepIdentifier ORK_AVAILABLE_DECL;
  The `ORKStepNavigationRule` class is the abstract base class for concrete step navigation rules.
  
  Step navigation rules can be used within an `ORKNavigableOrderedTask` object. You assign step
- navigation rules to be triggered by the task steps (each step can have one rule at most).
+ navigation rules to be triggered by the task steps. Each step can have one rule at most.
 
  Subclasses must implement the `identifierForDestinationStepWithTaskResult:` method, which returns
  the identifier of the destination step for the rule.
@@ -171,7 +171,7 @@ ORK_CLASS_AVAILABLE
  
  Each object in the array should be of the `ORKTaskResult` class.
  */
-@property (nonatomic, strong, nullable) NSArray<ORKTaskResult *> *additionalTaskResults;
+@property (nonatomic, copy, nullable) NSArray<ORKTaskResult *> *additionalTaskResults;
 
 /**
  The array of result predicates. 
@@ -227,6 +227,96 @@ ORK_CLASS_AVAILABLE
  The identifier of the destination step.
  */
 @property (nonatomic, copy, readonly) NSString *destinationStepIdentifier;
+
+@end
+
+
+/**
+ The `ORKSkipStepNavigationRule` class is the abstract base class for concrete skip step navigation
+ rules.
+ 
+ Skip step navigation rules can be used within an `ORKNavigableOrderedTask` object. You assign skip
+ step navigation rules to be triggered before a task step is shown. Each step can have one skip rule
+ at most.
+ 
+ Subclasses must implement the `identifierForDestinationStepWithTaskResult:` method, which returns
+ the identifier of the destination step for the rule.
+ 
+ Two concrete subclasses are included: `ORKPredicateStepNavigationRule` can match any answer
+ combination in the results of the ongoing task and jump accordingly; `ORKDirectStepNavigationRule`
+ unconditionally navigates to the step specified by the destination step identifier.
+ */
+ORK_CLASS_AVAILABLE
+@interface ORKSkipStepNavigationRule : NSObject <NSCopying, NSSecureCoding>
+
+/*
+ The `init` and `new` methods are unavailable.
+ 
+ `ORKStepNavigationRule` classes should be initialized with custom designated initializers on each
+ subclass.
+ */
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ Returns whether the targeted step should skip.
+ 
+ Subclasses must implement this method to calculate if the targeted step should skip based on the
+ passed task result.
+ 
+ @param taskResult      The up-to-date task result, used for calculating whether the task should
+                            skip.
+ 
+ @return YES if the step should skip.
+ */
+- (BOOL)stepShouldSkipWithTaskResult:(ORKTaskResult *)taskResult;
+
+@end
+
+
+@interface ORKPredicateSkipStepNavigationRule : ORKSkipStepNavigationRule
+
+/**
+ Returns an initialized predicate skip step navigation rule using the specified result predicate.
+ 
+ @param resultPredicate     A result predicate. If the result predicate matches, the step
+                                will skip.
+ 
+ @return An initialized skip predicate step navigation rule.
+ */
+- (instancetype)initWithResultPredicate:(NSPredicate *)resultPredicate NS_DESIGNATED_INITIALIZER;
+
+/**
+ Returns a new predicate step navigation rule that was initialized from data in the given
+ unarchiver.
+ 
+ @param aDecoder    The coder from which to initialize the step navigation rule.
+ 
+ @return A new predicate skip step navigation rule.
+ */
+- (instancetype)initWithCoder:(NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;
+
+/**
+ An optional array of additional task results.
+ 
+ With this property, a task can have different navigation behavior depending on the results of
+ related tasks that the user may have already completed. The predicate skip step navigation rule can
+ use the question results within these tasks, in addition to the current task question results, to
+ match the result predicates.
+ 
+ You must ensure that all the task result identifiers are unique and that they are different from
+ the ongoing task result identifier. Also ensure that no task result contains question
+ results with duplicate identifiers. Question results *can have* equal identifiers provided that
+ they belong to different task results.
+ 
+ Each object in the array should be of the `ORKTaskResult` class.
+ */
+@property (nonatomic, copy, nullable) NSArray<ORKTaskResult *> *additionalTaskResults;
+
+/**
+ The result predicate to match.
+ */
+@property (nonatomic, strong, readonly) NSPredicate *resultPredicate;
 
 @end
 

--- a/ResearchKit/Common/ORKStepNavigationRule.m
+++ b/ResearchKit/Common/ORKStepNavigationRule.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015, Ricardo Sánchez-Sáez.
+ Copyright (c) 2015-2016, Ricardo Sánchez-Sáez.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -41,12 +41,16 @@ NSString *const ORKNullStepIdentifier = @"org.researchkit.step.null";
 
 @implementation ORKStepNavigationRule
 
-- (instancetype)init_ork {
-    return [super init];
++ (instancetype)new {
+    ORKThrowMethodUnavailableException();
 }
 
 - (instancetype)init {
     ORKThrowMethodUnavailableException();
+}
+
+- (instancetype)init_ork {
+    return [super init];
 }
 
 - (NSString *)identifierForDestinationStepWithTaskResult:(ORKTaskResult *)taskResult {
@@ -66,18 +70,18 @@ NSString *const ORKNullStepIdentifier = @"org.researchkit.step.null";
 - (void)encodeWithCoder:(NSCoder *)aCoder {
 }
 
-- (BOOL)isEqual:(id)object {
-    if ([self class] != [object class]) {
-        return NO;
-    }
-    return YES;
-}
-
 #pragma mark NSCopying
 
 - (instancetype)copyWithZone:(NSZone *)zone {
     typeof(self) rule = [[[self class] allocWithZone:zone] init_ork];
     return rule;
+}
+
+- (BOOL)isEqual:(id)object {
+    if ([self class] != [object class]) {
+        return NO;
+    }
+    return YES;
 }
 
 @end
@@ -119,9 +123,9 @@ NSString *const ORKNullStepIdentifier = @"org.researchkit.step.null";
     }
     self = [super init_ork];
     if (self) {
-        self.resultPredicates = resultPredicates;
-        self.destinationStepIdentifiers = destinationStepIdentifiers;
-        self.defaultStepIdentifier = defaultStepIdentifier;
+        _resultPredicates = [resultPredicates copy];
+        _destinationStepIdentifiers = [destinationStepIdentifiers copy];
+        _defaultStepIdentifier = [defaultStepIdentifier copy];
     }
     
     return self;
@@ -238,10 +242,10 @@ static void ORKValidateIdentifiersUnique(NSArray *results, NSString *exceptionRe
     BOOL isParentSame = [super isEqual:object];
     __typeof(self) castObject = object;
     return (isParentSame
-            && ORKEqualObjects(self.resultPredicates, castObject.resultPredicates)
-            && ORKEqualObjects(self.destinationStepIdentifiers, castObject.destinationStepIdentifiers)
-            && ORKEqualObjects(self.defaultStepIdentifier, castObject.defaultStepIdentifier)
-            && ORKEqualObjects(self.additionalTaskResults, castObject.additionalTaskResults));
+            && ORKEqualObjects(_resultPredicates, castObject.resultPredicates)
+            && ORKEqualObjects(_destinationStepIdentifiers, castObject.destinationStepIdentifiers)
+            && ORKEqualObjects(_defaultStepIdentifier, castObject.defaultStepIdentifier)
+            && ORKEqualObjects(_additionalTaskResults, castObject.additionalTaskResults));
 }
 
 - (NSUInteger)hash {
@@ -264,14 +268,14 @@ static void ORKValidateIdentifiersUnique(NSArray *results, NSString *exceptionRe
     ORKThrowInvalidArgumentExceptionIfNil(destinationStepIdentifier);
     self = [super init_ork];
     if (self) {
-        self.destinationStepIdentifier = destinationStepIdentifier;
+        _destinationStepIdentifier = destinationStepIdentifier;
     }
     
     return self;
 }
 
 - (NSString *)identifierForDestinationStepWithTaskResult:(ORKTaskResult *)ORKTaskResult {
-    return self.destinationStepIdentifier;
+    return _destinationStepIdentifier;
 }
 
 #pragma mark NSSecureCoding
@@ -304,11 +308,144 @@ static void ORKValidateIdentifiersUnique(NSArray *results, NSString *exceptionRe
     BOOL isParentSame = [super isEqual:object];
     __typeof(self) castObject = object;
     return (isParentSame
-            && ORKEqualObjects(self.destinationStepIdentifier, castObject.destinationStepIdentifier));
+            && ORKEqualObjects(_destinationStepIdentifier, castObject.destinationStepIdentifier));
 }
 
 - (NSUInteger)hash {
     return [_destinationStepIdentifier hash];
+}
+
+@end
+
+
+@implementation ORKSkipStepNavigationRule
+
++ (instancetype)new {
+    ORKThrowMethodUnavailableException();
+}
+
+- (instancetype)init {
+    ORKThrowMethodUnavailableException();
+}
+
+- (instancetype)init_ork {
+    return [super init];
+}
+
+- (BOOL)stepShouldSkipWithTaskResult:(ORKTaskResult *)taskResult {
+    @throw [NSException exceptionWithName:NSGenericException reason:@"You should override this method in a subclass" userInfo:nil];
+}
+
+#pragma mark NSSecureCoding
+
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    return [super init];
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+}
+
+#pragma mark NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+    typeof(self) rule = [[[self class] allocWithZone:zone] init_ork];
+    return rule;
+}
+
+- (BOOL)isEqual:(id)object {
+    if ([self class] != [object class]) {
+        return NO;
+    }
+    return YES;
+}
+
+@end
+
+
+@interface ORKPredicateSkipStepNavigationRule()
+
+@property (nonatomic) NSPredicate *resultPredicate;
+
+@end
+
+
+@implementation ORKPredicateSkipStepNavigationRule
+
+- (instancetype)initWithResultPredicate:(NSPredicate *)resultPredicate {
+    ORKThrowInvalidArgumentExceptionIfNil(resultPredicate);
+    self = [super init_ork];
+    if (self) {
+        _resultPredicate = resultPredicate;
+    }
+    
+    return self;
+}
+
+- (void)setAdditionalTaskResults:(NSArray *)additionalTaskResults {
+    for (ORKTaskResult *taskResult in additionalTaskResults) {
+        ORKValidateIdentifiersUnique(ORKLeafQuestionResultsFromTaskResult(taskResult), @"All question results should have unique identifiers");
+    }
+    _additionalTaskResults = additionalTaskResults;
+}
+
+- (BOOL)stepShouldSkipWithTaskResult:(ORKTaskResult *)taskResult {
+    NSMutableArray *allTaskResults = [[NSMutableArray alloc] initWithObjects:taskResult, nil];
+    if (_additionalTaskResults) {
+        [allTaskResults addObjectsFromArray:_additionalTaskResults];
+    }
+    ORKValidateIdentifiersUnique(allTaskResults, @"All tasks should have unique identifiers");
+    
+    // The predicate can either have:
+    // - an ORKResultPredicateTaskIdentifierVariableName variable which will be substituted by the ongoign task identifier;
+    // - a hardcoded task identifier set by the developer (the substituionVariables dictionary is ignored in this case)
+    BOOL predicateDidMatch = [_resultPredicate evaluateWithObject:allTaskResults
+                                           substitutionVariables:@{ORKResultPredicateTaskIdentifierVariableName: taskResult.identifier}];
+    return predicateDidMatch;
+}
+
+#pragma mark NSSecureCoding
+
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        ORK_DECODE_OBJ_CLASS(aDecoder, resultPredicate, NSPredicate);
+        ORK_DECODE_OBJ_ARRAY(aDecoder, additionalTaskResults, ORKTaskResult);
+    }
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [super encodeWithCoder:aCoder];
+    ORK_ENCODE_OBJ(aCoder, resultPredicate);
+    ORK_ENCODE_OBJ(aCoder, additionalTaskResults);
+}
+
+#pragma mark NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+    typeof(self) rule = [[[self class] allocWithZone:zone] initWithResultPredicate:_resultPredicate];
+    rule->_additionalTaskResults = ORKArrayCopyObjects(_additionalTaskResults);
+    return rule;
+}
+
+- (BOOL)isEqual:(id)object {
+    BOOL isParentSame = [super isEqual:object];
+    __typeof(self) castObject = object;
+    return (isParentSame
+            && ORKEqualObjects(_resultPredicate, castObject.resultPredicate)
+            && ORKEqualObjects(_additionalTaskResults, castObject.additionalTaskResults));
+}
+
+- (NSUInteger)hash {
+    return [_resultPredicate hash] ^ [_additionalTaskResults hash];
 }
 
 @end

--- a/ResearchKitTests/ORKTaskTests.m
+++ b/ResearchKitTests/ORKTaskTests.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015, Ricardo Sánchez-Sáez.
+ Copyright (c) 2015-2016, Ricardo Sánchez-Sáez.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -401,11 +401,16 @@ BOOL (^testStepBeforeStep)(ORKNavigableOrderedTask *, ORKTaskResult *, ORKStep *
     
     ORKDirectStepNavigationRule *mockNavigationRule = [[ORKDirectStepNavigationRule alloc] initWithDestinationStepIdentifier:MockDestinationStepIdentifier];
     [_navigableOrderedTask setNavigationRule:mockNavigationRule forTriggerStepIdentifier:MockTriggerStepIdentifier];
-    
+
     XCTAssertEqualObjects([_navigableOrderedTask navigationRuleForTriggerStepIdentifier:MockTriggerStepIdentifier], [mockNavigationRule copy]);
+
+    ORKPredicateSkipStepNavigationRule *mockSkipNavigationRule = [[ORKPredicateSkipStepNavigationRule alloc] initWithResultPredicate:[NSPredicate predicateWithFormat:@"1 == 1"]];
+    [_navigableOrderedTask setSkipNavigationRule:mockSkipNavigationRule forStepIdentifier:MockTriggerStepIdentifier];
     
-    [_navigableOrderedTask removeNavigationRuleForTriggerStepIdentifier:MockTriggerStepIdentifier];
-    XCTAssertNil([_navigableOrderedTask navigationRuleForTriggerStepIdentifier:MockTriggerStepIdentifier]);
+    XCTAssertEqualObjects([_navigableOrderedTask skipNavigationRuleForStepIdentifier:MockTriggerStepIdentifier], [mockSkipNavigationRule copy]);
+    
+    [_navigableOrderedTask removeSkipNavigationRuleForStepIdentifier:MockTriggerStepIdentifier];
+    XCTAssertNil([_navigableOrderedTask skipNavigationRuleForStepIdentifier:MockTriggerStepIdentifier]);
 }
 
 - (void)testNavigableOrderedTaskEmpty {
@@ -417,6 +422,7 @@ BOOL (^testStepBeforeStep)(ORKNavigableOrderedTask *, ORKTaskResult *, ORKStep *
     ORKTaskResult *taskResult = [self getResultTreeWithTaskIdentifier:NavigableOrderedTaskIdentifier resultOptions:0];
     
     // Test forward navigation
+    XCTAssertTrue(testStepAfterStep(_navigableOrderedTask, taskResult, nil, symptomStep));
     XCTAssertTrue(testStepAfterStep(_navigableOrderedTask, taskResult, symptomStep, otherSymptomStep));
     XCTAssertTrue(testStepAfterStep(_navigableOrderedTask, taskResult, otherSymptomStep, endStep));
     XCTAssertTrue(testStepAfterStep(_navigableOrderedTask, taskResult, endStep, nil));
@@ -444,6 +450,7 @@ BOOL (^testStepBeforeStep)(ORKNavigableOrderedTask *, ORKTaskResult *, ORKStep *
     ORKTaskResult *taskResult = [self getResultTreeWithTaskIdentifier:NavigableOrderedTaskIdentifier resultOptions:TestsTaskResultOptionSymptomHeadache | TestsTaskResultOptionSeverityYes];
     
     // Test forward navigation
+    XCTAssertTrue(testStepAfterStep(_navigableOrderedTask, taskResult, nil, symptomStep));
     XCTAssertTrue(testStepAfterStep(_navigableOrderedTask, taskResult, symptomStep, severityStep));
     XCTAssertTrue(testStepAfterStep(_navigableOrderedTask, taskResult, severityStep, severeHeadacheStep));
     XCTAssertTrue(testStepAfterStep(_navigableOrderedTask, taskResult, severeHeadacheStep, endStep));
@@ -465,6 +472,7 @@ BOOL (^testStepBeforeStep)(ORKNavigableOrderedTask *, ORKTaskResult *, ORKStep *
     ORKTaskResult *taskResult = [self getResultTreeWithTaskIdentifier:NavigableOrderedTaskIdentifier resultOptions:TestsTaskResultOptionSymptomDizziness];
     
     // Test forward navigation
+    XCTAssertTrue(testStepAfterStep(_navigableOrderedTask, taskResult, nil, symptomStep));
     XCTAssertTrue(testStepAfterStep(_navigableOrderedTask, taskResult, symptomStep, otherSymptomStep));
     XCTAssertTrue(testStepAfterStep(_navigableOrderedTask, taskResult, otherSymptomStep, endStep));
     XCTAssertTrue(testStepAfterStep(_navigableOrderedTask, taskResult, endStep, nil));
@@ -484,6 +492,7 @@ BOOL (^testStepBeforeStep)(ORKNavigableOrderedTask *, ORKTaskResult *, ORKStep *
     ORKTaskResult *taskResult = [self getResultTreeWithTaskIdentifier:NavigableOrderedTaskIdentifier resultOptions:TestsTaskResultOptionSymptomHeadache | TestsTaskResultOptionSeverityYes];
     
     // Test forward navigation
+    XCTAssertTrue(testStepAfterStep(_navigableOrderedTask, taskResult, nil, symptomStep));
     XCTAssertTrue(testStepAfterStep(_navigableOrderedTask, taskResult, symptomStep, severityStep));
     XCTAssertTrue(testStepAfterStep(_navigableOrderedTask, taskResult, severityStep, severeHeadacheStep));
     XCTAssertTrue(testStepAfterStep(_navigableOrderedTask, taskResult, severeHeadacheStep, endStep));
@@ -505,6 +514,7 @@ BOOL (^testStepBeforeStep)(ORKNavigableOrderedTask *, ORKTaskResult *, ORKStep *
     ORKTaskResult *taskResult = [self getResultTreeWithTaskIdentifier:NavigableOrderedTaskIdentifier resultOptions:TestsTaskResultOptionSymptomHeadache | TestsTaskResultOptionSeverityNo];
     
     // Test forward navigation
+    XCTAssertTrue(testStepAfterStep(_navigableOrderedTask, taskResult, nil, symptomStep));
     XCTAssertTrue(testStepAfterStep(_navigableOrderedTask, taskResult, symptomStep, severityStep));
     XCTAssertTrue(testStepAfterStep(_navigableOrderedTask, taskResult, severityStep, lightHeadacheStep));
     XCTAssertTrue(testStepAfterStep(_navigableOrderedTask, taskResult, lightHeadacheStep, endStep));
@@ -515,6 +525,50 @@ BOOL (^testStepBeforeStep)(ORKNavigableOrderedTask *, ORKTaskResult *, ORKStep *
     XCTAssertTrue(testStepBeforeStep(_navigableOrderedTask, taskResult, lightHeadacheStep, severityStep));
     XCTAssertTrue(testStepBeforeStep(_navigableOrderedTask, taskResult, severityStep, symptomStep));
     XCTAssertTrue(testStepBeforeStep(_navigableOrderedTask, taskResult, symptomStep, nil));
+}
+
+- (void)testNavigableOrderedTaskSkip {
+    ORKNavigableOrderedTask *skipTask = [_navigableOrderedTask copy];
+
+    getIndividualNavigableOrderedTaskSteps();
+
+    //
+    // Light headache sequence
+    //
+    ORKTaskResult *taskResult = [self getResultTreeWithTaskIdentifier:NavigableOrderedTaskIdentifier resultOptions:TestsTaskResultOptionSymptomHeadache | TestsTaskResultOptionSeverityNo];
+
+    // User chose headache at the symptom step
+    ORKResultSelector *resultSelector = [[ORKResultSelector alloc] initWithResultIdentifier:SymptomStepIdentifier];
+    NSPredicate *predicateHeadache = [ORKResultPredicate predicateForChoiceQuestionResultWithResultSelector:resultSelector
+                                                                                        expectedAnswerValue:HeadacheChoiceValue];
+    ORKPredicateSkipStepNavigationRule *skipRule = [[ORKPredicateSkipStepNavigationRule alloc] initWithResultPredicate:predicateHeadache];
+    
+    // Skip endStep
+    [skipTask setSkipNavigationRule:skipRule forStepIdentifier:EndStepIdentifier];
+    
+    // Test forward navigation
+    XCTAssertTrue(testStepAfterStep(skipTask, taskResult, nil, symptomStep));
+    XCTAssertTrue(testStepAfterStep(skipTask, taskResult, symptomStep, severityStep));
+    XCTAssertTrue(testStepAfterStep(skipTask, taskResult, severityStep, lightHeadacheStep));
+    XCTAssertTrue(testStepAfterStep(skipTask, taskResult, lightHeadacheStep, nil));
+    
+    
+    // Skip lightHeadacheStep
+    [skipTask removeSkipNavigationRuleForStepIdentifier:EndStepIdentifier];
+    [skipTask setSkipNavigationRule:skipRule forStepIdentifier:LightHeadacheStepIdentifier];
+    
+    XCTAssertTrue(testStepAfterStep(skipTask, taskResult, nil, symptomStep));
+    XCTAssertTrue(testStepAfterStep(skipTask, taskResult, symptomStep, severityStep));
+    XCTAssertTrue(testStepAfterStep(skipTask, taskResult, severityStep, endStep));
+    XCTAssertTrue(testStepAfterStep(skipTask, taskResult, endStep, nil));
+
+    
+    // Skip lightHeadache and endStep
+    [skipTask setSkipNavigationRule:skipRule forStepIdentifier:EndStepIdentifier];
+    
+    XCTAssertTrue(testStepAfterStep(skipTask, taskResult, nil, symptomStep));
+    XCTAssertTrue(testStepAfterStep(skipTask, taskResult, symptomStep, severityStep));
+    XCTAssertTrue(testStepAfterStep(skipTask, taskResult, severityStep, nil));
 }
 
 ORKDefineStringKey(ScaleStepIdentifier);
@@ -856,6 +910,163 @@ static ORKStepResult *(^getStepResult)(NSString *, Class, ORKQuestionType, id) =
         additionalTaskResult = [self getSmallFormTaskResultTreeWithIsAdditionalTask:YES];
         predicateRule.additionalTaskResults = @[ additionalTaskResult ];
         XCTAssertEqualObjects([predicateRule identifierForDestinationStepWithTaskResult:taskResult], MatchedDestinationStepIdentifier);
+    }
+}
+
+- (void)testPredicateSkipStepNavigationRule {
+    NSPredicate *predicate = nil;
+    NSPredicate *predicateA = nil;
+    NSPredicate *predicateB = nil;
+    ORKPredicateSkipStepNavigationRule *predicateRule = nil;
+    ORKTaskResult *taskResult = nil;
+    ORKTaskResult *additionalTaskResult = nil;
+    
+    ORKResultSelector *resultSelector = nil;
+    
+    {
+        // Test predicate step navigation rule initializers
+        resultSelector = [[ORKResultSelector alloc] initWithResultIdentifier:TextStepIdentifier];
+        predicate = [ORKResultPredicate predicateForTextQuestionResultWithResultSelector:resultSelector
+                                                                          expectedString:TextValue];
+        predicateRule = [[ORKPredicateSkipStepNavigationRule alloc] initWithResultPredicate:predicate];
+        XCTAssertEqualObjects(predicateRule.resultPredicate, predicate);
+    }
+    
+    {
+        // Predicate matching, no additional task results, matching
+        taskResult = [ORKTaskResult new];
+        taskResult.identifier = OrderedTaskIdentifier;
+        
+        resultSelector = [[ORKResultSelector alloc] initWithResultIdentifier:TextStepIdentifier];
+        predicate = [ORKResultPredicate predicateForTextQuestionResultWithResultSelector:resultSelector
+                                                                          expectedString:TextValue];
+        predicateRule = [[ORKPredicateSkipStepNavigationRule alloc] initWithResultPredicate:predicate];
+        
+        XCTAssertFalse([predicateRule stepShouldSkipWithTaskResult:taskResult]);
+        
+        taskResult = [self getSmallTaskResultTreeWithIsAdditionalTask:NO];
+        XCTAssertTrue([predicateRule stepShouldSkipWithTaskResult:taskResult]);
+    }
+    
+    {
+        // Predicate matching, no additional task results, non matching
+        resultSelector = [[ORKResultSelector alloc] initWithResultIdentifier:TextStepIdentifier];
+        predicate = [ORKResultPredicate predicateForTextQuestionResultWithResultSelector:resultSelector
+                                                                          expectedString:OtherTextValue];
+        predicateRule = [[ORKPredicateSkipStepNavigationRule alloc] initWithResultPredicate:predicate];
+        taskResult = [self getSmallTaskResultTreeWithIsAdditionalTask:NO];
+        XCTAssertFalse([predicateRule stepShouldSkipWithTaskResult:taskResult]);
+    }
+
+    {
+        NSPredicate *currentPredicate = nil;
+        NSPredicate *additionalPredicate = nil;
+        
+        // Predicate matching, additional task results
+        resultSelector = [[ORKResultSelector alloc] initWithResultIdentifier:TextStepIdentifier];
+        currentPredicate = [ORKResultPredicate predicateForTextQuestionResultWithResultSelector:resultSelector
+                                                                                 expectedString:TextValue];
+        
+        resultSelector = [[ORKResultSelector alloc] initWithTaskIdentifier:AdditionalTaskIdentifier
+                                                          resultIdentifier:AdditionalTextStepIdentifier];
+        additionalPredicate = [ORKResultPredicate predicateForTextQuestionResultWithResultSelector:resultSelector
+                                                                                    expectedString:AdditionalTextValue];
+        
+        predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[currentPredicate, additionalPredicate]];
+        predicateRule = [[ORKPredicateSkipStepNavigationRule alloc] initWithResultPredicate:predicate];
+        
+        taskResult = [ORKTaskResult new];
+        taskResult.identifier = OrderedTaskIdentifier;
+        XCTAssertFalse([predicateRule stepShouldSkipWithTaskResult:taskResult]);
+        
+        taskResult = [self getSmallTaskResultTreeWithIsAdditionalTask:NO];
+        XCTAssertFalse([predicateRule stepShouldSkipWithTaskResult:taskResult]);
+        
+        additionalTaskResult = [self getSmallTaskResultTreeWithIsAdditionalTask:YES];
+        predicateRule.additionalTaskResults = @[ additionalTaskResult ];
+        XCTAssertTrue([predicateRule stepShouldSkipWithTaskResult:taskResult]);
+    }
+
+    {
+        // Test duplicate task identifiers check
+        predicateRule.additionalTaskResults = @[ taskResult ];
+        XCTAssertThrows([predicateRule stepShouldSkipWithTaskResult:taskResult]);
+        
+        // Test duplicate question result identifiers check
+        XCTAssertThrows(predicateRule.additionalTaskResults = @[ [self getSmallTaskResultTreeWithDuplicateStepIdentifiers] ]);
+    }
+    
+    {
+        // Form predicate matching, no additional task results, matching
+        resultSelector = [[ORKResultSelector alloc] initWithStepIdentifier:FormStepIdentifier
+                                                          resultIdentifier:TextFormItemIdentifier];
+        predicateA = [ORKResultPredicate predicateForTextQuestionResultWithResultSelector:resultSelector
+                                                                           expectedString:TextValue];
+        
+        resultSelector = [[ORKResultSelector alloc] initWithStepIdentifier:FormStepIdentifier
+                                                          resultIdentifier:NumericFormItemIdentifier];
+        predicateB = [ORKResultPredicate predicateForNumericQuestionResultWithResultSelector:resultSelector
+                                                                              expectedAnswer:IntegerValue];
+        
+        predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[predicateA, predicateB]];
+        predicateRule = [[ORKPredicateSkipStepNavigationRule alloc] initWithResultPredicate:predicate];
+        
+        taskResult = [self getSmallFormTaskResultTreeWithIsAdditionalTask:NO];
+        XCTAssertTrue([predicateRule stepShouldSkipWithTaskResult:taskResult]);
+    }
+
+    {
+        // Form predicate matching, no additional task results, non matching
+        resultSelector = [[ORKResultSelector alloc] initWithStepIdentifier:FormStepIdentifier
+                                                          resultIdentifier:TextFormItemIdentifier];
+        predicate = [ORKResultPredicate predicateForTextQuestionResultWithResultSelector:resultSelector
+                                                                          expectedString:OtherTextValue];
+        predicateRule = [[ORKPredicateSkipStepNavigationRule alloc] initWithResultPredicate:predicate];
+        
+        taskResult = [self getSmallFormTaskResultTreeWithIsAdditionalTask:NO];
+        XCTAssertFalse([predicateRule stepShouldSkipWithTaskResult:taskResult]);
+    }
+    
+    {
+        NSPredicate *currentPredicate = nil;
+        NSPredicate *additionalPredicate = nil;
+        
+        // Form predicate matching, additional task results
+        resultSelector = [[ORKResultSelector alloc] initWithStepIdentifier:FormStepIdentifier
+                                                          resultIdentifier:TextFormItemIdentifier];
+        predicateA = [ORKResultPredicate predicateForTextQuestionResultWithResultSelector:resultSelector
+                                                                           expectedString:TextValue];
+        
+        resultSelector = [[ORKResultSelector alloc] initWithStepIdentifier:FormStepIdentifier
+                                                          resultIdentifier:NumericFormItemIdentifier];
+        predicateB = [ORKResultPredicate predicateForNumericQuestionResultWithResultSelector:resultSelector
+                                                                              expectedAnswer:IntegerValue];
+        
+        currentPredicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[predicateA, predicateB]];
+        
+        resultSelector = [[ORKResultSelector alloc] initWithTaskIdentifier:AdditionalTaskIdentifier
+                                                            stepIdentifier:AdditionalFormStepIdentifier
+                                                          resultIdentifier:AdditionalTextFormItemIdentifier];
+        predicateA = [ORKResultPredicate predicateForTextQuestionResultWithResultSelector:resultSelector
+                                                                           expectedString:AdditionalTextValue];
+        
+        resultSelector = [[ORKResultSelector alloc] initWithTaskIdentifier:AdditionalTaskIdentifier
+                                                            stepIdentifier:AdditionalFormStepIdentifier
+                                                          resultIdentifier:AdditionalNumericFormItemIdentifier];
+        predicateB = [ORKResultPredicate predicateForNumericQuestionResultWithResultSelector:resultSelector
+                                                                              expectedAnswer:AdditionalIntegerValue];
+        
+        additionalPredicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[predicateA, predicateB]];
+        
+        predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[currentPredicate, additionalPredicate]];
+        predicateRule = [[ORKPredicateSkipStepNavigationRule alloc] initWithResultPredicate:predicate];
+        
+        taskResult = [self getSmallFormTaskResultTreeWithIsAdditionalTask:NO];
+        XCTAssertFalse([predicateRule stepShouldSkipWithTaskResult:taskResult]);
+        
+        additionalTaskResult = [self getSmallFormTaskResultTreeWithIsAdditionalTask:YES];
+        predicateRule.additionalTaskResults = @[ additionalTaskResult ];
+        XCTAssertTrue([predicateRule stepShouldSkipWithTaskResult:taskResult]);
     }
 }
 

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -1,7 +1,7 @@
 /*
  Copyright (c) 2015, Apple Inc. All rights reserved.
  Copyright (c) 2015, Bruce Duncan.
- Copyright (c) 2015, Ricardo Sánchez-Sáez.
+ Copyright (c) 2015-2016, Ricardo Sánchez-Sáez.
 
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -2855,9 +2855,19 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     
     // Intro step
     step = [[ORKInstructionStep alloc] initWithIdentifier:@"introStep"];
-    step.title = @"This task demonstrates an optional loop within a navigable ordered task";
+    step.title = @"This task demonstrates an skippable step and an optional loop within a navigable ordered task";
     [steps addObject:step];
 
+    // Skippable step
+    answerFormat = [ORKAnswerFormat booleanAnswerFormat];
+    questionStep = [ORKQuestionStep questionStepWithIdentifier:@"skipNextStep" title:@"Do you want to skip the next step?" answer:answerFormat];
+    questionStep.optional = NO;
+    [steps addObject:questionStep];
+
+    step = [[ORKInstructionStep alloc] initWithIdentifier:@"skippableStep"];
+    step.title = @"You'll optionally skip this step";
+    [steps addObject:step];
+    
     // Loop target step
     step = [[ORKInstructionStep alloc] initWithIdentifier:@"loopAStep"];
     step.title = @"You'll optionally return to this step";
@@ -2921,12 +2931,21 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
     // Build navigation rules
     ORKResultSelector *resultSelector = nil;
     ORKPredicateStepNavigationRule *predicateRule = nil;
-    ORKDirectStepNavigationRule *directRule;
+    ORKDirectStepNavigationRule *directRule = nil;
+    ORKPredicateSkipStepNavigationRule *predicateSkipRule = nil;
     
+    // skippable step
+    resultSelector = [ORKResultSelector selectorWithResultIdentifier:@"skipNextStep"];
+    NSPredicate *predicateSkipStep = [ORKResultPredicate predicateForBooleanQuestionResultWithResultSelector:resultSelector
+                                                                                              expectedAnswer:YES];
+    predicateSkipRule = [[ORKPredicateSkipStepNavigationRule alloc] initWithResultPredicate:predicateSkipStep];
+    [task setSkipNavigationRule:predicateSkipRule forStepIdentifier:@"skippableStep"];
+
     // From the branching step, go to either scaleStep or textChoiceStep
     resultSelector = [ORKResultSelector selectorWithResultIdentifier:@"branchingStep"];
-    NSPredicate *predicateAnswerType = [ORKResultPredicate predicateForChoiceQuestionResultWithResultSelector:resultSelector expectedAnswerValue:@"scale"];
-    predicateRule = [[ORKPredicateStepNavigationRule alloc] initWithResultPredicates:@[ predicateAnswerType ]
+    NSPredicate *predicateAnswerTypeScale = [ORKResultPredicate predicateForChoiceQuestionResultWithResultSelector:resultSelector
+                                                                                               expectedAnswerValue:@"scale"];
+    predicateRule = [[ORKPredicateStepNavigationRule alloc] initWithResultPredicates:@[ predicateAnswerTypeScale ]
                                                           destinationStepIdentifiers:@[ @"scaleStep" ]
                                                                defaultStepIdentifier:@"textChoiceStep"];
     [task setNavigationRule:predicateRule forTriggerStepIdentifier:@"branchingStep"];

--- a/Testing/ORKTest/ORKTest/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTest/ORKESerialization.m
@@ -1,6 +1,7 @@
 /*
  Copyright (c) 2015, Apple Inc. All rights reserved.
- 
+ Copyright (c) 2015-2016, Ricardo Sánchez-Sáez.
+
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
  
@@ -366,6 +367,7 @@ ret =
              return task;
          },(@{
               PROPERTY(stepNavigationRules, ORKStepNavigationRule, NSMutableDictionary, YES, nil, nil),
+              PROPERTY(skipStepNavigationRules, ORKSkipStepNavigationRule, NSMutableDictionary, YES, nil, nil),
               PROPERTY(shouldReportProgress, NSNumber, NSObject, YES, nil, nil),
               })),
    ENTRY(ORKStep,
@@ -1386,7 +1388,7 @@ static id jsonObjectForObject(id object) {
             encodedDictionary[key] = jsonObjectForObject(inputDict[key]);
         }
         jsonOutput = encodedDictionary;
-    } else {
+    } else if (![c isSubclassOfClass:[NSPredicate class]]) {  // Ignore NSPredicate which cannot be easily serialized for now
         NSCAssert(isValid(object), @"Expected valid JSON object");
         
         // Leaf: native JSON object

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -187,6 +187,7 @@
  allows us to write very short code to instantiate valid objects during these tests.
  */
 ORK_MAKE_TEST_INIT(ORKStepNavigationRule, ^{return [super init];});
+ORK_MAKE_TEST_INIT(ORKSkipStepNavigationRule, ^{return [super init];});
 ORK_MAKE_TEST_INIT(ORKAnswerFormat, ^{return [super init];});
 ORK_MAKE_TEST_INIT(ORKStep, ^{return [self initWithIdentifier:[NSUUID UUID].UUIDString];});
 ORK_MAKE_TEST_INIT(ORKReviewStep, ^{return [[self class] standaloneReviewStepWithIdentifier:[NSUUID UUID].UUIDString steps:@[] resultSource:[ORKTaskResult new]];});
@@ -313,6 +314,8 @@ ORK_MAKE_TEST_INIT(ORKLocation, (^{
     
     NSArray *classesExcludedForORKESerialization = @[
                                                      [ORKStepNavigationRule class],     // abstract base class
+                                                     [ORKSkipStepNavigationRule class],     // abstract base class
+                                                     [ORKPredicateSkipStepNavigationRule class],     // NSPredicate doesn't yet support JSON serialzation 
                                                      ];
     
     if ((classesExcludedForORKESerialization.count + classesWithORKSerialization.count) != classesWithSecureCoding.count) {
@@ -323,7 +326,8 @@ ORK_MAKE_TEST_INIT(ORKLocation, (^{
     }
     
     // Predefined exception
-    NSArray *propertyExclusionList = @[@"superclass",
+    NSArray *propertyExclusionList = @[
+                                       @"superclass",
                                        @"description",
                                        @"descriptionSuffix",
                                        @"debugDescription",
@@ -332,8 +336,10 @@ ORK_MAKE_TEST_INIT(ORKLocation, (^{
                                        @"requestedHealthKitTypesForWriting",
                                        @"healthKitUnit",
                                        @"answer",
-                                       @"firstResult"];
-    NSArray *knownNotSerializedProperties = @[@"ORKStep.task",
+                                       @"firstResult",
+                                       ];
+    NSArray *knownNotSerializedProperties = @[
+                                              @"ORKStep.task",
                                               @"ORKStep.restorable",
                                               @"ORKReviewStep.isStandalone",
                                               @"ORKAnswerFormat.questionType",
@@ -379,7 +385,8 @@ ORK_MAKE_TEST_INIT(ORKLocation, (^{
                                               @"ORKVerificationStep.verificationViewControllerClass",
                                               @"ORKLoginStep.loginViewControllerClass",
                                               @"ORKRegistrationStep.passcodeValidationRegex",
-                                              @"ORKRegistrationStep.passcodeInvalidMessage"];
+                                              @"ORKRegistrationStep.passcodeInvalidMessage",
+                                              ];
     NSArray *allowedUnTouchedKeys = @[@"_class"];
     
     // Test Each class
@@ -535,6 +542,8 @@ ORK_MAKE_TEST_INIT(ORKLocation, (^{
         [instance setValue:[[ORKLocation alloc] initWithCoordinate:CLLocationCoordinate2DMake(index? 2.0 : 3.0, 3.0) region:[[CLCircularRegion alloc] initWithCenter:CLLocationCoordinate2DMake(2.0, 3.0) radius:100.0 identifier:@"identifier"] userInput:@"addressString" addressDictionary:@{@"city":@"city", @"street":@"street"}] forKey:p.propertyName];
     } else if (p.propertyClass == [CLCircularRegion class]) {
         [instance setValue:[[CLCircularRegion alloc] initWithCenter:CLLocationCoordinate2DMake(index? 2.0 : 3.0, 3.0) radius:100.0 identifier:@"identifier"] forKey:p.propertyName];
+    } else if (p.propertyClass == [NSPredicate class]) {
+        [instance setValue:[NSPredicate predicateWithFormat:index?@"1 == 1":@"1 == 2"] forKey:p.propertyName];
     } else if (equality && (p.propertyClass == [UIImage class])) {
         // do nothing - meaningless for the equality check
         return NO;
@@ -635,7 +644,7 @@ ORK_MAKE_TEST_INIT(ORKLocation, (^{
             if (newValue == nil) {
                 NSString *notSerializedProperty = [NSString stringWithFormat:@"%@.%@", NSStringFromClass(aClass), pName];
                 BOOL success = [knownNotSerializedProperties containsObject:notSerializedProperty];
-                if (! success)
+                if (!success)
                 {
                     XCTAssertTrue(success, "Unexpected notSerializedProperty = %@", notSerializedProperty);
                 }
@@ -669,7 +678,7 @@ ORK_MAKE_TEST_INIT(ORKLocation, (^{
         NSData *data3 = [NSKeyedArchiver archivedDataWithRootObject:newInstance2];
         
         if (![data isEqualToData:data2]) { // allow breakpointing
-            if (! [aClass isSubclassOfClass:[ORKConsentSection class]]) {
+            if (![aClass isSubclassOfClass:[ORKConsentSection class]]) {
                 // ORKConsentSection mis-matches, but it is still "equal" because
                 // the net custom animation URL is a match.
                 XCTAssertEqualObjects(data, data2, @"data mismatch for %@", NSStringFromClass(aClass));
@@ -690,15 +699,16 @@ ORK_MAKE_TEST_INIT(ORKLocation, (^{
 
 - (id)instanceForClass:(Class)c {
     if (([c isSubclassOfClass:[ORKStepNavigationRule class]]) ||
-        ([c isSubclassOfClass:[ORKStep class]] ||
-         ([c isSubclassOfClass:[ORKOrderedTask class]]) ||
-         (c == [ORKTextChoice class]) ||
-         (c == [ORKImageChoice class]) ||
-         ([c isSubclassOfClass:[ORKAnswerFormat class]]) ||
-         ([c isSubclassOfClass:[ORKRecorderConfiguration class]]) ||
-         (c == [ORKLocation class]))
-    ) {
-        return [[c alloc] orktest_init];
+        ([c isSubclassOfClass:[ORKSkipStepNavigationRule class]]) ||
+        ([c isSubclassOfClass:[ORKStep class]]) ||
+        ([c isSubclassOfClass:[ORKOrderedTask class]]) ||
+        (c == [ORKTextChoice class]) ||
+        (c == [ORKImageChoice class]) ||
+        ([c isSubclassOfClass:[ORKAnswerFormat class]]) ||
+        ([c isSubclassOfClass:[ORKRecorderConfiguration class]]) ||
+        (c == [ORKLocation class]))
+    {
+            return [[c alloc] orktest_init];
     }
     
     return [[c alloc] init];
@@ -767,7 +777,7 @@ ORK_MAKE_TEST_INIT(ORKLocation, (^{
         }
         
         id copiedInstance = [instance copy];
-        if (! [copiedInstance isEqual:instance]) {
+        if (![copiedInstance isEqual:instance]) {
             XCTAssertEqualObjects(copiedInstance, instance);
         }
        


### PR DESCRIPTION
This PR deals with [Issue #535](https://github.com/ResearchKit/ResearchKit/issues/535).

It introduces the `ORKSkipStepNavigationRule` (abstract) and `ORKPredicateSkipStepNavigationRule` (concrete) classes, and the appropriate `ORKNavigableOrderedTask` methods to insert, view and remove them. Also adds some example code to `ORKTest`'s *Navigable Loop Task* item. Includes *unit tests* for all the new functionality, and makes sure all serialization tests continue to pass. Everything is documented.