### PR TITLE
Deprecated HKAnchoredObjectQuery.init: changed anchor to HKQueryAnchor instead of NSInteger

### DIFF
--- a/ResearchKit/ActiveTasks/ORKHealthQuantityTypeRecorder.m
+++ b/ResearchKit/ActiveTasks/ORKHealthQuantityTypeRecorder.m
@@ -43,7 +43,7 @@
     HKHealthStore *_healthStore;
     NSPredicate *_samplePredicate;
     HKObserverQuery *_observerQuery;
-    NSInteger _anchor;
+    HKQueryAnchor *_anchor;
     HKQuantitySample *_lastSample;
 }
 
@@ -89,7 +89,7 @@
 
 static const NSInteger _HealthAnchoredQueryLimit = 100;
 
-- (void)query_logResults:(NSArray *)results withAnchor:(NSUInteger)newAnchor {
+- (void)query_logResults:(NSArray *)results withAnchor:(HKQueryAnchor *)newAnchor {
     
     NSUInteger resultCount = results.count;
     if (resultCount == 0) {
@@ -133,7 +133,7 @@ static const NSInteger _HealthAnchoredQueryLimit = 100;
                                             predicate:_samplePredicate
                                             anchor:_anchor
                                             limit:_HealthAnchoredQueryLimit
-                                            completionHandler:^(HKAnchoredObjectQuery *query, NSArray *results, NSUInteger newAnchor, NSError *error)
+                                            resultsHandler:^(HKAnchoredObjectQuery *query, NSArray *results, NSArray *deletedObjects, HKQueryAnchor *newAnchor, NSError *error)
                                             {
                                                 if (error) {
                                                     // An error in the query's not the end of the world: we'll probably get another chance. Just log it.


### PR DESCRIPTION
**HKAnchoredObjectQuery**

`init(type:predicate:anchor:limit:completionHandler:)` is deprecated on iOS 9.0 - [HealthKit docs](https://developer.apple.com/library/ios/documentation/HealthKit/Reference/HKAnchoredObjectQuery_Class/index.html#//apple_ref/occ/instm/HKAnchoredObjectQuery/initWithType:predicate:anchor:limit:completionHandler:).

We should use `init(type:predicate:anchor:limit:resultsHandler:)` instead, where the parameter `anchor` is a `HKQueryAnchor` and not a `Int` anymore. See [Apple docs](https://developer.apple.com/library/ios/documentation/HealthKit/Reference/HKAnchoredObjectQuery_Class/index.html#//apple_ref/occ/instm/HKAnchoredObjectQuery/initWithType:predicate:anchor:limit:resultsHandler:).

It was causing compilation errors on Xcode 8 beta, viewing that it will be removed on iOS 10:
https://developer.apple.com/library/prerelease/content/releasenotes/General/iOS10APIDiffs/Swift/HealthKit.html
