### PR TITLE
Fix bug where the defaultResultSource is using ivar rather than public property accessor

### DIFF
--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1047,7 +1047,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
         ORKStepResult *result = nil;
         result = _managedResults[step.identifier];
         if (!result ) {
-            result = [_defaultResultSource stepResultForStepIdentifier:step.identifier];
+            result = [self.defaultResultSource stepResultForStepIdentifier:step.identifier];
         }
         
         if (!result) {


### PR DESCRIPTION
By using the ivar rather than the property method accessor, this will fail for implementations where the developer is overriding `-defaultResultSource` rather than setting it. Since override is an accepted pattern in both objc and swift, direct access of the ivar can result in unexpected behavior.