### PR TITLE
Modifications to ORKTappingContentView to support resizing the view if skippable.

### DIFF
--- a/ResearchKit/ActiveTasks/ORKTappingContentView.h
+++ b/ResearchKit/ActiveTasks/ORKTappingContentView.h
@@ -40,6 +40,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setTapCount:(NSUInteger)tapCount;
 - (void)setProgress:(CGFloat)progress animated:(BOOL)animated;
 
+@property (nonatomic, assign) BOOL hasSkipButton;
+
 @property (nonatomic, strong, readonly) ORKRoundTappingButton *tapButton1;
 
 @property (nonatomic, strong, readonly) ORKRoundTappingButton *tapButton2;

--- a/ResearchKit/ActiveTasks/ORKTappingContentView.m
+++ b/ResearchKit/ActiveTasks/ORKTappingContentView.m
@@ -276,7 +276,7 @@
     self.layoutMargins = (UIEdgeInsets){.left = margin * 2, .right = margin * 2};
     
     static const CGFloat CaptionBaselineToTapCountBaseline = 56;
-    static const CGFloat TapButtonBottomToBottom = 36;
+    CGFloat tapButtonBottomToBottom = self.hasSkipButton ? 0 : 36;
     
     // On the iPhone, _progressView is positioned outside the bounds of this view, to be in-between the header and this view.
     // On the iPad, we want to stretch this out a bit so it feels less compressed.
@@ -294,7 +294,7 @@
     _topToProgressViewConstraint.constant = topToProgressViewOffset;
     _topToCaptionLabelConstraint.constant = topToCaptionLabelOffset;
     _captionLabelToTapCountLabelConstraint.constant = CaptionBaselineToTapCountBaseline;
-    _tapButtonToBottomConstraint.constant = TapButtonBottomToBottom;
+    _tapButtonToBottomConstraint.constant = tapButtonBottomToBottom;
 }
 
 - (void)updateConstraints {

--- a/ResearchKit/ActiveTasks/ORKTappingIntervalStep.m
+++ b/ResearchKit/ActiveTasks/ORKTappingIntervalStep.m
@@ -43,6 +43,7 @@
     self = [super initWithIdentifier:identifier];
     if (self) {
         self.shouldShowDefaultTimer = NO;
+        self.optional = NO; // default to *not* optional
     }
     return self;
 }

--- a/ResearchKit/ActiveTasks/ORKTappingIntervalStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKTappingIntervalStepViewController.m
@@ -93,6 +93,7 @@
     _expired = NO;
     
     _tappingContentView = [[ORKTappingContentView alloc] init];
+    _tappingContentView.hasSkipButton = self.step.optional;
     self.activeStepView.activeCustomView = _tappingContentView;
     
     [_tappingContentView.tapButton1 addTarget:self action:@selector(buttonPressed:forEvent:) forControlEvents:UIControlEventTouchDown];


### PR DESCRIPTION
In order to implement a two-hand tapping task (pull request TBD), the tapping view needs to be resizable to accommodate showing the skip button. The skip button is required so that the participant in a research study can skip one of their hands if needed.