### PR TITLE
New VAS (Visual Analogue Scale) answer format

### DIFF
--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -77,6 +77,8 @@
 		2441034F1B966D4C00EEAB0C /* ORKPasscodeViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 2441034D1B966D4C00EEAB0C /* ORKPasscodeViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		244103501B966D4C00EEAB0C /* ORKPasscodeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2441034E1B966D4C00EEAB0C /* ORKPasscodeViewController.m */; };
 		244EFAD21BCEFD83001850D9 /* ORKAnswerFormat_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 244EFAD11BCEFD83001850D9 /* ORKAnswerFormat_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		24651A991C99B9E400B52AAA /* ORKSurveyAnswerCellForVAS.h in Headers */ = {isa = PBXBuildFile; fileRef = 24651A971C99B9E400B52AAA /* ORKSurveyAnswerCellForVAS.h */; settings = {ASSET_TAGS = (); }; };
+		24651A9A1C99B9E400B52AAA /* ORKSurveyAnswerCellForVAS.m in Sources */ = {isa = PBXBuildFile; fileRef = 24651A981C99B9E400B52AAA /* ORKSurveyAnswerCellForVAS.m */; settings = {ASSET_TAGS = (); }; };
 		24850E191BCDA9C7006E91FB /* ORKLoginStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 24850E171BCDA9C7006E91FB /* ORKLoginStepViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		24850E1A1BCDA9C7006E91FB /* ORKLoginStepViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 24850E181BCDA9C7006E91FB /* ORKLoginStepViewController.m */; };
 		248604061B4C98760010C8A0 /* ORKAnswerFormatTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 248604051B4C98760010C8A0 /* ORKAnswerFormatTests.m */; };
@@ -93,6 +95,10 @@
 		24BC5CEF1BC345D900846B43 /* ORKLoginStep.m in Sources */ = {isa = PBXBuildFile; fileRef = 24BC5CED1BC345D900846B43 /* ORKLoginStep.m */; };
 		24C296751BD052F800B42EF1 /* ORKVerificationStep_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 24C296741BD052F800B42EF1 /* ORKVerificationStep_Internal.h */; };
 		24C296771BD055B800B42EF1 /* ORKLoginStep_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 24C296761BD055B800B42EF1 /* ORKLoginStep_Internal.h */; };
+		24C337E11C99FBBF004A0C8F /* ORKVASSlider.h in Headers */ = {isa = PBXBuildFile; fileRef = 24C337DF1C99FBBF004A0C8F /* ORKVASSlider.h */; settings = {ASSET_TAGS = (); }; };
+		24C337E21C99FBBF004A0C8F /* ORKVASSlider.m in Sources */ = {isa = PBXBuildFile; fileRef = 24C337E01C99FBBF004A0C8F /* ORKVASSlider.m */; settings = {ASSET_TAGS = (); }; };
+		24CFE3A11C99BC3D008DAA57 /* ORKVASSliderView.h in Headers */ = {isa = PBXBuildFile; fileRef = 24CFE39F1C99BC3D008DAA57 /* ORKVASSliderView.h */; settings = {ASSET_TAGS = (); }; };
+		24CFE3A21C99BC3D008DAA57 /* ORKVASSliderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 24CFE3A01C99BC3D008DAA57 /* ORKVASSliderView.m */; settings = {ASSET_TAGS = (); }; };
 		250F94041B4C5A6600FA23EB /* ORKTowerOfHanoiStep.h in Headers */ = {isa = PBXBuildFile; fileRef = 250F94021B4C5A6600FA23EB /* ORKTowerOfHanoiStep.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		250F94051B4C5A6600FA23EB /* ORKTowerOfHanoiStep.m in Sources */ = {isa = PBXBuildFile; fileRef = 250F94031B4C5A6600FA23EB /* ORKTowerOfHanoiStep.m */; };
 		250F94081B4C5AA400FA23EB /* ORKTowerOfHanoiStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 250F94061B4C5AA400FA23EB /* ORKTowerOfHanoiStepViewController.h */; };
@@ -588,6 +594,8 @@
 		2441034D1B966D4C00EEAB0C /* ORKPasscodeViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKPasscodeViewController.h; sourceTree = "<group>"; };
 		2441034E1B966D4C00EEAB0C /* ORKPasscodeViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKPasscodeViewController.m; sourceTree = "<group>"; };
 		244EFAD11BCEFD83001850D9 /* ORKAnswerFormat_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKAnswerFormat_Private.h; sourceTree = "<group>"; };
+		24651A971C99B9E400B52AAA /* ORKSurveyAnswerCellForVAS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKSurveyAnswerCellForVAS.h; sourceTree = "<group>"; };
+		24651A981C99B9E400B52AAA /* ORKSurveyAnswerCellForVAS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKSurveyAnswerCellForVAS.m; sourceTree = "<group>"; };
 		24850E171BCDA9C7006E91FB /* ORKLoginStepViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ORKLoginStepViewController.h; path = Onboarding/ORKLoginStepViewController.h; sourceTree = "<group>"; };
 		24850E181BCDA9C7006E91FB /* ORKLoginStepViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ORKLoginStepViewController.m; path = Onboarding/ORKLoginStepViewController.m; sourceTree = "<group>"; };
 		248604051B4C98760010C8A0 /* ORKAnswerFormatTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKAnswerFormatTests.m; sourceTree = "<group>"; };
@@ -604,6 +612,10 @@
 		24BC5CED1BC345D900846B43 /* ORKLoginStep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ORKLoginStep.m; path = Onboarding/ORKLoginStep.m; sourceTree = "<group>"; };
 		24C296741BD052F800B42EF1 /* ORKVerificationStep_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ORKVerificationStep_Internal.h; path = Onboarding/ORKVerificationStep_Internal.h; sourceTree = "<group>"; };
 		24C296761BD055B800B42EF1 /* ORKLoginStep_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ORKLoginStep_Internal.h; path = Onboarding/ORKLoginStep_Internal.h; sourceTree = "<group>"; };
+		24C337DF1C99FBBF004A0C8F /* ORKVASSlider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKVASSlider.h; sourceTree = "<group>"; };
+		24C337E01C99FBBF004A0C8F /* ORKVASSlider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKVASSlider.m; sourceTree = "<group>"; };
+		24CFE39F1C99BC3D008DAA57 /* ORKVASSliderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKVASSliderView.h; sourceTree = "<group>"; };
+		24CFE3A01C99BC3D008DAA57 /* ORKVASSliderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKVASSliderView.m; sourceTree = "<group>"; };
 		250F94021B4C5A6600FA23EB /* ORKTowerOfHanoiStep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKTowerOfHanoiStep.h; sourceTree = "<group>"; };
 		250F94031B4C5A6600FA23EB /* ORKTowerOfHanoiStep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKTowerOfHanoiStep.m; sourceTree = "<group>"; };
 		250F94061B4C5AA400FA23EB /* ORKTowerOfHanoiStepViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKTowerOfHanoiStepViewController.h; sourceTree = "<group>"; };
@@ -1741,6 +1753,8 @@
 				865EA16B1ABA1BE20037C68E /* ORKSurveyAnswerCellForPicker.m */,
 				CBD34A581BB207FC00F204EA /* ORKSurveyAnswerCellForLocation.h */,
 				CBD34A591BB207FC00F204EA /* ORKSurveyAnswerCellForLocation.m */,
+				24651A971C99B9E400B52AAA /* ORKSurveyAnswerCellForVAS.h */,
+				24651A981C99B9E400B52AAA /* ORKSurveyAnswerCellForVAS.m */,
 			);
 			name = "Question Step Views";
 			sourceTree = "<group>";
@@ -1768,6 +1782,10 @@
 				865EA1611AB8DF750037C68E /* ORKDateTimePicker.m */,
 				865EA1661ABA1AA10037C68E /* ORKPicker.h */,
 				865EA1671ABA1AA10037C68E /* ORKPicker.m */,
+				24CFE39F1C99BC3D008DAA57 /* ORKVASSliderView.h */,
+				24CFE3A01C99BC3D008DAA57 /* ORKVASSliderView.m */,
+				24C337DF1C99FBBF004A0C8F /* ORKVASSlider.h */,
+				24C337E01C99FBBF004A0C8F /* ORKVASSlider.m */,
 			);
 			name = "Control Views";
 			sourceTree = "<group>";
@@ -2352,6 +2370,7 @@
 				861D2AEC1B8409B2008C4CD0 /* ORKTimedWalkStepViewController.h in Headers */,
 				86C40C7A1A8D7C5C00081FAC /* ORKAccelerometerRecorder.h in Headers */,
 				242C9E051BBDFDAC0088B7F4 /* ORKVerificationStep.h in Headers */,
+				24CFE3A11C99BC3D008DAA57 /* ORKVASSliderView.h in Headers */,
 				86C40D141A8D7C5C00081FAC /* ORKDefines_Private.h in Headers */,
 				86C40CA81A8D7C5C00081FAC /* ORKPedometerRecorder.h in Headers */,
 				86C40CD01A8D7C5C00081FAC /* ORKInstructionStepView.h in Headers */,
@@ -2495,10 +2514,12 @@
 				861D11B51AA7D073003C98A7 /* ORKTextChoiceCellGroup.h in Headers */,
 				24BC5CEE1BC345D900846B43 /* ORKLoginStep.h in Headers */,
 				147503B91AEE807C004B17F3 /* ORKToneAudiometryStep.h in Headers */,
+				24651A991C99B9E400B52AAA /* ORKSurveyAnswerCellForVAS.h in Headers */,
 				106FF2A21B665B86004EACF2 /* ORKHolePegTestPlaceStepViewController.h in Headers */,
 				24A4DA101B8D0F21009C797A /* ORKPasscodeStepView.h in Headers */,
 				86C40C9A1A8D7C5C00081FAC /* ORKDataLogger_Private.h in Headers */,
 				861D11AD1AA7951F003C98A7 /* ORKChoiceAnswerFormatHelper.h in Headers */,
+				24C337E11C99FBBF004A0C8F /* ORKVASSlider.h in Headers */,
 				86C40C461A8D7C5C00081FAC /* ORKSpatialSpanMemoryStepViewController.h in Headers */,
 				86C40C521A8D7C5C00081FAC /* ORKTappingIntervalStep.h in Headers */,
 				86C40D8A1A8D7C5C00081FAC /* ORKSkin.h in Headers */,
@@ -2804,6 +2825,7 @@
 				86C40D001A8D7C5C00081FAC /* ORKChoiceViewCell.m in Sources */,
 				86C40C4C1A8D7C5C00081FAC /* ORKSpatialSpanTargetView.m in Sources */,
 				86C40D9E1A8D7C5C00081FAC /* ORKSubheadlineLabel.m in Sources */,
+				24651A9A1C99B9E400B52AAA /* ORKSurveyAnswerCellForVAS.m in Sources */,
 				10864CA31B27146B000F4158 /* ORKPSATContentView.m in Sources */,
 				6146D0A41B84A91E0068491D /* ORKLineGraphAccessibilityElement.m in Sources */,
 				D42FEFB91AF7557000A124F8 /* ORKImageCaptureView.m in Sources */,
@@ -2864,6 +2886,7 @@
 				86C40DB01A8D7C5C00081FAC /* ORKSurveyAnswerCellForScale.m in Sources */,
 				86C40C281A8D7C5C00081FAC /* ORKCountdownStepViewController.m in Sources */,
 				86C40C641A8D7C5C00081FAC /* CLLocation+ORKJSONDictionary.m in Sources */,
+				24C337E21C99FBBF004A0C8F /* ORKVASSlider.m in Sources */,
 				86C40D041A8D7C5C00081FAC /* ORKContinueButton.m in Sources */,
 				24A4DA151B8D1115009C797A /* ORKPasscodeStep.m in Sources */,
 				86C40DEC1A8D7C5C00081FAC /* UIBarButtonItem+ORKBarButtonItem.m in Sources */,
@@ -2921,6 +2944,7 @@
 				86C40DF41A8D7C5C00081FAC /* ORKConsentReviewController.m in Sources */,
 				242C9E121BBE06DE0088B7F4 /* ORKVerificationStepView.m in Sources */,
 				147503BA1AEE807C004B17F3 /* ORKToneAudiometryStep.m in Sources */,
+				24CFE3A21C99BC3D008DAA57 /* ORKVASSliderView.m in Sources */,
 				FA7A9D301B083DD3005A2BEA /* ORKConsentSectionFormatter.m in Sources */,
 				86C40D2A1A8D7C5C00081FAC /* ORKFormTextView.m in Sources */,
 				242C9E0E1BBE03F90088B7F4 /* ORKVerificationStepViewController.m in Sources */,
@@ -3121,6 +3145,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
@@ -3141,8 +3166,9 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = ResearchKit/module.modulemap;
 				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.researchkit.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_BUNDLE_IDENTIFIER = nsg.resKit.VAS;
 				PRODUCT_NAME = ResearchKit;
+				PROVISIONING_PROFILE = "02f940db-26e2-4a85-a448-3022ef9d87c6";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -3155,6 +3181,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
@@ -3172,8 +3199,9 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = ResearchKit/module.modulemap;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.researchkit.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_BUNDLE_IDENTIFIER = nsg.resKit.VAS;
 				PRODUCT_NAME = ResearchKit;
+				PROVISIONING_PROFILE = "02f940db-26e2-4a85-a448-3022ef9d87c6";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ResearchKit/Accessibility/ORKAccessibilityFunctions.h
+++ b/ResearchKit/Accessibility/ORKAccessibilityFunctions.h
@@ -34,10 +34,15 @@
 
 
 @class ORKScaleSlider;
+@class ORKVASSlider;
 
 // Used to properly format values from the ORKScaleSlider.
 ORK_EXTERN NSString *ORKAccessibilityFormatScaleSliderValue(CGFloat value, ORKScaleSlider *slider);
+
 ORK_EXTERN NSString *ORKAccessibilityFormatContinuousScaleSliderValue(CGFloat value, ORKScaleSlider *slider);
+
+//Used to property format values for the ORKVASSlider.
+ORK_EXTERN NSString *ORKAccessibilityFormatVASSliderValue(CGFloat value, ORKVASSlider *slider);
 
 // Performs a block on the main thread after a delay. If Voice Over is not running, the block is performed immediately.
 ORK_EXTERN void ORKAccessibilityPerformBlockAfterDelay(NSTimeInterval delay, void(^block)(void));

--- a/ResearchKit/Accessibility/ORKAccessibilityFunctions.m
+++ b/ResearchKit/Accessibility/ORKAccessibilityFunctions.m
@@ -34,11 +34,22 @@
 #import "ORKAnswerFormat_Internal.h"
 #import "ORKScaleSlider.h"
 #import "ORKScaleSliderView.h"
+#import "ORKVASSliderView.h"
+#import "ORKVASSlider.h"
 #import "UIView+ORKAccessibility.h"
-
 
 NSString *ORKAccessibilityFormatScaleSliderValue(CGFloat value, ORKScaleSlider *slider) {
     ORKScaleSliderView *sliderView = (ORKScaleSliderView *)[slider ork_superviewOfType:[ORKScaleSliderView class]];
+    if (!slider || !sliderView) {
+        return nil;
+    }
+    
+    NSNumber *normalizedValue = [sliderView.formatProvider normalizedValueForNumber:@(value)];
+    return [sliderView.formatProvider localizedStringForNumber:normalizedValue];
+}
+
+NSString *ORKAccessibilityFormatVASSliderValue(CGFloat value, ORKVASSlider *slider) {
+    ORKVASSliderView *sliderView = (ORKVASSliderView *)[slider ork_superviewOfType:[ORKVASSliderView class]];
     if (!slider || !sliderView) {
         return nil;
     }
@@ -88,3 +99,4 @@ NSString *_ORKAccessibilityStringForVariables(NSInteger numParameters, NSString 
     
     return [variables componentsJoinedByString:@", "];
 }
+

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -54,6 +54,12 @@ typedef NS_ENUM(NSInteger, ORKQuestionType) {
     ORKQuestionTypeScale,
 
     /**
+     The scale question type asks participants to place a mark at an appropriate position based on "feeling"
+     with out numbers.
+     */
+    ORKQuestionTypeVAS,
+
+    /**
      In a single choice question, the participant can pick only one predefined option.
      */
     ORKQuestionTypeSingleChoice,
@@ -141,8 +147,28 @@ typedef NS_ENUM(NSInteger, ORKNumberFormattingStyle) {
     ORKNumberFormattingStylePercent
 } ORK_ENUM_AVAILABLE;
 
+/**
+ An enumeration of the styles for marker fo VAS slider.
+ */
+typedef NS_ENUM(NSInteger, ORKVASMarkerStyle) {
+    /**
+     The default - no triangles.
+     */
+    ORKVASMerkerStyleDefault,
+    
+    /**
+     Lower traingle style.
+     */
+    ORKVASMerkerStyleLowerOnly,
+    /**
+     Both traingles style.
+     */
+    ORKVASMerkerStyleBoth,
+} ORK_ENUM_AVAILABLE;
+
 @class ORKScaleAnswerFormat;
 @class ORKContinuousScaleAnswerFormat;
+@class ORKVASScaleAnswerFormat;
 @class ORKTextScaleAnswerFormat;
 @class ORKValuePickerAnswerFormat;
 @class ORKImageChoiceAnswerFormat;
@@ -211,6 +237,10 @@ ORK_CLASS_AVAILABLE
                                                                        vertical:(BOOL)vertical
                                                         maximumValueDescription:(nullable NSString *)maximumValueDescription
                                                         minimumValueDescription:(nullable NSString *)minimumValueDescription;
+
++ (ORKVASScaleAnswerFormat *)VASScaleAnswerFormatWithMaximumValueDescription:(nullable NSString *)maximumValueDescription
+                                                            minimumValueDescription:(nullable NSString *)minimumValueDescription
+                                                                        markerStyle:(ORKVASMarkerStyle)markerStyle;
 
 + (ORKTextScaleAnswerFormat *)textScaleAnswerFormatWithTextChoices:(NSArray <ORKTextChoice *> *)textChoices
                                                       defaultIndex:(NSInteger)defaultIndex
@@ -632,6 +662,98 @@ ORK_CLASS_AVAILABLE
 
 @end
 
+
+/**
+ The `ORKVASScaleAnswerFormat` class represents an answer format that lets participants
+ select a value on a continuous predefined scale without numbers, just "feeling".
+ 
+ The continuous scale answer format produces an `ORKScaleQuestionResult` object that has a
+ real-number value.
+ */
+
+ORK_CLASS_AVAILABLE
+@interface ORKVASScaleAnswerFormat : ORKAnswerFormat
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ Returns an initialized continuous VAS scale answer format using the specified values.
+ 
+ This method is the designated initializer.
+ 
+ @param maximumValueDescription     A localized label to describe the maximum value of the scale.
+ For none, pass `nil`.
+ @param minimumValueDescription     A localized label to describe the minimum value of the scale.
+ For none, pass `nil`.
+ @param markerStyle                 Style for value selection marker.
+ 
+ @return An initialized scale answer format.
+ */
+
+- (instancetype)initWithMaximumValueDescription:(nullable NSString *)maximumValueDescription
+                        minimumValueDescription:(nullable NSString *)minimumValueDescription
+                                    markerStyle:(ORKVASMarkerStyle) markerStyle;
+
+
+/**
+ Returns an initialized continuous scale answer format using the specified values with default marker style.
+ 
+ @param maximumValueDescription     A localized label to describe the maximum value of the scale.
+ For none, pass `nil`.
+ @param minimumValueDescription     A localized label to describe the minimum value of the scale.
+ For none, pass `nil`.
+ 
+ @return An initialized scale answer format.
+ */
+    
+- (instancetype)initWithMaximumValueDescription:(nullable NSString *)maximumValueDescription
+                        minimumValueDescription:(nullable NSString *)minimumValueDescription;
+
+/**
+ The upper bound of the scale. (read-only)
+ */
+@property (readonly) double maximum;
+
+/**
+ The lower bound of the scale. (read-only)
+ */
+@property (readonly) double minimum;
+
+/**
+ The default value for the slider. (read-only)
+ 
+ If the value of this property is less than `minimum` or greater than `maximum`, the slider has no
+ default value.
+ */
+@property (readonly) double defaultValue;
+
+/**
+ A formatting style applied to the minimum, maximum, and slider values.
+ */
+@property ORKNumberFormattingStyle numberStyle;
+
+/**
+ A number formatter applied to the minimum, maximum, and slider values. Can be overridden by
+ subclasses.
+ */
+@property (readonly) NSNumberFormatter *numberFormatter;
+
+/**
+ A localized label to describe the maximum value of the scale. (read-only)
+ */
+@property (readonly, nullable) NSString *maximumValueDescription;
+
+/**
+ A localized label to describe the minimum value of the scale. (read-only)
+ */
+@property (readonly, nullable) NSString *minimumValueDescription;
+
+/**
+ Style for VAS marker. (read-only)
+ */
+@property (readonly) ORKVASMarkerStyle markerStyle;
+
+@end
 
 /**
  The `ORKValuePickerAnswerFormat` class represents an answer format that lets participants use a

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -1,6 +1,7 @@
 /*
  Copyright (c) 2015, Apple Inc. All rights reserved.
  Copyright (c) 2015, Bruce Duncan.
+ Copyright (c) 2016, ICON plc. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -160,6 +161,7 @@ typedef NS_ENUM(NSInteger, ORKVASMarkerStyle) {
      Lower traingle style.
      */
     ORKVASMerkerStyleLowerOnly,
+    
     /**
      Both traingles style.
      */
@@ -664,11 +666,22 @@ ORK_CLASS_AVAILABLE
 
 
 /**
- The `ORKVASScaleAnswerFormat` class represents an answer format that lets participants
- select a value on a continuous predefined scale without numbers, just "feeling".
- 
- The continuous scale answer format produces an `ORKScaleQuestionResult` object that has a
- real-number value.
+ The `ORKVASScaleAnswerFormat` class represents a visual analogue scale (VAS) answer format.
+ Using this, participants select a position on a continuous linear scale that represents 
+ how they rate their health condition by marking a point on a horizontal line between two endpoints.
+ The health conditions represented by the endpoints of the line are described by the left and right
+ anchor text: @param minimumValueDescription and @param maximumValueDescription respectively.  
+ This scale is an electronic version of the standard 100cm visual analogue scale (VAS) used
+ in many paper questionnaires and validated health instruments, particularly in the area of 
+ pain measurement.
+ The VAS automatically scales to the optimal length for the device display, and the scientific
+ literature contains strong validation evidence that the display length of the VAS does not influence
+ the psychometric properties of the scale.  In common with the 100cm paper visual analogue scale,
+ the scale answer format produces an `ORKScaleQuestionResult` object that returns an integer result
+ from 0 to 100 with all possible integers between 0 to 100 measurable.
+ The style of marker used to indicate the point on the VAS that the participant has selected 
+ is controlled by @param markerStyle.  The presence or absence of arrows to associate the anchor 
+ text with the ends of the VAS line is controlled by @arrows.
  */
 
 ORK_CLASS_AVAILABLE

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1,6 +1,7 @@
 /*
  Copyright (c) 2015, Apple Inc. All rights reserved.
  Copyright (c) 2015, Scott Guelich.
+ Copyright (c) 2016, ICON plc. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -69,6 +69,7 @@ NSString *ORKQuestionTypeString(ORKQuestionType questionType) {
             SQT_CASE(Date);
             SQT_CASE(TimeInterval);
             SQT_CASE(Location);
+            default: return @"";
     }
 #undef SQT_CASE
 }
@@ -281,6 +282,14 @@ NSNumberFormatterStyle ORKNumberFormattingStyleConvert(ORKNumberFormattingStyle 
     return [[ORKTextScaleAnswerFormat alloc] initWithTextChoices:textChoices
                                                     defaultIndex:defaultIndex
                                                         vertical:vertical];
+}
+
++ (ORKVASScaleAnswerFormat *)VASScaleAnswerFormatWithMaximumValueDescription:(nullable NSString *)maximumValueDescription
+                                                            minimumValueDescription:(nullable NSString *)minimumValueDescription
+                                                                        markerStyle:(ORKVASMarkerStyle)markerStyle {
+    return [[ORKVASScaleAnswerFormat alloc] initWithMaximumValueDescription:maximumValueDescription
+                                                    minimumValueDescription:minimumValueDescription
+                                                                markerStyle:markerStyle];
 }
 
 + (ORKBooleanAnswerFormat *)booleanAnswerFormat {
@@ -1574,8 +1583,6 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 @end
 
 
-#pragma mark - ORKContinuousScaleAnswerFormat
-
 @implementation ORKContinuousScaleAnswerFormat {
     NSNumberFormatter *_numberFormatter;
 }
@@ -2383,6 +2390,127 @@ static NSString * const formattedAddressLinesKey = @"FormattedAddressLines";
         MKStringFromMapPoint(MKMapPointForCoordinate(location.coordinate));
     }
     return answerString;
+}
+
+@end
+
+#pragma mark - ORKVASScaleAnswerFormat
+
+@implementation ORKVASScaleAnswerFormat {
+    NSNumberFormatter *_numberFormatter;
+}
+
+- (Class)questionResultClass {
+    return [ORKScaleQuestionResult class];
+}
+
+- (instancetype)init {
+    ORKThrowMethodUnavailableException();
+    return nil;
+}
+
+- (instancetype)initWithMaximumValueDescription:(nullable NSString *)maximumValueDescription
+                        minimumValueDescription:(nullable NSString *)minimumValueDescription
+                                    markerStyle:(ORKVASMarkerStyle) markerStyle {
+    self = [super init];
+    if (self) {
+        _minimum = 0;
+        _maximum = 100;
+        _defaultValue = -1;
+        _maximumValueDescription = maximumValueDescription;
+        _minimumValueDescription = minimumValueDescription;
+        _markerStyle = markerStyle;
+        [self validateParameters];
+    }
+    return self;
+}
+
+- (instancetype)initWithMaximumValueDescription:(nullable NSString *)maximumValueDescription
+                        minimumValueDescription:(nullable NSString *)minimumValueDescription {
+    return [self initWithMaximumValueDescription:maximumValueDescription
+                         minimumValueDescription:minimumValueDescription
+                                     markerStyle:ORKVASMerkerStyleDefault];
+}
+
+- (NSNumber *)minimumNumber {
+    return @(_minimum);
+}
+- (NSNumber *)maximumNumber {
+    return @(_maximum);
+}
+- (NSNumber *)defaultAnswer {
+    if ( _defaultValue > _maximum || _defaultValue < _minimum) {
+        return nil;
+    }
+    return @(_defaultValue);
+}
+
+- (NSNumberFormatter *)numberFormatter {
+    if (!_numberFormatter) {
+        _numberFormatter = [[NSNumberFormatter alloc] init];
+        _numberFormatter.numberStyle = ORKNumberFormattingStyleConvert(_numberStyle);
+        _numberFormatter.maximumFractionDigits = 0;
+    }
+    return _numberFormatter;
+}
+
+- (NSInteger)numberOfSteps {
+    return 0;
+}
+
+- (NSNumber *)normalizedValueForNumber:(NSNumber *)number {
+    return @(number.integerValue);
+}
+
+- (NSString *)localizedStringForNumber:(NSNumber *)number {
+    return [self.numberFormatter stringFromNumber:number];
+}
+
+- (void)validateParameters {
+    [super validateParameters];
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        ORK_DECODE_DOUBLE(aDecoder, maximum);
+        ORK_DECODE_DOUBLE(aDecoder, minimum);
+        ORK_DECODE_DOUBLE(aDecoder, defaultValue);
+        ORK_DECODE_OBJ(aDecoder, maximumValueDescription);
+        ORK_DECODE_OBJ(aDecoder, minimumValueDescription);
+        ORK_DECODE_ENUM(aDecoder, markerStyle);
+    }
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [super encodeWithCoder:aCoder];
+    ORK_ENCODE_DOUBLE(aCoder, maximum);
+    ORK_ENCODE_DOUBLE(aCoder, minimum);
+    ORK_ENCODE_DOUBLE(aCoder, defaultValue);
+    ORK_ENCODE_OBJ(aCoder, maximumValueDescription);
+    ORK_ENCODE_OBJ(aCoder, minimumValueDescription);
+    ORK_ENCODE_ENUM(aCoder, markerStyle);
+}
+
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
+- (BOOL)isEqual:(id)object {
+    BOOL isParentSame = [super isEqual:object];
+    
+    __typeof(self) castObject = object;
+    return (isParentSame &&
+            (_maximum == castObject.maximum) &&
+            (_minimum == castObject.minimum) &&
+            ORKEqualObjects(_maximumValueDescription, castObject.maximumValueDescription) &&
+            ORKEqualObjects(_minimumValueDescription, castObject.minimumValueDescription) &&
+            (_markerStyle == castObject.markerStyle));
+}
+
+- (ORKQuestionType)questionType {
+    return ORKQuestionTypeVAS;
 }
 
 @end

--- a/ResearchKit/Common/ORKAnswerFormat_Internal.h
+++ b/ResearchKit/Common/ORKAnswerFormat_Internal.h
@@ -61,7 +61,9 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTimeOfDayAnswerFormat);
 ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKNumericAnswerFormat);
 ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKScaleAnswerFormat);
 ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKContinuousScaleAnswerFormat);
+ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKVASScaleAnswerFormat);
 ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTextScaleAnswerFormat);
+ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTextAnswerFormat);
 ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTextAnswerFormat);
 ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTimeIntervalAnswerFormat);
 
@@ -138,6 +140,16 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTimeIntervalAnswerFormat)
 
 @end
 
+@protocol ORKVASAnswerFormatProvider <NSObject>
+- (nullable NSString *)localizedStringForNumber:(nullable NSNumber *)number;
+- (nullable NSNumber *)normalizedValueForNumber:(nullable NSNumber *)number;
+- (nullable NSNumber *)minimumNumber;
+- (nullable NSNumber *)maximumNumber;
+- (nullable id)defaultAnswer;
+- (NSString *)maximumValueDescription;
+- (NSString *)minimumValueDescription;
+- (ORKVASMarkerStyle)markerStyle;
+@end
 
 @protocol ORKTextScaleAnswerFormatProvider <ORKScaleAnswerFormatProvider>
 
@@ -157,6 +169,9 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTimeIntervalAnswerFormat)
 
 @end
 
+@interface ORKVASScaleAnswerFormat() <ORKVASAnswerFormatProvider>
+
+@end
 
 @interface ORKTextScaleAnswerFormat () <ORKTextScaleAnswerFormatProvider>
 

--- a/ResearchKit/Common/ORKAnswerTextView.h
+++ b/ResearchKit/Common/ORKAnswerTextView.h
@@ -49,7 +49,7 @@ ORK_CLASS_AVAILABLE
 
 @interface ORKAnswerTextView ()
 
-@property (nonatomic, copy, nullable) NSString *placeholder;
+@property (nonatomic, strong, nullable) UILabel *placeHolder;
 
 @end
 

--- a/ResearchKit/Common/ORKAnswerTextView.m
+++ b/ResearchKit/Common/ORKAnswerTextView.m
@@ -1,6 +1,5 @@
 /*
  Copyright (c) 2015, Apple Inc. All rights reserved.
- Copyright (c) 2015, Ricardo Sánchez-Sáez.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -31,82 +30,42 @@
 
 
 #import "ORKAnswerTextView.h"
-#import "ORKDefines_Private.h"
-#import "ORKSkin.h"
 
 
-@implementation ORKAnswerTextView {
-    UITextView *_placeholderTextView;
-}
+@implementation ORKAnswerTextView
 
 - (instancetype)init {
-    return [self initWithFrame:CGRectZero textContainer:nil];
+    self = [super init];
+    if (self) {
+        [self init_ORKAnswerTextView];
+    }
+    return self;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
-    return [self initWithFrame:frame textContainer:nil];
+    self = [super initWithFrame:frame];
+    if (self) {
+        [self init_ORKAnswerTextView];
+    }
+    return self;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame textContainer:(NSTextContainer *)textContainer {
     self = [super initWithFrame:frame textContainer:textContainer];
     if (self) {
-        [self commonInit];
+        [self init_ORKAnswerTextView];
     }
     return self;
 }
 
-- (void)commonInit {
+- (void)init_ORKAnswerTextView {
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(updateAppearance)
                                                  name:UIContentSizeCategoryDidChangeNotification
                                                object:nil];
-    [[NSNotificationCenter defaultCenter]  addObserver:self
-                                              selector:@selector(textViewTextDidChange:)
-                                                  name:UITextViewTextDidChangeNotification
-                                                object:self];
-
-    _placeholderTextView = [[UITextView alloc] initWithFrame:CGRectZero];
-    _placeholderTextView.textColor = [UIColor ork_midGrayTintColor];
-    _placeholderTextView.userInteractionEnabled = NO;
-    _placeholderTextView.translatesAutoresizingMaskIntoConstraints = NO;
-    [self insertSubview:_placeholderTextView atIndex:0];
     
-    [self setUpConstraints];
     
     [self updateAppearance];
-}
-
-- (void)layoutSubviews {
-    [super layoutSubviews];
-    // Setting the frame directly causes a layout error on a form step (it looks like an iOS bug, as setting the frame should produce the same effect as setting the bounds and the center)
-    CGRect answerTextViewBounds = self.bounds;
-    _placeholderTextView.bounds = answerTextViewBounds;
-    _placeholderTextView.center = CGPointMake(answerTextViewBounds.size.width / 2, answerTextViewBounds.size.height / 2);
-}
-
-- (void)setUpConstraints {
-    // This shouldn't be needed, as we're directly setting the _placeholderTextView bounds and center, but it is needed, otherwise it diplays incorrectly in form steps
-    NSMutableArray *constraints = [NSMutableArray new];
-    NSDictionary *views = @{@"placeholderTextView": _placeholderTextView};
-    [constraints addObjectsFromArray:
-     [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[placeholderTextView]|"
-                                             options:NSLayoutFormatDirectionLeftToRight
-                                             metrics:nil
-                                               views:views]];
-    [constraints addObjectsFromArray:
-     [NSLayoutConstraint constraintsWithVisualFormat:@"V:|[placeholderTextView]|"
-                                             options:(NSLayoutFormatOptions)0
-                                             metrics:nil
-                                               views:views]];
-    [NSLayoutConstraint activateConstraints:constraints];
-}
-
-- (void)textViewTextDidChange:(NSNotification *)notification {
-    [self ork_updatePlaceholder];
-}
-
-- (void)ork_updatePlaceholder {
-    _placeholderTextView.hidden = (self.text.length > 0);
 }
 
 - (void)updateAppearance {
@@ -116,27 +75,12 @@
 
 - (void)setFont:(UIFont *)font {
     [super setFont:font];
-    _placeholderTextView.font = font;
+    self.placeHolder.font = font;
 }
 
-- (void)setTextContainerInset:(UIEdgeInsets)textContainerInset {
-    [super setTextContainerInset:textContainerInset];
-    _placeholderTextView.textContainerInset = textContainerInset;
-}
-
-- (void)setLayoutMargins:(UIEdgeInsets)layoutMargins {
-    [super setLayoutMargins:layoutMargins];
-    _placeholderTextView.layoutMargins = layoutMargins;
-}
-
-- (void)setPlaceholder:(NSString *)placeholder {
-    _placeholder = placeholder ?: ORKLocalizedString(@"PLACEHOLDER_LONG_TEXT", nil);
-    _placeholderTextView.text = _placeholder;
-}
-
-- (void)setText:(NSString *)text {
-    [super setText:text];
-    [self ork_updatePlaceholder];
+- (void)setPlaceHolder:(UILabel *)placeHolder {
+    _placeHolder = placeHolder;
+    _placeHolder.font  = self.font;
 }
 
 - (void)dealloc {

--- a/ResearchKit/Common/ORKFormItemCell.m
+++ b/ResearchKit/Common/ORKFormItemCell.m
@@ -44,6 +44,7 @@
 #import "ORKAccessibility.h"
 #import "ORKPicker.h"
 #import "ORKScaleSliderView.h"
+#import "ORKVASSliderView.h"
 #import "ORKSubheadlineLabel.h"
 #import "ORKLocationSelectionView.h"
 #import <MapKit/MapKit.h>
@@ -472,7 +473,7 @@ static const CGFloat HorizontalMargin = 15.0;
 }
 
 - (BOOL)textFieldShouldEndEditing:(UITextField *)textField {
-    if (textField.text.length > 0 && ![[self.formItem impliedAnswerFormat] isAnswerValidWithString:textField.text]) {
+    if (![[self.formItem impliedAnswerFormat] isAnswerValidWithString:textField.text]) {
         [self showValidityAlertWithMessage:[[self.formItem impliedAnswerFormat] localizedInvalidValueStringWithAnswerString:textField.text]];
     }
     return YES;
@@ -756,7 +757,6 @@ static const CGFloat HorizontalMargin = 15.0;
     _textView.contentInset = UIEdgeInsetsMake(-5.0, -4.0, -5.0, 0.0);
     _textView.textAlignment = NSTextAlignmentNatural;
     _textView.scrollEnabled = NO;
-    _textView.placeholder = self.formItem.placeholder;
     
     [self applyAnswerFormat];
     [self answerDidChange];
@@ -824,6 +824,17 @@ static const CGFloat HorizontalMargin = 15.0;
         answer = nil;
     }
     _textView.text = (NSString *)answer;
+    _textView.textColor = [UIColor blackColor];
+    
+    if (_textView.text.length == 0) {
+        if ([_textView isFirstResponder]) {
+            _textView.text = nil;
+            _textView.textColor = [UIColor blackColor];
+        } else {
+            _textView.text = self.formItem.placeholder;
+            _textView.textColor = [self placeholderColor];
+        }
+    }
 }
 
 - (BOOL)becomeFirstResponder {

--- a/ResearchKit/Common/ORKQuestionStepViewController.m
+++ b/ResearchKit/Common/ORKQuestionStepViewController.m
@@ -57,7 +57,7 @@
 #import "ORKStepHeaderView_Internal.h"
 #import "ORKNavigationContainerView_Internal.h"
 #import "ORKQuestionStepView.h"
-
+#import "ORKSurveyAnswerCellForVAS.h"
 
 typedef NS_ENUM(NSInteger, ORKQuestionSection) {
     ORKQuestionSectionAnswer = 0,
@@ -572,7 +572,9 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
                                @(ORKQuestionTypeDateAndTime) : [ORKSurveyAnswerCellForPicker class],
                                @(ORKQuestionTypeTimeInterval) : [ORKSurveyAnswerCellForPicker class],
                                @(ORKQuestionTypeInteger) : [ORKSurveyAnswerCellForNumber class],
-                               @(ORKQuestionTypeLocation) : [ORKSurveyAnswerCellForLocation class]};
+                               @(ORKQuestionTypeLocation) : [ORKSurveyAnswerCellForLocation class],
+                               @(ORKQuestionTypeVAS) : [ORKSurveyAnswerCellForVAS class]
+                               };
     });
     
     // SingleSelectionPicker Cell && Other Cells

--- a/ResearchKit/Common/ORKSurveyAnswerCellForText.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForText.m
@@ -41,6 +41,7 @@
 @interface ORKSurveyAnswerCellForText () <UITextViewDelegate>
 
 @property (nonatomic, strong) ORKAnswerTextView *textView;
+@property (nonatomic, strong) UILabel *placeHolder;
 
 @end
 
@@ -90,9 +91,14 @@
         
         [self addSubview:self.textView];
         
-        self.textView.placeholder = self.step.placeholder;
+        self.placeHolder = [[UILabel alloc] initWithFrame:CGRectMake(10.0, 0, self.bounds.size.width, 36)];
+        self.textView.placeHolder = self.placeHolder;
+        self.placeHolder.text = self.step.placeholder? :ORKLocalizedString(@"PLACEHOLDER_LONG_TEXT", nil);
+        self.placeHolder.textColor = [UIColor lightGrayColor];
+        self.placeHolder.userInteractionEnabled = NO;
+        [self addSubview:self.placeHolder];
         
-        ORKEnableAutoLayoutForViews(@[_textView]);
+        ORKEnableAutoLayoutForViews(@[_placeHolder, _textView]);
         
         [self setUpConstraints];
         
@@ -106,12 +112,14 @@
 - (void)answerDidChange {
     id answer = self.answer;
     self.textView.text = (answer == ORKNullAnswerValue()) ? nil : self.answer;
+    self.placeHolder.hidden = (self.textView.text.length > 0) && ![self.textView isFirstResponder];
+    
 }
 
 - (void)setUpConstraints {
     NSMutableArray *constraints = [NSMutableArray array];
 
-    NSDictionary *views = NSDictionaryOfVariableBindings(_textView);
+    NSDictionary *views = NSDictionaryOfVariableBindings(_textView, _placeHolder);
     
     [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-[_textView]-|"
                                                                              options:(NSLayoutFormatOptions)0
@@ -121,6 +129,35 @@
                                                                              options:(NSLayoutFormatOptions)0
                                                                              metrics:nil
                                                                                views:views]];
+    [constraints addObject:[NSLayoutConstraint constraintWithItem:_placeHolder
+                                                        attribute:NSLayoutAttributeLeading
+                                                        relatedBy:NSLayoutRelationEqual
+                                                           toItem:_textView
+                                                        attribute:NSLayoutAttributeLeading
+                                                       multiplier:1.0
+                                                         constant:0.0]];
+    [constraints addObject:[NSLayoutConstraint constraintWithItem:_placeHolder
+                                                        attribute:NSLayoutAttributeWidth
+                                                        relatedBy:NSLayoutRelationLessThanOrEqual
+                                                           toItem:_textView
+                                                        attribute:NSLayoutAttributeWidth
+                                                       multiplier:1.0
+                                                         constant:0.0]];
+    [constraints addObject:[NSLayoutConstraint constraintWithItem:_placeHolder
+                                                        attribute:NSLayoutAttributeHeight
+                                                        relatedBy:NSLayoutRelationLessThanOrEqual
+                                                           toItem:_textView
+                                                        attribute:NSLayoutAttributeHeight
+                                                       multiplier:1.0
+                                                         constant:0.0]];
+    [constraints addObject:[NSLayoutConstraint constraintWithItem:_placeHolder
+                                                        attribute:NSLayoutAttributeTopMargin
+                                                        relatedBy:NSLayoutRelationEqual
+                                                           toItem:_textView
+                                                        attribute:NSLayoutAttributeTopMargin
+                                                       multiplier:1.0
+                                                         constant:0.0]];
+    
     [NSLayoutConstraint activateConstraints:constraints];
 }
 
@@ -144,7 +181,14 @@
 #pragma mark - UITextViewDelegate
 
 - (void)textViewDidEndEditing:(UITextView *)textView {
+    
     [self textDidChange];
+    self.placeHolder.hidden = (self.textView.text.length > 0);
+}
+
+- (void)textViewDidBeginEditing:(UITextView *)textView {
+
+    self.placeHolder.hidden = YES;
 }
 
 - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text {

--- a/ResearchKit/Common/ORKSurveyAnswerCellForVAS.h
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForVAS.h
@@ -2,8 +2,8 @@
 //  ORKSurveyAnswerCellForVAS.h
 //  ResearchKit
 //
-//  Created by Janusz Bień on 16.03.2016.
-//  Copyright © 2016 researchkit.org. All rights reserved.
+//  Created by Bill Byrom and Willie Muehlhausen, ICON Clinical Research.
+//  Copyright (c) 2016 ICON Clinical Research.  All rights reserved.
 //
 
 #import "ORKSurveyAnswerCell.h"

--- a/ResearchKit/Common/ORKSurveyAnswerCellForVAS.h
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForVAS.h
@@ -1,0 +1,18 @@
+//
+//  ORKSurveyAnswerCellForVAS.h
+//  ResearchKit
+//
+//  Created by Janusz Bień on 16.03.2016.
+//  Copyright © 2016 researchkit.org. All rights reserved.
+//
+
+#import "ORKSurveyAnswerCell.h"
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ORKSurveyAnswerCellForVAS : ORKSurveyAnswerCell
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKSurveyAnswerCellForVAS.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForVAS.m
@@ -1,0 +1,81 @@
+//
+//  ORKSurveyAnswerCellForVAS.m
+//  ResearchKit
+//
+//  Created by Janusz Bień on 16.03.2016.
+//  Copyright © 2016 researchkit.org. All rights reserved.
+//
+
+#import "ORKSurveyAnswerCellForVAS.h"
+#import "ORKScaleSlider.h"
+#import "ORKSkin.h"
+#import "ORKQuestionStep_Internal.h"
+#import "ORKAnswerFormat_Internal.h"
+#import "ORKVASSliderView.h"
+
+
+@interface ORKSurveyAnswerCellForVAS () <ORKVASSliderViewDelegate>
+
+@property (nonatomic, strong) ORKVASSliderView *sliderView;
+@property (nonatomic, strong) id<ORKVASAnswerFormatProvider> formatProvider;
+
+@end
+
+
+@implementation ORKSurveyAnswerCellForVAS
+
+- (id<ORKVASAnswerFormatProvider>)formatProvider {
+    if (_formatProvider == nil) {
+        _formatProvider = (id<ORKVASAnswerFormatProvider>)[self.step impliedAnswerFormat];
+    }
+    return _formatProvider;
+}
+
+- (void)prepareView {
+    [super prepareView];
+    
+    id<ORKVASAnswerFormatProvider> formatProvider = self.formatProvider;
+    
+    if (_sliderView == nil) {
+        _sliderView = [[ORKVASSliderView alloc] initWithFormatProvider:formatProvider delegate:self];
+        [self addSubview:_sliderView];
+        
+        self.sliderView.translatesAutoresizingMaskIntoConstraints = NO;
+        NSDictionary *views = @{ @"sliderView": _sliderView };
+        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[sliderView]|"
+                                                                     options:NSLayoutFormatDirectionLeadingToTrailing
+                                                                     metrics:nil
+                                                                       views:views]];
+        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[sliderView]|"
+                                                                     options:NSLayoutFormatDirectionLeadingToTrailing
+                                                                     metrics:nil
+                                                                       views:views]];
+    }
+    
+    [self answerDidChange];
+}
+
+- (void)answerDidChange {
+    id<ORKVASAnswerFormatProvider> formatProvider = self.formatProvider;
+    id answer = self.answer;
+    if (answer && answer != ORKNullAnswerValue()) {
+        [_sliderView setCurrentAnswerValue:answer];
+    } else {
+        if (answer == nil && [formatProvider defaultAnswer]) {
+            [self.sliderView setCurrentAnswerValue:[formatProvider defaultAnswer]];
+            [self ork_setAnswer:self.sliderView.currentAnswerValue];
+        } else {
+            [self.sliderView setCurrentAnswerValue:nil];
+        }
+    }
+}
+
+- (NSArray *)suggestedCellHeightConstraintsForView:(UIView *)view {
+    return @[];
+}
+
+- (void)VASSliderViewCurrentValueDidChange:(ORKVASSliderView *)sliderView {
+    [self ork_setAnswer:sliderView.currentAnswerValue];
+}
+
+@end

--- a/ResearchKit/Common/ORKSurveyAnswerCellForVAS.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForVAS.m
@@ -2,8 +2,8 @@
 //  ORKSurveyAnswerCellForVAS.m
 //  ResearchKit
 //
-//  Created by Janusz Bień on 16.03.2016.
-//  Copyright © 2016 researchkit.org. All rights reserved.
+//  Created by Bill Byrom and Willie Muehlhausen, ICON Clinical Research.
+//  Copyright (c) 2016 ICON Clinical Research.  All rights reserved.
 //
 
 #import "ORKSurveyAnswerCellForVAS.h"

--- a/ResearchKit/Common/ORKTextFieldView.m
+++ b/ResearchKit/Common/ORKTextFieldView.m
@@ -1,7 +1,6 @@
 /*
  Copyright (c) 2015, Apple Inc. All rights reserved.
- Copyright (c) 2015, Ricardo Sánchez-Sáez.
-
+ 
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
  
@@ -35,8 +34,8 @@
 #import "ORKAccessibility.h"
 
 
-static NSString *const EmptyBulletString = @"\u25CB";
-static NSString *const FilledBulletString = @"\u25CF";
+static NSString * const EmptyBullet = @"\u25CB";
+static NSString * const FilledBullet = @"\u25CF";
 
 @implementation ORKCaretOptionalTextField
 
@@ -88,6 +87,7 @@ static NSString *const FilledBulletString = @"\u25CF";
 }
 
 - (void)updateTextWithNumberOfFilledBullets:(NSInteger)filledBullets {
+    
     // Error checking.
     if (filledBullets > self.numberOfDigits) {
         @throw [NSException exceptionWithName:NSInvalidArgumentException
@@ -97,8 +97,8 @@ static NSString *const FilledBulletString = @"\u25CF";
     
     // Append the string with the correct number of filled and empty bullets.
     NSString *text = [NSString new];
-    text = [text stringByPaddingToLength:filledBullets withString:FilledBulletString startingAtIndex:0];
-    text = [text stringByPaddingToLength:self.numberOfDigits withString:EmptyBulletString startingAtIndex:0];
+    text = [text stringByPaddingToLength:filledBullets withString:FilledBullet startingAtIndex:0];
+    text = [text stringByPaddingToLength:self.numberOfDigits withString:EmptyBullet startingAtIndex:0];
     
     // Apply spacing attribute to string.
     NSMutableAttributedString *attributedText = [[NSMutableAttributedString alloc] initWithString:text];
@@ -122,7 +122,7 @@ static NSString *const FilledBulletString = @"\u25CF";
 }
 
 - (NSString *)accessibilityValue {
-    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:FilledBulletString options:NSRegularExpressionCaseInsensitive error:nil];
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:FilledBullet options:NSRegularExpressionCaseInsensitive error:nil];
     NSUInteger numberOfFilledBullets = [regex numberOfMatchesInString:self.text options:0 range:NSMakeRange(0, [self.text length])];
     return [NSString stringWithFormat:ORKLocalizedString(@"PASSCODE_TEXTFIELD_ACCESSIBILTIY_VALUE", nil), ORKLocalizedStringFromNumber(@(numberOfFilledBullets)), ORKLocalizedStringFromNumber(@([self.text length]))];
 }
@@ -138,6 +138,7 @@ static NSString *const FilledBulletString = @"\u25CF";
     NSString *_managedPlaceholder;
     
     NSString *_unitWithNumber;
+    NSString *_unitWithPlaceholder;
  
     UIColor *_unitRegularColor;
     UIColor *_unitActiveColor;
@@ -151,9 +152,9 @@ static NSString *const FilledBulletString = @"\u25CF";
 - (instancetype)init {
     self = [super init];
     if (self) {
-        [[NSNotificationCenter defaultCenter]  addObserver:self selector:@selector(textFieldTextDidBeginEditing:) name:UITextFieldTextDidBeginEditingNotification object:self];
-        [[NSNotificationCenter defaultCenter]  addObserver:self selector:@selector(textFieldTextDidEndEditing:) name:UITextFieldTextDidEndEditingNotification object:self];
-        [[NSNotificationCenter defaultCenter]  addObserver:self selector:@selector(textFieldTextDidChange:) name:UITextFieldTextDidChangeNotification object:self];
+        [[NSNotificationCenter defaultCenter]  addObserver:self selector:@selector(textFieldDidBeginEditing:) name:UITextFieldTextDidBeginEditingNotification object:self];
+        [[NSNotificationCenter defaultCenter]  addObserver:self selector:@selector(textFieldDidEndEditing:) name:UITextFieldTextDidEndEditingNotification object:self];
+        [[NSNotificationCenter defaultCenter]  addObserver:self selector:@selector(textFieldDidChange:) name:UITextFieldTextDidChangeNotification object:self];
         
     }
     return self;
@@ -184,7 +185,7 @@ static NSString *const FilledBulletString = @"\u25CF";
     if (suffix.length == 0) {
         return;
     }
-    _suffixLabel = [self ork_createTextLabelWithTextColor:(color ?: [UIColor ork_midGrayTintColor])];
+    _suffixLabel = [self ork_createTextLabelWithTextColor:color ?: [UIColor grayColor]];
     _suffixLabel.text = suffix;
     _suffixLabel.font = self.font;
     _suffixLabel.textAlignment = NSTextAlignmentLeft;
@@ -239,10 +240,12 @@ static NSString *const FilledBulletString = @"\u25CF";
     _unit = unit;
     
     if (_unit.length > 0) {
-        _unitWithNumber = [NSString stringWithFormat:@" %@", unit];
+        _unitWithPlaceholder = [NSString stringWithFormat:@"    %@",unit];
+        _unitWithNumber = [NSString stringWithFormat:@" %@",unit];
         _unitRegularColor = [UIColor blackColor];
         _unitActiveColor = [UIColor ork_midGrayTintColor];
     } else {
+        _unitWithPlaceholder = nil;
         _unitWithNumber = nil;
     }
     
@@ -251,19 +254,24 @@ static NSString *const FilledBulletString = @"\u25CF";
 
 - (void)updateManagedUnitAndPlaceholder {
     if (_manageUnitAndPlaceholder) {
-        BOOL isEditing = self.isEditing;
+        BOOL editing = [self isEditing];
         
-        UIColor *suffixColor = isEditing ? _unitActiveColor : _unitRegularColor;
-        if (_managedPlaceholder.length > 0) {
-            [self ork_setPlaceholder: (isEditing && _unit.length > 0) ? nil : _managedPlaceholder];
-            [self ork_updateSuffix:_unitWithNumber withColor:suffixColor];
+        if (editing) {
+            [self ork_setPlaceholder: nil];
+            [self ork_updateSuffix:_unitWithNumber withColor:_unitActiveColor];
         } else {
-            if (self.text.length > 0 || isEditing) {
-                [self ork_setPlaceholder:nil];
-                [self ork_updateSuffix:_unitWithNumber withColor:suffixColor];
+            if (_managedPlaceholder.length > 0) {
+                [self ork_setPlaceholder: (self.text.length == 0)? _managedPlaceholder : nil];
+                NSString *unit = (self.text.length == 0)? _unitWithPlaceholder : _unitWithNumber;
+                [self ork_updateSuffix:unit withColor:_unitRegularColor];
             } else {
-                [self ork_setPlaceholder: _unit];
-                [self ork_updateSuffix:nil withColor:suffixColor];
+                if (self.text.length > 0) {
+                    [self ork_setPlaceholder:nil];
+                    [self ork_updateSuffix:_unitWithNumber withColor:_unitRegularColor];
+                } else {
+                    [self ork_setPlaceholder: _unit];
+                    [self ork_updateSuffix:nil withColor:_unitRegularColor];
+                }
             }
         }
     } else {
@@ -277,19 +285,18 @@ static NSString *const FilledBulletString = @"\u25CF";
         }
     }
     [self invalidateIntrinsicContentSize];
-    [self layoutIfNeeded]; // layout immediatly to avoid animation glitch in which the unit label frame grows from left to right
 }
 
-- (void)textFieldTextDidBeginEditing:(NSNotification *)notification {
+- (void)textFieldDidBeginEditing:(NSNotification *)notification {
     [self updateManagedUnitAndPlaceholder];
 }
 
-- (void)textFieldTextDidEndEditing:(NSNotification *)notification {
+- (void)textFieldDidEndEditing:(NSNotification *)notification {
     [self updateManagedUnitAndPlaceholder];
     
 }
 
-- (void)textFieldTextDidChange:(NSNotification *)notification {
+- (void)textFieldDidChange:(NSNotification *)notification {
     [self updateManagedUnitAndPlaceholder];
 }
 
@@ -299,9 +306,8 @@ static NSString *const FilledBulletString = @"\u25CF";
 }
 
 - (BOOL)isPlaceholderVisible {
-    BOOL isEditing = self.isEditing;
-    return (self.placeholder.length > 0) &&
-            ((!isEditing && self.text.length == 0) || (isEditing && self.text.length == 0 && _unit.length == 0));
+    BOOL editing = [self isEditing];
+    return (!editing) && ([self placeholder].length > 0);
 }
 
 - (CGFloat)suffixWidthForBounds:(CGRect)bounds {
@@ -310,7 +316,7 @@ static NSString *const FilledBulletString = @"\u25CF";
     return suffixWidth;
 }
 
-static const UIEdgeInsets paddingGuess = (UIEdgeInsets){.left = 2, .right = 6};
+static const UIEdgeInsets paddingGuess = (UIEdgeInsets){.left = 6, .right=6};
 
 - (CGRect)textRectForBounds:(CGRect)bounds {
     CGRect textRect = [super textRectForBounds:bounds];
@@ -328,7 +334,7 @@ static const UIEdgeInsets paddingGuess = (UIEdgeInsets){.left = 2, .right = 6};
 
 
 - (CGRect)editingRectForBounds:(CGRect)bounds {
-    CGRect rect = [super editingRectForBounds:bounds];
+    CGRect r = [super editingRectForBounds:bounds];
     
     // Leave room for the suffix label
     if (_suffixLabel.text.length) {
@@ -336,15 +342,15 @@ static const UIEdgeInsets paddingGuess = (UIEdgeInsets){.left = 2, .right = 6};
         if (suffixWidth > 0) {
             suffixWidth += paddingGuess.right;
         }
-        rect.size.width = MAX(0, rect.size.width - suffixWidth);
+        r.size.width = MAX(0, r.size.width - suffixWidth);
     }
     
-    return rect;
+    return r;
 }
 
 - (CGRect)ork_suffixFrame {
     // Get the text currently 'in' the edit field
-    NSString *textToMeasure = [self isPlaceholderVisible] ? self.placeholder : self.text;
+    NSString *textToMeasure = [self isPlaceholderVisible] ? [self placeholder] : self.text;
     CGSize sizeOfText = [textToMeasure sizeWithAttributes:[self defaultTextAttributes]];
     
     // Get the maximum size of the actual editable area (taking into account prefix/suffix/views/clear button
@@ -393,7 +399,6 @@ static const UIEdgeInsets paddingGuess = (UIEdgeInsets){.left = 2, .right = 6};
 - (NSString *)accessibilityValue {
     if (self.text.length > 0) {
         return ORKAccessibilityStringForVariables([super accessibilityValue], _unitWithNumber);
-    
     }
     else if ( _managedPlaceholder ) {
         return ORKAccessibilityStringForVariables(_managedPlaceholder, _unitWithNumber);
@@ -423,7 +428,6 @@ static const UIEdgeInsets paddingGuess = (UIEdgeInsets){.left = 2, .right = 6};
     NSMutableArray *constraints = [NSMutableArray new];
     
     NSDictionary *views = NSDictionaryOfVariableBindings(_textField);
-    
     [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_textField]|"
                                                                              options:NSLayoutFormatDirectionLeadingToTrailing
                                                                              metrics:nil
@@ -465,5 +469,6 @@ static const UIEdgeInsets paddingGuess = (UIEdgeInsets){.left = 2, .right = 6};
     
     return fieldWidth;
 }
+
 
 @end

--- a/ResearchKit/Common/ORKVASSlider.h
+++ b/ResearchKit/Common/ORKVASSlider.h
@@ -1,0 +1,18 @@
+//
+//  ORKVASSlider.h
+//  ResearchKit
+//
+//  Created by Janusz Bień on 16.03.2016.
+//  Copyright © 2016 researchkit.org. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "ORKAnswerFormat.h"
+
+@interface ORKVASSlider : UISlider
+
+@property (nonatomic, assign) BOOL showThumb;
+@property (nonatomic, assign) NSUInteger numberOfSteps;
+@property (nonatomic, assign) ORKVASMarkerStyle markerStyle;
+
+@end

--- a/ResearchKit/Common/ORKVASSlider.h
+++ b/ResearchKit/Common/ORKVASSlider.h
@@ -2,8 +2,8 @@
 //  ORKVASSlider.h
 //  ResearchKit
 //
-//  Created by Janusz Bień on 16.03.2016.
-//  Copyright © 2016 researchkit.org. All rights reserved.
+//  Created by Bill Byrom and Willie Muehlhausen, ICON Clinical Research.
+//  Copyright (c) 2016 ICON Clinical Research.  All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/ResearchKit/Common/ORKVASSlider.m
+++ b/ResearchKit/Common/ORKVASSlider.m
@@ -2,8 +2,8 @@
 //  ORKVASSlider.m
 //  ResearchKit
 //
-//  Created by Janusz Bień on 16.03.2016.
-//  Copyright © 2016 researchkit.org. All rights reserved.
+//  Created by Bill Byrom and Willie Muehlhausen, ICON Clinical Research.
+//  Copyright (c) 2016 ICON Clinical Research.  All rights reserved.
 //
 
 #import "ORKVASSlider.h"

--- a/ResearchKit/Common/ORKVASSlider.m
+++ b/ResearchKit/Common/ORKVASSlider.m
@@ -1,0 +1,241 @@
+//
+//  ORKVASSlider.m
+//  ResearchKit
+//
+//  Created by Janusz Bień on 16.03.2016.
+//  Copyright © 2016 researchkit.org. All rights reserved.
+//
+
+#import "ORKVASSlider.h"
+
+
+#import "ORKScaleSlider.h"
+#import "ORKAccessibility.h"
+#import "ORKDefines_Private.h"
+#import "ORKAnswerFormat_Internal.h"
+#import "ORKSkin.h"
+#import "ORKVASSliderView.h"
+#import "ORKScaleRangeDescriptionLabel.h"
+#import "ORKScaleRangeImageView.h"
+
+
+@implementation ORKVASSlider {
+    CFAbsoluteTime _axLastOutputTime;
+    BOOL _thumbImageNeedsTransformUpdate;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(sliderTouched:)];
+        [self addGestureRecognizer:tapGesture];
+        
+        UIPanGestureRecognizer *panGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(sliderTouched:)];
+        [self addGestureRecognizer:panGesture];
+        
+        self.minimumTrackTintColor = [UIColor clearColor];
+        self.maximumTrackTintColor = [UIColor clearColor];
+        _numberOfSteps = 100;
+        self.showThumb = NO;
+        _axLastOutputTime = 0;
+        _thumbImageNeedsTransformUpdate = NO;
+        
+        [self setThumbImage:[self thumbImage] forState:UIControlStateNormal];
+    }
+    return self;
+}
+
+- (void)setShowThumb:(BOOL)showThumb {
+    _showThumb = showThumb;
+    [self setNeedsLayout];
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    if (_thumbImageNeedsTransformUpdate) {
+        _thumbImageNeedsTransformUpdate = NO;
+        //[self thumbImageSubview].transform = CGAffineTransformIdentity;
+    }
+}
+
+- (void) setMarkerStyle:(ORKVASMarkerStyle)markerStyle {
+    _markerStyle = markerStyle;
+    [self setThumbImage:[self thumbImage] forState:UIControlStateNormal];
+}
+
+- (CGSize)intrinsicContentSize {
+    CGSize intrinsicContentSize = [super intrinsicContentSize];
+    return intrinsicContentSize;
+}
+
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
+    BOOL pointInside = NO;
+    pointInside = [super pointInside:point withEvent:event];
+    return pointInside;
+}
+
+- (void)sliderTouched:(UIGestureRecognizer *)gesture {
+    self.showThumb = YES;
+    
+    CGPoint touchPoint = [gesture locationInView:self];
+    [self updateValueForTouchAtPoint:touchPoint];
+    
+    [self sendActionsForControlEvents:UIControlEventValueChanged];
+    [self _announceNewValue];
+}
+
+- (void)updateValueForTouchAtPoint:(CGPoint)touchPoint {
+    // Ignore negative (out of bounds) positions
+    if (touchPoint.x < 0) {
+        touchPoint.x = 0;
+    }
+    CGRect trackRect = [self trackRectForBounds:self.bounds];
+    CGFloat position = (touchPoint.x - CGRectGetMinX(trackRect)) / CGRectGetWidth(trackRect);
+    
+    CGFloat newValue = position * (self.maximumValue - self.minimumValue) + self.minimumValue;
+    if (_numberOfSteps > 0) {
+        CGFloat stepSize = 1.0 / _numberOfSteps;
+        NSUInteger steps = round(position / stepSize);
+        
+        newValue = stepSize*steps * (self.maximumValue - self.minimumValue) + self.minimumValue;
+    }
+    [self setValue:newValue animated:YES];
+}
+
+static CGFloat LineWidth = 1.0;
+- (void)drawRect:(CGRect)rect {
+    CGRect bounds = self.bounds;
+    CGRect trackRect = [self trackRectForBounds:bounds];
+    CGFloat centerY = bounds.size.height / 2.0;
+    
+    [[UIColor blackColor] set];
+    
+    UIBezierPath *path = [[UIBezierPath alloc] init];
+    [path setLineWidth:LineWidth];
+        
+    for (int discreteOffset = 0; discreteOffset <= 1; ++discreteOffset) {
+        CGFloat x = trackRect.origin.x + (trackRect.size.width - LineWidth) * discreteOffset;
+        x += LineWidth / 2; // Draw in center of line (center of pixel on 1x devices)
+        [path moveToPoint:CGPointMake(x, centerY - 3.5)];
+        [path addLineToPoint:CGPointMake(x, centerY + 3.5)];
+    }
+    [path stroke];
+    [[UIBezierPath bezierPathWithRect:trackRect] fill];
+}
+
+static const CGFloat Padding = 2.0;
+- (CGRect)trackRectForBounds:(CGRect)bounds {
+    CGFloat centerY = (bounds.size.height / 2.0) - (LineWidth / 2.0);
+    CGRect rect = CGRectMake(bounds.origin.x + Padding, centerY, bounds.size.width - 2 * Padding, 1.0);
+    return rect;
+}
+
+- (CGRect)thumbRectForBounds:(CGRect)bounds trackRect:(CGRect)trackRect value:(float)value {
+    CGRect rect = [super thumbRectForBounds:bounds trackRect:trackRect value:value];
+    
+    // VO needs the thumb to be visible, so we don't hide it if VO is running.
+    if (_showThumb == NO && !UIAccessibilityIsVoiceOverRunning()) {
+        rect.origin.x = -1000;
+        return rect;
+    }
+    
+    CGFloat centerX = (value - self.minimumValue) / (self.maximumValue - self.minimumValue) * trackRect.size.width + trackRect.origin.x;
+    rect.origin.x = centerX - rect.size.width / 2.0;
+    
+    return rect;
+}
+
+#pragma mark - Accessibility
+
+- (BOOL)isAccessibilityElement {
+    return YES;
+}
+
+- (void)accessibilityIncrement {
+    [self axBumpValue:YES];
+}
+
+- (void)accessibilityDecrement {
+    [self axBumpValue:NO];
+}
+
+
+- (NSString *)accessibilityValue {
+    // If thumb is hidden it means that the slider hasn't been touched yet. That is, there's currently
+    // no value (nor a default value), hence we shouldn't return one to VO.
+    if (!self.showThumb) {
+        return nil;
+    }
+    return [self _axFormattedValue:self.value];
+}
+
+- (CGRect)accessibilityFrame {
+    UIView *containingCell = [self ork_superviewOfType:[UITableViewCell class]];
+    
+    // Let the accessibilityFrame be equal to that of the containing cell so it's easier for VO users to touch.
+    if ([self isDescendantOfView:containingCell]) {
+        return UIAccessibilityConvertFrameToScreenCoordinates(containingCell.bounds, containingCell);
+    }
+    return CGRectZero;
+}
+
+#pragma mark Accessibility Helpers
+
+- (NSString *)_axFormattedValue:(CGFloat)value {
+    return ORKAccessibilityFormatVASSliderValue(value, self);
+}
+
+- (void)axBumpValue:(BOOL)increment {
+    self.showThumb = YES;
+    CGFloat stepSize = (self.maximumValue - self.minimumValue) / _numberOfSteps;
+    CGFloat newValue = self.value + (increment ? stepSize : -stepSize);
+    self.value = newValue;
+    [self sendActionsForControlEvents:UIControlEventValueChanged];
+}
+
+static const NSTimeInterval TimeoutSpeakThreshold = 1.0;
+- (void)_announceNewValue {
+    if ( (CFAbsoluteTimeGetCurrent() - _axLastOutputTime) > TimeoutSpeakThreshold ) {
+        UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, self.accessibilityValue);
+        _axLastOutputTime = CFAbsoluteTimeGetCurrent();
+    }
+}
+
+#pragma mark Drawings
+
+-(UIImage *)thumbImage {
+    CGRect rect = CGRectMake(0.0f, 0.0f, 21.0f, 80.0f);
+    UIGraphicsBeginImageContext(rect.size);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    CGContextSetFillColorWithColor(context, [[UIColor clearColor] CGColor]);
+    CGContextFillRect(context, rect);
+    UIColor *markerColor = [UIColor colorWithRed:100.0f/255.0f green:150.0f/255.0f blue:199.0f/255.0f alpha:1.0f];
+    CGContextSetStrokeColorWithColor(context, [markerColor CGColor]);
+    CGContextSetFillColorWithColor(context, [markerColor CGColor]);
+    CGContextSetLineWidth(context, 1.0f);
+    CGContextMoveToPoint(context, 11.0f, 10.0f);
+    CGContextAddLineToPoint(context, 11.0f, 70.0f);
+    CGContextStrokePath(context);
+    switch (_markerStyle) {
+        case ORKVASMerkerStyleBoth:
+            CGContextMoveToPoint(context, 0.0f, 00.0f);
+            CGContextAddLineToPoint(context, 21.0f, 0.0f);
+            CGContextAddLineToPoint(context, 11.0f, 20.0f);
+            CGContextClosePath(context);
+            CGContextFillPath(context);
+        case ORKVASMerkerStyleLowerOnly:
+            CGContextMoveToPoint(context, 0.0f, 80.0f);
+            CGContextAddLineToPoint(context, 21.0f, 80.0f);
+            CGContextAddLineToPoint(context, 11.0f, 60.0f);
+            CGContextClosePath(context);
+            CGContextFillPath(context);
+            break;
+        default:
+            break;
+    }
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return image;
+}
+
+@end

--- a/ResearchKit/Common/ORKVASSliderView.h
+++ b/ResearchKit/Common/ORKVASSliderView.h
@@ -1,0 +1,52 @@
+//
+//  ORKVASSliderView.h
+//  ResearchKit
+//
+//  Created by Janusz Bień on 16.03.2016.
+//  Copyright © 2016 researchkit.org. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <ResearchKit/ResearchKit.h>
+#import "ORKAnswerFormat_Internal.h"
+#import "ORKScaleSlider.h"
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class ORKScaleRangeLabel;
+@class ORKScaleValueLabel;
+@class ORKScaleRangeDescriptionLabel;
+@class ORKScaleRangeImageView;
+@class ORKVASSliderView;
+
+@protocol ORKVASSliderViewDelegate <NSObject>
+
+- (void)VASSliderViewCurrentValueDidChange:(ORKVASSliderView *)sliderView;
+
+@end
+
+
+@interface ORKVASSliderView : UIView
+
+- (instancetype)initWithFormatProvider:(id<ORKVASAnswerFormatProvider>)formatProvider delegate:(id<ORKVASSliderViewDelegate>)delegate;
+
+@property (nonatomic, weak, readonly) id<ORKVASSliderViewDelegate> delegate;
+
+@property (nonatomic, strong, readonly) id<ORKVASAnswerFormatProvider> formatProvider;
+
+@property (nonatomic, strong, readonly) ORKScaleRangeDescriptionLabel *leftRangeDescriptionLabel;
+
+@property (nonatomic, strong, readonly) ORKScaleRangeDescriptionLabel *rightRangeDescriptionLabel;
+
+@property (nonatomic, strong, readonly) UIImageView *rightArrowView;
+
+@property (nonatomic, strong, readonly) UIImageView *leftArrowView;
+
+// Accepts NSNumber for continous scale or discrete scale.
+// Accepts NSArray<id<NSCopying, NSCoding, NSObject>> for text scale.
+@property (nonatomic, strong, nullable) id currentAnswerValue;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKVASSliderView.h
+++ b/ResearchKit/Common/ORKVASSliderView.h
@@ -2,8 +2,8 @@
 //  ORKVASSliderView.h
 //  ResearchKit
 //
-//  Created by Janusz Bień on 16.03.2016.
-//  Copyright © 2016 researchkit.org. All rights reserved.
+//  Created by Bill Byrom and Willie Muehlhausen, ICON Clinical Research.
+//  Copyright (c) 2016 ICON Clinical Research.  All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/ResearchKit/Common/ORKVASSliderView.m
+++ b/ResearchKit/Common/ORKVASSliderView.m
@@ -1,0 +1,215 @@
+//
+//  ORKVASSliderView.m
+//  ResearchKit
+//
+//  Created by Janusz Bień on 16.03.2016.
+//  Copyright © 2016 researchkit.org. All rights reserved.
+//
+
+#import "ORKVASSliderView.h"
+#import "ORKVASSlider.h"
+#import "ORKScaleRangeLabel.h"
+#import "ORKScaleRangeDescriptionLabel.h"
+#import "ORKScaleValueLabel.h"
+#import "ORKScaleRangeImageView.h"
+#import "ORKSkin.h"
+
+
+// #define LAYOUT_DEBUG 1
+
+@implementation ORKVASSliderView {
+    id<ORKVASAnswerFormatProvider> _formatProvider;
+    ORKVASSlider *_slider;
+    ORKScaleRangeDescriptionLabel *_leftRangeDescriptionLabel;
+    ORKScaleRangeDescriptionLabel *_rightRangeDescriptionLabel;
+    NSNumber *_currentNumberValue;
+}
+
+- (instancetype)initWithFormatProvider:(id<ORKVASAnswerFormatProvider>)formatProvider
+                              delegate:(id<ORKVASSliderViewDelegate>)delegate {
+    self = [self initWithFrame:CGRectZero];
+    if (self) {
+        _formatProvider = formatProvider;
+        _delegate = delegate;
+        
+        _slider = [[ORKVASSlider alloc] initWithFrame:CGRectZero];
+        _slider.userInteractionEnabled = YES;
+        _slider.contentMode = UIViewContentModeRedraw;
+        [self addSubview:_slider];
+        _slider.maximumValue = [formatProvider maximumNumber].floatValue;
+        _slider.minimumValue = [formatProvider minimumNumber].floatValue;
+        
+        _slider.numberOfSteps = 100;
+        _slider.markerStyle = [formatProvider markerStyle];
+        
+        [_slider addTarget:self action:@selector(sliderValueChanged:) forControlEvents:UIControlEventValueChanged];
+        
+        
+        _leftRangeDescriptionLabel = [[ORKScaleRangeDescriptionLabel alloc] initWithFrame:CGRectZero];
+        _leftRangeDescriptionLabel.numberOfLines = -1;
+        [self addSubview:_leftRangeDescriptionLabel];
+        
+        _rightRangeDescriptionLabel = [[ORKScaleRangeDescriptionLabel alloc] initWithFrame:CGRectZero];
+        _rightRangeDescriptionLabel.numberOfLines = -1;
+        [self addSubview:_rightRangeDescriptionLabel];
+        
+        CGRect arrowFrame = CGRectMake(0.0f, 0.0f, 11.0f, 54.0f);
+        UIImage *arrowImage = [self arrowImageInRect:arrowFrame];
+        _leftArrowView = [[UIImageView alloc] initWithFrame:CGRectZero];
+        _leftArrowView.contentMode = UIViewContentModeCenter;
+        _leftArrowView.image = arrowImage;
+        [self addSubview:_leftArrowView];
+        
+        _rightArrowView = [[UIImageView alloc] initWithFrame:CGRectZero];
+        _rightArrowView.contentMode = UIViewContentModeCenter;
+        _rightArrowView.image = arrowImage;
+        [self addSubview:_rightArrowView];
+        
+            
+#if LAYOUT_DEBUG
+        self.backgroundColor = [UIColor greenColor];
+        _slider.backgroundColor = [UIColor redColor];
+        _leftRangeDescriptionLabel.backgroundColor = [UIColor yellowColor];
+        _rightRangeDescriptionLabel.backgroundColor = [UIColor yellowColor];
+#endif
+        _leftRangeDescriptionLabel.textAlignment = NSTextAlignmentLeft;
+        _rightRangeDescriptionLabel.textAlignment = NSTextAlignmentRight;
+            
+        _leftRangeDescriptionLabel.text = [formatProvider minimumValueDescription];
+        _rightRangeDescriptionLabel.text = [formatProvider maximumValueDescription];
+            
+        _leftRangeDescriptionLabel.translatesAutoresizingMaskIntoConstraints = NO;
+        _rightRangeDescriptionLabel.translatesAutoresizingMaskIntoConstraints = NO;
+
+        _leftArrowView.translatesAutoresizingMaskIntoConstraints = NO;
+        _rightArrowView.translatesAutoresizingMaskIntoConstraints = NO;
+
+        self.translatesAutoresizingMaskIntoConstraints = NO;
+        _slider.translatesAutoresizingMaskIntoConstraints = NO;
+        
+        [self setUpConstraints];
+    }
+    return self;
+}
+
+- (void)setUpConstraints {
+    NSDictionary *views = nil;
+    views = NSDictionaryOfVariableBindings(_slider, _leftRangeDescriptionLabel, _rightRangeDescriptionLabel, _leftArrowView, _rightArrowView);
+    
+    NSMutableArray *constraints = [NSMutableArray new];
+        [constraints addObjectsFromArray:
+         [NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_slider(==80)]-(>=15)-|"
+                                                 options:NSLayoutFormatAlignAllCenterX | NSLayoutFormatDirectionLeftToRight
+                                                 metrics:nil
+                                                   views:views]];
+    
+        [constraints addObjectsFromArray:
+         [NSLayoutConstraint constraintsWithVisualFormat:@"V:[_slider]-[_leftArrowView]-(==4)-[_leftRangeDescriptionLabel]-(>=8)-|"
+                                                 options:NSLayoutFormatDirectionLeftToRight
+                                                 metrics:nil
+                                                   views:views]];
+        [constraints addObjectsFromArray:
+         [NSLayoutConstraint constraintsWithVisualFormat:@"V:[_slider]-[_rightArrowView]-(==4)-[_rightRangeDescriptionLabel]-(>=8)-|"
+                                                 options:NSLayoutFormatDirectionLeftToRight
+                                                 metrics:nil
+                                                   views:views]];
+        
+        const CGFloat kMargin = 17.0;
+        const CGFloat kArrowMargin = kMargin - 4.0f;
+        [constraints addObjectsFromArray:
+         [NSLayoutConstraint constraintsWithVisualFormat:@"H:|-kMargin-[_slider]-kMargin-|"
+                                                 options:NSLayoutFormatAlignAllCenterY | NSLayoutFormatDirectionLeftToRight
+                                                 metrics:@{@"kMargin": @(kMargin)}
+                                                   views:views]];
+        [constraints addObjectsFromArray:
+         [NSLayoutConstraint constraintsWithVisualFormat:@"H:|-kArrowMargin-[_leftArrowView]-(>=11)-[_rightArrowView(==_leftArrowView)]-kArrowMargin-|"
+                                                 options:NSLayoutFormatAlignAllCenterY | NSLayoutFormatDirectionLeftToRight
+                                                 metrics:@{@"kArrowMargin": @(kArrowMargin)}
+                                                   views:views]];
+        [constraints addObjectsFromArray:
+         [NSLayoutConstraint constraintsWithVisualFormat:@"H:|-kMargin-[_leftRangeDescriptionLabel]-(>=16)-[_rightRangeDescriptionLabel(==_leftRangeDescriptionLabel)]-kMargin-|"
+                                                 options:NSLayoutFormatAlignAllCenterY | NSLayoutFormatDirectionLeftToRight
+                                                 metrics:@{@"kMargin": @(kMargin)}
+                                                   views:views]];
+    [NSLayoutConstraint activateConstraints:constraints];
+}
+
+- (id<ORKTextScaleAnswerFormatProvider>)textScaleFormatProvider {
+    if ([[_formatProvider class] conformsToProtocol:@protocol(ORKTextScaleAnswerFormatProvider)]) {
+        return (id<ORKTextScaleAnswerFormatProvider>)_formatProvider;
+    }
+    return nil;
+}
+
+- (void)setCurrentNumberValue:(NSNumber *)value {
+    _currentNumberValue = value ? [_formatProvider normalizedValueForNumber:value] : nil;
+    _slider.showThumb = _currentNumberValue ? YES : NO;
+    _slider.value = _currentNumberValue.floatValue;
+}
+
+- (NSUInteger)currentTextChoiceIndex {
+    return _currentNumberValue.unsignedIntegerValue - 1;
+}
+
+- (IBAction)sliderValueChanged:(id)sender {
+    _currentNumberValue = [_formatProvider normalizedValueForNumber:@(_slider.value)];
+    [self notifyDelegate];
+}
+
+- (void)notifyDelegate {
+    if (self.delegate && [self.delegate respondsToSelector:@selector(VASSliderViewCurrentValueDidChange:)]) {
+        [self.delegate VASSliderViewCurrentValueDidChange:self];
+    }
+}
+
+- (id)currentAnswerValue {
+    return _currentNumberValue;
+}
+
+- (void)setCurrentAnswerValue:(id)currentAnswerValue {
+    return [self setCurrentNumberValue:currentAnswerValue];
+}
+
+#pragma mark - Accessibility
+
+// Since the slider is the only interesting thing within this cell, we make the
+// cell a container with only one element, i.e. the slider.
+
+- (BOOL)isAccessibilityElement {
+    return NO;
+}
+
+- (NSInteger)accessibilityElementCount {
+    return (_slider != nil ? 1 : 0);
+}
+
+- (id)accessibilityElementAtIndex:(NSInteger)index {
+    return _slider;
+}
+
+- (NSInteger)indexOfAccessibilityElement:(id)element {
+    return (element == _slider ? 0 : NSNotFound);
+}
+
+#pragma mark Drawings
+
+-(UIImage *)arrowImageInRect: (CGRect) rect {
+    UIGraphicsBeginImageContext(rect.size);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    CGContextSetFillColorWithColor(context, [[UIColor clearColor] CGColor]);
+    CGContextFillRect(context, rect);
+    
+    CGContextSetStrokeColorWithColor(context, [[UIColor blackColor] CGColor]);
+    CGContextSetLineWidth(context, 1.0f);
+    CGContextMoveToPoint(context, 0.0f, 15.0f);
+    CGContextAddLineToPoint(context, rect.size.width/2.0f, 0.0f);
+    CGContextAddLineToPoint(context, 11.0f, 15.0f);
+    CGContextMoveToPoint(context, rect.size.width/2.0f, 0.0f);
+    CGContextAddLineToPoint(context, rect.size.width/2.0f, rect.size.height);
+    
+    CGContextStrokePath(context);
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return image;
+}
+@end

--- a/ResearchKit/Common/ORKVASSliderView.m
+++ b/ResearchKit/Common/ORKVASSliderView.m
@@ -2,8 +2,8 @@
 //  ORKVASSliderView.m
 //  ResearchKit
 //
-//  Created by Janusz Bień on 16.03.2016.
-//  Copyright © 2016 researchkit.org. All rights reserved.
+//  Created by Bill Byrom and Willie Muehlhausen, ICON Clinical Research.
+//  Copyright (c) 2016 ICON Clinical Research.  All rights reserved.
 //
 
 #import "ORKVASSliderView.h"

--- a/samples/ORKSample/ORKSample.xcodeproj/project.pbxproj
+++ b/samples/ORKSample/ORKSample.xcodeproj/project.pbxproj
@@ -251,6 +251,7 @@
 				TargetAttributes = {
 					161479BF1BD6CE8F0099A068 = {
 						CreatedOnToolsVersion = 7.2;
+						DevelopmentTeam = 5GR6LD469C;
 						SystemCapabilities = {
 							com.apple.HealthKit = {
 								enabled = 1;
@@ -430,14 +431,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = ORKSample/ORKSample.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_ENTITLEMENTS = "";
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				INFOPLIST_FILE = "$(SRCROOT)/ORKSample/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.example.apple-samplecode.Sample";
+				PRODUCT_BUNDLE_IDENTIFIER = nsg.resKit.VAS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE = "06d01b6a-4a00-4052-a6f4-636157d5e39e";
 			};
 			name = Debug;
 		};
@@ -445,14 +446,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = ORKSample/ORKSample.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_ENTITLEMENTS = "";
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				INFOPLIST_FILE = "$(SRCROOT)/ORKSample/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.example.apple-samplecode.Sample";
+				PRODUCT_BUNDLE_IDENTIFIER = nsg.resKit.VAS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE = "06d01b6a-4a00-4052-a6f4-636157d5e39e";
 			};
 			name = Release;
 		};

--- a/samples/ORKSample/ORKSample/ActivityViewController.swift
+++ b/samples/ORKSample/ORKSample/ActivityViewController.swift
@@ -32,7 +32,7 @@ import UIKit
 import ResearchKit
 
 enum Activity: Int {
-    case Survey, Microphone, Tapping
+    case Survey, Microphone, Tapping, VASTest, VASTest2, VASTest3
     
     static var allValues: [Activity] {
         var idx = 0
@@ -47,6 +47,12 @@ enum Activity: Int {
                 return "Microphone"
             case .Tapping:
                 return "Tapping"
+            case .VASTest:
+                return "VASTest"
+            case .VASTest2:
+                return "VASTest (bottom)"
+            case .VASTest3:
+                return "VASTest (booth)"
         }
     }
     
@@ -58,6 +64,12 @@ enum Activity: Int {
                 return "Voice evaluation"
             case .Tapping:
                 return "Test tapping speed"
+            case .VASTest:
+                return "Test for VAS question (default)"
+            case .VASTest2:
+                return "Test for VAS question (bottome marker)"
+            case .VASTest3:
+                return "Test for VAS question (both markers)"
         }
     }
 }
@@ -113,6 +125,12 @@ class ActivityViewController: UITableViewController {
                 
             case .Tapping:
                 taskViewController = ORKTaskViewController(task: StudyTasks.tappingTask, taskRunUUID: NSUUID())
+            case .VASTest:
+                taskViewController = ORKTaskViewController(task: StudyTasks.VasTestTask, taskRunUUID: NSUUID())
+            case .VASTest2:
+                taskViewController = ORKTaskViewController(task: StudyTasks.VasTestTask2, taskRunUUID: NSUUID())
+            case .VASTest3:
+                taskViewController = ORKTaskViewController(task: StudyTasks.VasTestTask3, taskRunUUID: NSUUID())
         }
 
         taskViewController.delegate = self

--- a/samples/ORKSample/ORKSample/Base.lproj/LaunchScreen.storyboard
+++ b/samples/ORKSample/ORKSample/Base.lproj/LaunchScreen.storyboard
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9527" systemVersion="15B22" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="14F1605" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9526"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
     </dependencies>
     <scenes>
         <!--View Controller-->

--- a/samples/ORKSample/ORKSample/Base.lproj/Main.storyboard
+++ b/samples/ORKSample/ORKSample/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="2XQ-Fv-Vxw">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="14F1605" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="2XQ-Fv-Vxw">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
         <capability name="Alignment constraints to the first baseline" minToolsVersion="6.0"/>
         <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
@@ -173,7 +173,7 @@
                                         <rect key="frame" x="0.0" y="64" width="600" height="250"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="FaG-WB-dgL" id="lZo-t3-Gmk">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="249.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="249"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Pie Chart" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L4Y-s4-kek">
@@ -205,7 +205,7 @@
                                         <rect key="frame" x="0.0" y="314" width="600" height="250"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Py6-MC-VuO" id="K6e-O5-O9n">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="249.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="249"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Discrete Graph" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XtH-8y-OQZ">
@@ -237,7 +237,7 @@
                                         <rect key="frame" x="0.0" y="564" width="600" height="250"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="weU-PY-XeW" id="oJP-u1-xIe">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="249.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="249"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Line Graph" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ysh-4a-8jA">
@@ -298,18 +298,18 @@
                                 <rect key="frame" x="0.0" y="92" width="600" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="WGx-1H-dkt" id="YhE-Rx-VQZ">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="hMF-C9-eWk">
-                                            <rect key="frame" x="15" y="6" width="31.5" height="19.5"/>
+                                            <rect key="frame" x="15" y="5" width="32" height="20"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="frW-cv-wEy">
-                                            <rect key="frame" x="15" y="25.5" width="40.5" height="13.5"/>
+                                            <rect key="frame" x="15" y="25" width="41" height="14"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -403,7 +403,7 @@
                                 <rect key="frame" x="0.0" y="256" width="600" height="49"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="l1j-hP-NgK" id="gSL-84-VI9">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="48.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="48"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="500" text="add weight (lbs.)" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1WS-QE-f8O">

--- a/samples/ORKSample/ORKSample/StudyTasks.swift
+++ b/samples/ORKSample/ORKSample/StudyTasks.swift
@@ -124,4 +124,81 @@ struct StudyTasks {
         
         return ORKOrderedTask(identifier: "SurveyTask", steps: steps)
     }()
+    
+    static let VasTestTask: ORKOrderedTask = {
+        var steps = [ORKStep]()
+        
+        // Instruction step
+        let instructionStep = ORKInstructionStep(identifier: "VASIntroStep")
+        instructionStep.title = "We need to test\nVAS slider"
+        instructionStep.text = "It shold be unforgetable experience."
+        
+        steps += [instructionStep]
+        let continuousAnswerFormat = ORKAnswerFormat.VASScaleAnswerFormatWithMaximumValueDescription("Right\nanchor text", minimumValueDescription: "Left\nanchor text", markerStyle: ORKVASMarkerStyle.MerkerStyleDefault)
+        let continuousQuestionStepTitle = "How many difficulty\ndid you have walking at\nyour usual speed?"
+        let continuousQuestionStep = ORKQuestionStep(identifier: "ContinuousQuestionStep", title: continuousQuestionStepTitle, answer: continuousAnswerFormat)
+        
+        steps += [continuousQuestionStep]
+
+        let summaryStep = ORKCompletionStep(identifier: "SummaryStep")
+        summaryStep.title = "Thank you for watching."
+        summaryStep.text = "Hope all is as shold be."
+        
+        steps += [summaryStep]
+
+        
+        return ORKOrderedTask(identifier: "VASTestTask", steps: steps)
+        }()
+
+    static let VasTestTask2: ORKOrderedTask = {
+        var steps = [ORKStep]()
+        
+        // Instruction step
+        let instructionStep = ORKInstructionStep(identifier: "VASIntroStep")
+        instructionStep.title = "We need to test\nVAS slider (bottom marker)"
+        instructionStep.text = "It shold be unforgetable experience."
+        
+        steps += [instructionStep]
+        let continuousAnswerFormat = ORKAnswerFormat.VASScaleAnswerFormatWithMaximumValueDescription("Right\nanchor text", minimumValueDescription: "Left\nanchor text", markerStyle: ORKVASMarkerStyle.MerkerStyleLowerOnly)
+        let continuousQuestionStepTitle = "How many difficulty\ndid you have walking at\nyour usual speed?"
+        let continuousQuestionStep = ORKQuestionStep(identifier: "ContinuousQuestionStep", title: continuousQuestionStepTitle, answer: continuousAnswerFormat)
+        
+        steps += [continuousQuestionStep]
+        
+        let summaryStep = ORKCompletionStep(identifier: "SummaryStep")
+        summaryStep.title = "Thank you for watching."
+        summaryStep.text = "Hope all is as shold be."
+        
+        steps += [summaryStep]
+        
+        
+        return ORKOrderedTask(identifier: "VASTestTask", steps: steps)
+        }()
+    
+    static let VasTestTask3: ORKOrderedTask = {
+        var steps = [ORKStep]()
+        
+        // Instruction step
+        let instructionStep = ORKInstructionStep(identifier: "VASIntroStep")
+        instructionStep.title = "We need to test\nVAS slider (both marker)"
+        instructionStep.text = "It shold be unforgetable experience."
+        
+        steps += [instructionStep]
+        let continuousAnswerFormat = ORKAnswerFormat.VASScaleAnswerFormatWithMaximumValueDescription("Right\nanchor text", minimumValueDescription: "Left\nanchor text", markerStyle: ORKVASMarkerStyle.MerkerStyleBoth)
+        let continuousQuestionStepTitle = "How many difficulty\ndid you have walking at\nyour usual speed?"
+        let continuousQuestionStep = ORKQuestionStep(identifier: "ContinuousQuestionStep", title: continuousQuestionStepTitle, answer: continuousAnswerFormat)
+        
+        steps += [continuousQuestionStep]
+        
+        let summaryStep = ORKCompletionStep(identifier: "SummaryStep")
+        summaryStep.title = "Thank you for watching."
+        summaryStep.text = "Hope all is as shold be."
+        
+        steps += [summaryStep]
+        
+        
+        return ORKOrderedTask(identifier: "VASTestTask", steps: steps)
+        }()
+
+
 }


### PR DESCRIPTION
The `ORKVASScaleAnswerFormat` class represents a visual analogue scale (VAS) answer format. 

Using this, participants select a position on a continuous linear scale that represents how they rate their health condition by marking a point on a horizontal line between two endpoints.  The health conditions represented by the endpoints of the line are described by the left and right anchor text: @param minimumValueDescription and @param maximumValueDescription respectively.  
This scale is an electronic version of the standard 100cm visual analogue scale (VAS) used in many paper questionnaires and validated health instruments, particularly in the area of pain measurement.  The VAS automatically scales to the optimal length for the device display, and the scientific literature contains strong validation evidence that the display length of the VAS does not influence the psychometric properties of the scale.
 In common with the 100cm paper visual analogue scale, the scale answer format produces an `ORKScaleQuestionResult` object that returns an integer result from 0 to 100 with all possible integers between 0 to 100 measurable.
The style of marker used to indicate the point on the VAS that the participant has selected is controlled by @param markerStyle.
The presence or absence of arrows to associate the anchor text with the ends of the VAS line is controlled by @arrows.