### PR TITLE
allow plot fill color of ORKLineGraphChartView to be set by the delegate

### DIFF
--- a/ResearchKit/Charts/ORKDiscreteGraphChartView.m
+++ b/ResearchKit/Charts/ORKDiscreteGraphChartView.m
@@ -48,8 +48,7 @@
 
 - (void)setDrawsConnectedRanges:(BOOL)drawsConnectedRanges {
     _drawsConnectedRanges = drawsConnectedRanges;
-    [super updateLineLayers];
-    [super updatePointLayers];
+    [super updateLineAndPointLayers];
     [super layoutLineLayers];
     [super layoutPointLayers];
 }

--- a/ResearchKit/Charts/ORKGraphChartView.h
+++ b/ResearchKit/Charts/ORKGraphChartView.h
@@ -148,7 +148,8 @@ ORK_AVAILABLE_DECL
 /**
  Asks the data source for the fill color of the specified plot.
  
- If this method is not implemented, the plot applies 60% transparency to the graph chart view `colorForPlotIndex`.
+ The fill color is only used by `ORKLineGraphChartView`. If this method is not implemented, the
+ chart uses the main color of the specified plot with a 0.4 opacity value.
  
  @param graphChartView      The graph chart view asking for the color of the segment.
  @param plotIndex           An index number identifying the plot in the graph chart view. This index

--- a/ResearchKit/Charts/ORKGraphChartView.h
+++ b/ResearchKit/Charts/ORKGraphChartView.h
@@ -146,6 +146,19 @@ ORK_AVAILABLE_DECL
 - (UIColor *)graphChartView:(ORKGraphChartView *)graphChartView colorForPlotIndex:(NSInteger)plotIndex;
 
 /**
+ Asks the data source for the fill color of the specified plot.
+ 
+ If this method is not implemented, the plot applies 60% transparency to the graph chart view `colorForPlotIndex`.
+ 
+ @param graphChartView      The graph chart view asking for the color of the segment.
+ @param plotIndex           An index number identifying the plot in the graph chart view. This index
+ is always 0 in single-plot graph chart views.
+ 
+ @return The color of the fill layer at the specified index in a line chart view.
+ */
+- (UIColor *)graphChartView:(ORKGraphChartView *)graphChartView fillColorForPlotIndex:(NSInteger)plotIndex;
+
+/**
  Asks the data source which plot the scrubber should snap to in multigraph chart views.
  
  If this method is not implemented, the scrubber snaps over the first plot.

--- a/ResearchKit/Charts/ORKGraphChartView.m
+++ b/ResearchKit/Charts/ORKGraphChartView.m
@@ -100,8 +100,7 @@ static const CGFloat ScrubberLabelVerticalPadding = 4.0;
     [self calculateMinAndMaxValues];
     [_xAxisView updateTitles];
     [_yAxisView updateTicksAndLabels];
-    [self updateLineLayers];
-    [self updatePointLayers];
+    [self updateLineAndPointLayers];
     [self updateNoDataLabel];
     
     [self setNeedsLayout];
@@ -237,16 +236,6 @@ static const CGFloat ScrubberLabelVerticalPadding = 4.0;
         color = [_dataSource graphChartView:self colorForPlotIndex:plotIndex];
     } else {
         color = (plotIndex == 0) ? self.tintColor : _referenceLineColor;
-    }
-    return color;
-}
-
-- (UIColor *)fillColorForPlotIndex:(NSInteger)plotIndex {
-    UIColor *color = nil;
-    if ([_dataSource respondsToSelector:@selector(graphChartView:fillColorForPlotIndex:)]) {
-        color = [_dataSource graphChartView:self fillColorForPlotIndex:plotIndex];
-    } else {
-        color = [[self colorForplotIndex:plotIndex] colorWithAlphaComponent:0.4];
     }
     return color;
 }
@@ -522,21 +511,32 @@ inline static CALayer *graphPointLayerWithColor(UIColor *color) {
     return pointLayer;
 }
 
-- (void)updatePointLayers {
-    for (NSInteger plotIndex = 0; plotIndex < _pointLayers.count; plotIndex++) {
+- (void)updateLineAndPointLayers {
+    for (NSInteger plotIndex = 0; plotIndex < _lineLayers.count; plotIndex++) {
+        [_lineLayers[plotIndex] makeObjectsPerformSelector:@selector(removeFromSuperlayer)];
         [_pointLayers[plotIndex] makeObjectsPerformSelector:@selector(removeFromSuperlayer)];
     }
+    [_lineLayers removeAllObjects];
     [_pointLayers removeAllObjects];
-    
+
     NSInteger numberOfPlots = [self numberOfPlots];
     for (NSInteger plotIndex = 0; plotIndex < numberOfPlots; plotIndex++) {
+        // Line layers
+        // Add array even if it should not draw lines so all layer arays have the same number of elements for animating purposes
+        NSMutableArray<CAShapeLayer *> *currentPlotLineLayers = [NSMutableArray new];
+        [_lineLayers addObject:currentPlotLineLayers];
+        if ([self shouldDrawLinesForPlotIndex:plotIndex]) {
+            [self updateLineLayersForPlotIndex:plotIndex];
+        }
+        
+        // Point layers
         NSMutableArray<CALayer *> *currentPlotPointLayers = [NSMutableArray new];
         [_pointLayers addObject:currentPlotPointLayers];
         [self updatePointLayersForPlotIndex:plotIndex];
     }
     
-    // We perform the same double-looping when creating the elements and there is no need to do that if Voice Over is not running.
-    if (!UIAccessibilityIsVoiceOverRunning()) {
+    // Calculate accessibility elements only if Voice Over is running
+    if (UIAccessibilityIsVoiceOverRunning()) {
         [self _axCreateAccessibilityElements];
     }
 }
@@ -594,23 +594,6 @@ inline static CALayer *graphPointLayerWithColor(UIColor *color) {
                     pointLayerIndex++;
                 }
             }
-        }
-    }
-}
-
-- (void)updateLineLayers {
-    for (NSInteger plotIndex = 0; plotIndex < _lineLayers.count; plotIndex++) {
-        [_lineLayers[plotIndex] makeObjectsPerformSelector:@selector(removeFromSuperlayer)];
-    }
-    [_lineLayers removeAllObjects];
-    
-    NSInteger numberOfPlots = [self numberOfPlots];
-    for (NSInteger plotIndex = 0; plotIndex < numberOfPlots; plotIndex++) {
-        // Add array even if it should not draw lines so all layer arays have the same number of elements for animating purposes
-        NSMutableArray<CAShapeLayer *> *currentPlotLineLayers = [NSMutableArray new];
-        [self.lineLayers addObject:currentPlotLineLayers];
-        if ([self shouldDrawLinesForPlotIndex:plotIndex]) {
-            [self updateLineLayersForPlotIndex:plotIndex];
         }
     }
 }

--- a/ResearchKit/Charts/ORKGraphChartView.m
+++ b/ResearchKit/Charts/ORKGraphChartView.m
@@ -241,6 +241,16 @@ static const CGFloat ScrubberLabelVerticalPadding = 4.0;
     return color;
 }
 
+- (UIColor *)fillColorForPlotIndex:(NSInteger)plotIndex {
+    UIColor *color = nil;
+    if ([_dataSource respondsToSelector:@selector(graphChartView:fillColorForPlotIndex:)]) {
+        color = [_dataSource graphChartView:self fillColorForPlotIndex:plotIndex];
+    } else {
+        color = [[self colorForplotIndex:plotIndex] colorWithAlphaComponent:0.4];
+    }
+    return color;
+}
+
 - (void)updatePlotColors {
     for (NSUInteger plotIndex = 0; plotIndex < _lineLayers.count; plotIndex++) {
         UIColor *color = [self colorForplotIndex:plotIndex];

--- a/ResearchKit/Charts/ORKGraphChartView_Internal.h
+++ b/ResearchKit/Charts/ORKGraphChartView_Internal.h
@@ -110,6 +110,7 @@ static inline CGFloat xAxisPoint(NSInteger pointIndex, NSInteger numberOfXAxisPo
 - (void)layoutPointLayers;
 
 - (UIColor *)colorForplotIndex:(NSInteger)plotIndex;
+- (UIColor *)fillColorForPlotIndex:(NSInteger)plotIndex;
 
 - (void)animateLayersSequentiallyWithDuration:(NSTimeInterval)duration;
 

--- a/ResearchKit/Charts/ORKGraphChartView_Internal.h
+++ b/ResearchKit/Charts/ORKGraphChartView_Internal.h
@@ -110,6 +110,7 @@ static inline CGFloat xAxisPoint(NSInteger pointIndex, NSInteger numberOfXAxisPo
 - (void)layoutPointLayers;
 
 - (UIColor *)colorForplotIndex:(NSInteger)plotIndex;
+
 - (UIColor *)fillColorForPlotIndex:(NSInteger)plotIndex;
 
 - (void)animateLayersSequentiallyWithDuration:(NSTimeInterval)duration;

--- a/ResearchKit/Charts/ORKGraphChartView_Internal.h
+++ b/ResearchKit/Charts/ORKGraphChartView_Internal.h
@@ -101,17 +101,13 @@ static inline CGFloat xAxisPoint(NSInteger pointIndex, NSInteger numberOfXAxisPo
 
 - (void)updatePlotColors;
 
-- (void)updateLineLayers;
+- (void)updateLineAndPointLayers;
 
 - (void)layoutLineLayers;
-
-- (void)updatePointLayers;
 
 - (void)layoutPointLayers;
 
 - (UIColor *)colorForplotIndex:(NSInteger)plotIndex;
-
-- (UIColor *)fillColorForPlotIndex:(NSInteger)plotIndex;
 
 - (void)animateLayersSequentiallyWithDuration:(NSTimeInterval)duration;
 

--- a/ResearchKit/Charts/ORKLineGraphChartView.m
+++ b/ResearchKit/Charts/ORKLineGraphChartView.m
@@ -102,7 +102,7 @@ const CGFloat FillColorAlpha = 0.4;
     }
     
     CAShapeLayer *fillLayer = [CAShapeLayer layer];
-    fillLayer.fillColor = [[self colorForplotIndex:plotIndex] colorWithAlphaComponent:0.4].CGColor;
+    fillLayer.fillColor = [self fillColorForPlotIndex:plotIndex].CGColor;
     
     [self.plotView.layer addSublayer:fillLayer];
     _fillLayers[@(plotIndex)] = fillLayer;

--- a/Testing/ORKTest/ORKTest/Charts/ChartDataSources.swift
+++ b/Testing/ORKTest/ORKTest/Charts/ChartDataSources.swift
@@ -166,6 +166,21 @@ class ColoredLineGraphChartDataSource: LineGraphChartDataSource {
         }
         return color
     }
+    
+    func graphChartView(graphChartView: ORKGraphChartView, fillColorForPlotIndex plotIndex: Int) -> UIColor {
+        let color: UIColor
+        switch plotIndex {
+        case 0:
+            color = UIColor.blueColor().colorWithAlphaComponent(0.6)
+        case 1:
+            color = UIColor.redColor().colorWithAlphaComponent(0.6)
+        case 2:
+            color = UIColor.greenColor().colorWithAlphaComponent(0.6)
+        default:
+            color = UIColor.cyanColor().colorWithAlphaComponent(0.6)
+        }
+        return color
+    }
 }
 
 class DiscreteGraphChartDataSource: BaseGraphChartDataSource {


### PR DESCRIPTION
Currently, all plots have a fill color of 60% of their plot color. `ORKGraphChartView:fillColorForPlotIndex:` could be used to allow a plot to not be filled.