### PR TITLE
[ORKStepResult] Add 'enabledAssistiveTechnology' property

### DIFF
--- a/ResearchKit/Common/ORKResult.h
+++ b/ResearchKit/Common/ORKResult.h
@@ -373,7 +373,6 @@ ORK_CLASS_AVAILABLE
 @interface ORKToneAudiometrySample : NSObject <NSCopying, NSSecureCoding>
 
 /**
- 
  The frequency value in hertz for the tone associated with the sample.
  */
 @property (nonatomic, assign) double frequency;
@@ -1246,6 +1245,23 @@ ORK_CLASS_AVAILABLE
  @return An initialized step result.
  */
 - (instancetype)initWithStepIdentifier:(NSString *)stepIdentifier results:(nullable NSArray<ORKResult *> *)results;
+
+/**
+ This property indicates whether the Voice Over or Switch Control assistive technologies were active
+ while performing the corresponding step.
+ 
+ This information can be used, for example, to take into consideration the extra time needed by
+ handicapped participants to complete some tasks, such as the Tower of Hanoi activity.
+ 
+ The property can have the following values:
+ - `UIAccessibilityNotificationVoiceOverIdentifier` if Voice Over was active
+ - `UIAccessibilityNotificationSwitchControlIdentifier` if Switch Control was active
+ 
+ Note that the Voice Over and Switch Control assistive technologies are mutually exclusive.
+ 
+ If the property is `nil`, none of these assistive technologies was used.
+ */
+@property (nonatomic, copy, readonly, nullable) NSString *enabledAssistiveTechnology;
 
 @end
 

--- a/ResearchKit/Common/ORKResult.m
+++ b/ResearchKit/Common/ORKResult.m
@@ -2056,16 +2056,15 @@ static NSString * const RegionIdentifierKey = @"region.identifier";
     self = [super initWithIdentifier:stepIdentifier];
     if (self) {
         [self setResultsCopyObjects:results];
-        [self checkEnabledAssistiveTechnology];
+        [self updateEnabledAssistiveTechnology];
     }
     return self;
 }
 
-- (void)checkEnabledAssistiveTechnology {
+- (void)updateEnabledAssistiveTechnology {
     if (UIAccessibilityIsVoiceOverRunning()) {
         _enabledAssistiveTechnology = [UIAccessibilityNotificationVoiceOverIdentifier copy];
-    }
-    else if (UIAccessibilityIsSwitchControlRunning()) {
+    } else if (UIAccessibilityIsSwitchControlRunning()) {
         _enabledAssistiveTechnology = [UIAccessibilityNotificationSwitchControlIdentifier copy];
     }
 }

--- a/ResearchKit/Common/ORKResult.m
+++ b/ResearchKit/Common/ORKResult.m
@@ -675,7 +675,7 @@ const NSUInteger NumberOfPaddingSpacesForIndentationLevel = 4;
 @implementation ORKFileResult
 
 - (BOOL)isSaveable {
-    return (_fileURL!=nil);
+    return (_fileURL != nil);
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
@@ -1759,9 +1759,7 @@ const NSUInteger NumberOfPaddingSpacesForIndentationLevel = 4;
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
     [super encodeWithCoder:aCoder];
-
     ORK_ENCODE_OBJ(aCoder, results);
-    
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
@@ -1839,7 +1837,7 @@ const NSUInteger NumberOfPaddingSpacesForIndentationLevel = 4;
     NSMutableString *description = [NSMutableString stringWithFormat:@"%@; results: (", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces]];
     
     NSUInteger numberOfResults = self.results.count;
-    [self.results enumerateObjectsUsingBlock:^(ORKResult *result, NSUInteger idx, BOOL * _Nonnull stop) {
+    [self.results enumerateObjectsUsingBlock:^(ORKResult *result, NSUInteger idx, BOOL *stop) {
         if (idx == 0) {
             [description appendString:@"\n"];
         }
@@ -2058,8 +2056,57 @@ static NSString * const RegionIdentifierKey = @"region.identifier";
     self = [super initWithIdentifier:stepIdentifier];
     if (self) {
         [self setResultsCopyObjects:results];
+        [self checkEnabledAssistiveTechnology];
     }
     return self;
+}
+
+- (void)checkEnabledAssistiveTechnology {
+    if (UIAccessibilityIsVoiceOverRunning()) {
+        _enabledAssistiveTechnology = [UIAccessibilityNotificationVoiceOverIdentifier copy];
+    }
+    else if (UIAccessibilityIsSwitchControlRunning()) {
+        _enabledAssistiveTechnology = [UIAccessibilityNotificationSwitchControlIdentifier copy];
+    }
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [super encodeWithCoder:aCoder];
+    ORK_ENCODE_OBJ(aCoder, enabledAssistiveTechnology);
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        ORK_DECODE_OBJ_CLASS(aDecoder, enabledAssistiveTechnology, NSString);
+    }
+    return self;
+}
+
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
+- (BOOL)isEqual:(id)object {
+    BOOL isParentSame = [super isEqual:object];
+    
+    __typeof(self) castObject = object;
+    return (isParentSame &&
+            ORKEqualObjects(self.enabledAssistiveTechnology, castObject.enabledAssistiveTechnology));
+}
+
+- (NSUInteger)hash {
+    return super.hash ^ _enabledAssistiveTechnology.hash;
+}
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+    ORKStepResult *result = [super copyWithZone:zone];
+    result->_enabledAssistiveTechnology = [_enabledAssistiveTechnology copy];
+    return result;
+}
+
+- (NSString *)descriptionPrefixWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
+    return [NSString stringWithFormat:@"%@; enabledAssistiveTechnology: %@", [super descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces], _enabledAssistiveTechnology ? : @"None"];
 }
 
 @end

--- a/Testing/ORKTest/ORKTest/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTest/ORKESerialization.m
@@ -1230,6 +1230,7 @@ ret =
    ENTRY(ORKStepResult,
          nil,
          (@{
+            PROPERTY(enabledAssistiveTechnology, NSString, NSObject, YES, nil, nil),
             })),
    
    } mutableCopy];


### PR DESCRIPTION
This PR deals with [Issue #369](https://github.com/ResearchKit/ResearchKit/issues/369).

It adds the `enabledAssistiveTechnology` property to `ORKStepResult`. The property can have the following values:
 - `UIAccessibilityNotificationVoiceOverIdentifier` if *Voice Over* was active
 - `UIAccessibilityNotificationSwitchControlIdentifier` if *Switch Control* was active

Also made sure `ORKTest` *serialization unit tests* continue to pass.