### PR TITLE
Add attributedText property to ORKQuestionStep

### DIFF
--- a/ResearchKit/Common/ORKQuestionStep.h
+++ b/ResearchKit/Common/ORKQuestionStep.h
@@ -81,6 +81,21 @@ ORK_CLASS_AVAILABLE
                                       text:(nullable NSString *)text
                                     answer:(nullable ORKAnswerFormat *)answerFormat;
 
+
+
+/**
+ Returns a new question step that includes the specified identifier, title, text, and answer format.
+ 
+ @param identifier    The identifier of the step (a step identifier should be unique within the task).
+ @param title         A localized string that represents the primary text of the question.
+ @param text          A attribute string that represents the additional text of the question.
+ @param answerFormat  The format in which the answer is expected.
+ */
++ (instancetype)questionStepWithIdentifier:(NSString *)identifier
+                                     title:(nullable NSString *)title
+                            attributedText:(nullable NSAttributedString *)text
+                                    answer:(nullable ORKAnswerFormat *)answerFormat;
+
 /**
  The format of the answer.
  
@@ -104,6 +119,17 @@ ORK_CLASS_AVAILABLE
  text field or text area when an answer has not yet been entered.
   */
 @property (nonatomic, copy, nullable) NSString *placeholder;
+
+
+
+ /**
+ Additional text to display for the step in attibuted String. So that the additional text can be displayed with formtted way. For example, highlight the key word of the question
+ 
+ The additional text is displayed in a smaller font below `title`. If you need to display a
+ long question, it can work well to keep the title short and put the additional content in
+ the `text` property.
+ */
+@property (nonatomic, copy, nullable) NSAttributedString *attributedText;
 
 @end
 

--- a/ResearchKit/Common/ORKQuestionStep.m
+++ b/ResearchKit/Common/ORKQuestionStep.m
@@ -66,6 +66,17 @@
     return step;
 }
 
++ (instancetype)questionStepWithIdentifier:(NSString *)identifier
+                                     title:(nullable NSString *)title
+                            attributedText:(nullable NSAttributedString *)text
+                                    answer:(nullable ORKAnswerFormat *)answerFormat {
+    ORKQuestionStep *step = [[ORKQuestionStep alloc] initWithIdentifier:identifier];
+    step.title = title;
+    step.attributedText = text;
+    step.answerFormat = answerFormat;
+    return step;
+}
+
 - (instancetype)initWithIdentifier:(NSString *)identifier {
     
     self = [super initWithIdentifier:identifier];

--- a/ResearchKit/Common/ORKQuestionStepViewController.m
+++ b/ResearchKit/Common/ORKQuestionStepViewController.m
@@ -169,6 +169,7 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
             _headerView.captionLabel.useSurveyMode = self.step.useSurveyMode;
             _headerView.captionLabel.text = self.questionStep.title;
             _headerView.instructionLabel.text = self.questionStep.text;
+            _headerView.instructionLabel.attributedText = self.questionStep.attributedText;
             _headerView.learnMoreButtonItem = self.learnMoreButtonItem;
             
             _continueSkipView = _tableContainer.continueSkipContainerView;


### PR DESCRIPTION
Based on a very high frequency requirement that the text in the `ORKStepViewController` could Support more formated content, even HTML, in order to highlight some words to user. I open the attributedText property of the `instructionLabel` in the `headerView`. 
Hope we can do more discussion so that figure out better way to support attributedText not only in the Text in the StepViewController, even the choices in the TextChoice.