### PR TITLE
Adding tap duration to Tapping Task Issue #561

### DIFF
--- a/ResearchKit/ActiveTasks/ORKTappingIntervalStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKTappingIntervalStepViewController.m
@@ -244,7 +244,7 @@
 }
 
 - (IBAction)buttonReleased:(id)button forEvent:(UIEvent *)event {
-    NSInteger index = (button == _tappingContentView.tapButton1) ? ORKTappingButtonIdentifierLeft : ORKTappingButtonIdentifierRight;
+    ORKTappingButtonIdentifier index = (button == _tappingContentView.tapButton1) ? ORKTappingButtonIdentifierLeft : ORKTappingButtonIdentifierRight;
     
     [self releaseTouch:[[event touchesForView:button] anyObject] onButton:index];
 }

--- a/ResearchKit/ActiveTasks/ORKTappingIntervalStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKTappingIntervalStepViewController.m
@@ -97,6 +97,8 @@
     
     [_tappingContentView.tapButton1 addTarget:self action:@selector(buttonPressed:forEvent:) forControlEvents:UIControlEventTouchDown];
     [_tappingContentView.tapButton2 addTarget:self action:@selector(buttonPressed:forEvent:) forControlEvents:UIControlEventTouchDown];
+    [_tappingContentView.tapButton1 addTarget:self action:@selector(buttonReleased:forEvent:) forControlEvents:(UIControlEventTouchUpInside | UIControlEventTouchUpOutside)];
+    [_tappingContentView.tapButton2 addTarget:self action:@selector(buttonReleased:forEvent:) forControlEvents:(UIControlEventTouchUpInside | UIControlEventTouchUpOutside)];
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -142,7 +144,6 @@
         _tappingStart = mediaTime;
     }
     
-    
     CGPoint location = [touch locationInView:self.view];
     
     // Add new sample
@@ -151,6 +152,7 @@
     ORKTappingSample *sample = [[ORKTappingSample alloc] init];
     sample.buttonIdentifier = buttonIdentifier;
     sample.location = location;
+    sample.duration = 0;
     sample.timestamp = mediaTime;
 
     [self.samples addObject:sample];
@@ -162,8 +164,52 @@
     [_tappingContentView setTapCount:_hitButtonCount];
 }
 
+- (void)releaseTouch:(UITouch *)touch onButton:(ORKTappingButtonIdentifier)buttonIdentifier {
+    if (self.samples == nil) {
+        return;
+    }
+    NSTimeInterval mediaTime = touch.timestamp;
+    
+    // Take last sample for buttonIdentifier, and fill duration
+    ORKTappingSample *sample = [self lastSampleWithEmptyDurationForButton:buttonIdentifier];
+    sample.duration = mediaTime - sample.timestamp - _tappingStart;
+}
+
+- (ORKTappingSample *)lastSampleWithEmptyDurationForButton:(ORKTappingButtonIdentifier)buttonIdentifier{
+    NSEnumerator *enumerator = [self.samples reverseObjectEnumerator];
+    for (ORKTappingSample *sample in enumerator) {
+        if (sample.buttonIdentifier == buttonIdentifier && sample.duration == 0) {
+            return sample;
+        }
+    }
+    return nil;
+}
+
+- (void)fillSampleDurationIfAnyButtonPressed {
+    /*
+     * Because we will not able to get UITouch from UIButton, we will use systemUptime.
+     * Documentation for -[UITouch timestamp] tells:
+     * The value of this property is the time, in seconds, since system startup the touch either originated or was last changed.
+     * For a definition of the time-since-boot value, see the description of the systemUptime method of the NSProcessInfo class.
+     */
+    NSTimeInterval mediaTime = [[NSProcessInfo processInfo] systemUptime];
+    
+    ORKTappingSample *tapButton1LastSample = [self lastSampleWithEmptyDurationForButton:ORKTappingButtonIdentifierLeft];
+    if (tapButton1LastSample) {
+        tapButton1LastSample.duration = mediaTime - tapButton1LastSample.timestamp - _tappingStart;
+    }
+    
+    ORKTappingSample *tapButton2LastSample = [self lastSampleWithEmptyDurationForButton:ORKTappingButtonIdentifierRight];
+    if (tapButton2LastSample) {
+        tapButton2LastSample.duration = mediaTime - tapButton2LastSample.timestamp - _tappingStart;
+    }
+}
+
 - (void)stepDidFinish {
     [super stepDidFinish];
+    
+    // If user didn't release touch from button, fill manually duration for last sample
+    [self fillSampleDurationIfAnyButtonPressed];
     
     _expired = YES;
     [_tappingContentView finishStep:self];
@@ -195,6 +241,12 @@
     NSInteger index = (button == _tappingContentView.tapButton1) ? ORKTappingButtonIdentifierLeft : ORKTappingButtonIdentifierRight;
     
     [self receiveTouch:[[event touchesForView:button] anyObject] onButton:index];
+}
+
+- (IBAction)buttonReleased:(id)button forEvent:(UIEvent *)event {
+    NSInteger index = (button == _tappingContentView.tapButton1) ? ORKTappingButtonIdentifierLeft : ORKTappingButtonIdentifierRight;
+    
+    [self releaseTouch:[[event touchesForView:button] anyObject] onButton:index];
 }
 
 #pragma mark UIGestureRecognizerDelegate

--- a/ResearchKit/Common/ORKResult.h
+++ b/ResearchKit/Common/ORKResult.h
@@ -180,6 +180,13 @@ ORK_CLASS_AVAILABLE
  */
 @property (nonatomic, assign) NSTimeInterval timestamp;
 
+/**
+ A duration of the tap event.
+ 
+ The duration store time interval between touch down and touch release events.
+ */
+@property (nonatomic, assign) NSTimeInterval duration;
+
 /** 
  An enumerated value that indicates which button was tapped, if any.
  

--- a/ResearchKit/Common/ORKResult.m
+++ b/ResearchKit/Common/ORKResult.m
@@ -157,6 +157,7 @@ const NSUInteger NumberOfPaddingSpacesForIndentationLevel = 4;
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
     ORK_ENCODE_DOUBLE(aCoder, timestamp);
+    ORK_ENCODE_DOUBLE(aCoder, duration);
     ORK_ENCODE_CGPOINT(aCoder, location);
     ORK_ENCODE_ENUM(aCoder, buttonIdentifier);
 
@@ -165,6 +166,7 @@ const NSUInteger NumberOfPaddingSpacesForIndentationLevel = 4;
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super init];
     if (self) {
+        ORK_DECODE_DOUBLE(aDecoder, duration);
         ORK_DECODE_DOUBLE(aDecoder, timestamp);
         ORK_DECODE_CGPOINT(aDecoder, location);
         ORK_DECODE_ENUM(aDecoder, buttonIdentifier);
@@ -180,6 +182,7 @@ const NSUInteger NumberOfPaddingSpacesForIndentationLevel = 4;
     __typeof(self) castObject = object;
     
     return ((self.timestamp == castObject.timestamp) &&
+            (self.duration == castObject.duration) &&
             CGPointEqualToPoint(self.location, castObject.location) &&
             (self.buttonIdentifier == castObject.buttonIdentifier));
 }
@@ -187,13 +190,14 @@ const NSUInteger NumberOfPaddingSpacesForIndentationLevel = 4;
 - (instancetype)copyWithZone:(NSZone *)zone {
     ORKTappingSample *sample = [[[self class] allocWithZone:zone] init];
     sample.timestamp = self.timestamp;
+    sample.duration = self.duration;
     sample.location = self.location;
     sample.buttonIdentifier = self.buttonIdentifier;
     return sample;
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"<%@: %p; button: %@; timestamp: %.03f; location: %@>", self.class.description, self, @(self.buttonIdentifier), self.timestamp, NSStringFromCGPoint(self.location)];
+    return [NSString stringWithFormat:@"<%@: %p; button: %@; timestamp: %.03f; timestamp: %.03f; location: %@>", self.class.description, self, @(self.buttonIdentifier), self.timestamp, self.duration, NSStringFromCGPoint(self.location)];
 }
 
 @end

--- a/Testing/ORKTest/ORKTest/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTest/ORKESerialization.m
@@ -953,6 +953,7 @@ ret =
         nil,
         (@{
            PROPERTY(timestamp, NSNumber, NSObject, NO, nil, nil),
+           PROPERTY(duration, NSNumber, NSObject, NO, nil, nil),
            PROPERTY(buttonIdentifier, NSNumber, NSObject, NO,
                     ^id(id numeric) { return tableMapForward(((NSNumber *)numeric).integerValue, buttonIdentifierTable()); },
                     ^id(id string) { return @(tableMapReverse(string, buttonIdentifierTable())); }),


### PR DESCRIPTION
This PR adds a duration to ORKTappingSample.

When user press the button and don't release finger before times up, then i measure `duration` when step is finished for last sample.