### PR TITLE
[Framework] Expose ORKCountdownStep and ORKCompletionStep publicly

### DIFF
--- a/ResearchKit/ActiveTasks/ORKCountdownStep.h
+++ b/ResearchKit/ActiveTasks/ORKCountdownStep.h
@@ -29,7 +29,6 @@
  */
 
 
-#import <ResearchKit/ResearchKit.h>
 #import <ResearchKit/ORKActiveStep.h>
 
 

--- a/ResearchKit/Common/ORKCompletionStep.h
+++ b/ResearchKit/Common/ORKCompletionStep.h
@@ -29,16 +29,13 @@
  */
 
 
-#import <ResearchKit/ResearchKit.h>
+#import <ResearchKit/ORKInstructionStep.h>
 
 
 /**
  The `ORKCompletionStep` class is a subclass of `ORKInstructionStep` which behaves like
  an instruction step, but includes animated imagery that thanks the user
  for participating in the task.
- 
- This class is presently private as its interface is still considered
- subject to change while support for active tasks matures.
  */
 ORK_CLASS_AVAILABLE
 @interface ORKCompletionStep : ORKInstructionStep

--- a/ResearchKit/Common/ORKInstructionStep.h
+++ b/ResearchKit/Common/ORKInstructionStep.h
@@ -29,7 +29,8 @@
  */
 
 
-#import <ResearchKit/ResearchKit.h>
+#import <UIKit/UIKit.h>
+#import <ResearchKit/ORKStep.h>
 
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ResearchKit/ResearchKit.h
+++ b/ResearchKit/ResearchKit.h
@@ -37,6 +37,7 @@
 #import <ResearchKit/ORKStep.h>
 #import <ResearchKit/ORKQuestionStep.h>
 #import <ResearchKit/ORKInstructionStep.h>
+#import <ResearchKit/ORKCompletionStep.h>
 #import <ResearchKit/ORKFormStep.h>
 #import <ResearchKit/ORKStepNavigationRule.h>
 #import <ResearchKit/ORKImageCaptureStep.h>
@@ -73,6 +74,7 @@
 
 #import <ResearchKit/ORKRecorder.h>
 #import <ResearchKit/ORKActiveStep.h>
+#import <ResearchKit/ORKCountdownStep.h>
 #import <ResearchKit/ORKActiveStepViewController.h>
 
 #import <ResearchKit/ORKRangedPoint.h>

--- a/ResearchKit/ResearchKit_Private.h
+++ b/ResearchKit/ResearchKit_Private.h
@@ -58,14 +58,12 @@
 #import <ResearchKit/ORKToneAudiometryPracticeStep.h>
 #import <ResearchKit/ORKSpatialSpanMemoryStep.h>
 #import <ResearchKit/ORKWalkingTaskStep.h>
-#import <ResearchKit/ORKCountdownStep.h>
 #import <ResearchKit/ORKFitnessStep.h>
 #import <ResearchKit/ORKTappingIntervalStep.h>
 #import <ResearchKit/ORKTimedWalkStep.h>
 #import <ResearchKit/ORKPSATStep.h>
 #import <ResearchKit/ORKHolePegTestPlaceStep.h>
 #import <ResearchKit/ORKHolePegTestRemoveStep.h>
-#import <ResearchKit/ORKCompletionStep.h>
 #import <ResearchKit/ORKReactionTimeStep.h>
 #import <ResearchKit/ORKTowerOfHanoiStep.h>
 


### PR DESCRIPTION
This PR deals with [Issue #560](https://github.com/ResearchKit/ResearchKit/issues/560) by exposing the `ORKCountdownStep` and `ORKCompletionStep` classes on the public framework header.