### PR TITLE
Improved flexibility for laying out a vertical ORKScaleSliderView.

### DIFF
--- a/ResearchKit/Common/ORKScaleSliderView.m
+++ b/ResearchKit/Common/ORKScaleSliderView.m
@@ -209,7 +209,15 @@
                                                                 attribute:NSLayoutAttributeCenterY
                                                                multiplier:1.0
                                                                  constant:0.0]];
-            
+
+            [constraints addObject:[NSLayoutConstraint constraintWithItem:_slider
+                                                                attribute:NSLayoutAttributeCenterX
+                                                                relatedBy:NSLayoutRelationLessThanOrEqual
+                                                                   toItem:self
+                                                                attribute:NSLayoutAttributeCenterX
+                                                               multiplier:0.25
+                                                                 constant:0.0]];
+
             [constraints addObjectsFromArray:
              [NSLayoutConstraint constraintsWithVisualFormat:@"V:|-kSliderMargin-[_slider]-kSliderMargin-|"
                                                      options:NSLayoutFormatDirectionLeadingToTrailing
@@ -230,13 +238,6 @@
                 if (i == 0) {
                     // First label
                     [constraints addObject:[NSLayoutConstraint constraintWithItem:_textChoiceLabels[i]
-                                                                        attribute:NSLayoutAttributeCenterX
-                                                                        relatedBy:NSLayoutRelationEqual
-                                                                           toItem:self
-                                                                        attribute:NSLayoutAttributeCenterX
-                                                                       multiplier:1.0
-                                                                         constant:0.0]];
-                    [constraints addObject:[NSLayoutConstraint constraintWithItem:_textChoiceLabels[i]
                                                                         attribute:NSLayoutAttributeCenterY
                                                                         relatedBy:NSLayoutRelationEqual
                                                                            toItem:_slider
@@ -248,8 +249,17 @@
                                                                         relatedBy:NSLayoutRelationLessThanOrEqual
                                                                            toItem:self
                                                                         attribute:NSLayoutAttributeWidth
-                                                                       multiplier:0.5
-                                                                         constant:0.0]];
+                                                                       multiplier:0.75
+                                                                         constant:0]];
+                    
+                    [constraints addObject:[NSLayoutConstraint constraintWithItem:_textChoiceLabels[i]
+                                                                        attribute:NSLayoutAttributeTrailing
+                                                                        relatedBy:NSLayoutRelationEqual
+                                                                           toItem:self
+                                                                        attribute:NSLayoutAttributeTrailing
+                                                                       multiplier:1.0
+                                                                         constant:-SideLabelMargin]];
+
                 } else {
                     // Middle labels
                     [constraints addObject:[NSLayoutConstraint constraintWithItem:_textChoiceLabels[i - 1]


### PR DESCRIPTION
This allows longer text labels by setting constraints to allow the slider to move as far left as 25% the width of the view, and allows the text labels to expand to the edge of the view (less a `SideLabelMargin` margin width).

Before:
![before](https://cloud.githubusercontent.com/assets/42683/13799340/b5340a86-eaf4-11e5-86a6-1cb1f0d4bbf7.png)

After:
![after](https://cloud.githubusercontent.com/assets/42683/13799342/b91ca6e4-eaf4-11e5-8477-520ea0e065e9.png)
