### PR TITLE
Fix declaration of constants in ORKHelpers

### DIFF
--- a/ResearchKit/Common/ORKHelpers.h
+++ b/ResearchKit/Common/ORKHelpers.h
@@ -269,7 +269,7 @@ id ORKDynamicCast_(id x, Class objClass);
 
 #define ORKDynamicCast(x, c) ((c *) ORKDynamicCast_(x, [c class]))
 
-const CGFloat ORKScrollToTopAnimationDuration;
+extern const CGFloat ORKScrollToTopAnimationDuration;
 
 ORK_INLINE CGFloat
 ORKCGFloatNearlyEqualToFloat(CGFloat f1, CGFloat f2) {
@@ -285,7 +285,7 @@ void ORKValidateArrayForObjectsOfClass(NSArray *array, Class expectedObjectClass
 
 void ORKRemoveConstraintsForRemovedViews(NSMutableArray *constraints, NSArray *removedViews);
 
-const CGFloat ORKCGFloatInvalidValue;
+extern const CGFloat ORKCGFloatInvalidValue;
 
 void ORKAdjustPageViewControllerNavigationDirectionForRTL(UIPageViewControllerNavigationDirection *direction);
 


### PR DESCRIPTION
The following constants were missing `extern` declarations in `ORKHelpers.h`:

* `ORKScrollToTopAnimationDuration`
* `ORKCGFloatInvalidValue`

Aside from being semantically incorrect, this also caused an issue with using ResearchKit as a dependency in a CocoaPod; see #679.

Also see this issue in the CocoaPods repo: https://github.com/CocoaPods/CocoaPods/issues/5304. Thanks to @neonichu for helping pin this one down quickly.