### PR TITLE
Allow steps to instantiate the view controller

### DIFF
--- a/ResearchKit/Common/ORKStep.h
+++ b/ResearchKit/Common/ORKStep.h
@@ -37,6 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 ORK_EXTERN NSString *const ORKNullStepIdentifier ORK_AVAILABLE_DECL;
 
+@class ORKStepViewController;
+
 @protocol ORKTask;
 
 /**
@@ -178,6 +180,11 @@ ORK_CLASS_AVAILABLE
  properties, and must call super.
  */
 - (void)validateParameters;
+
+/**
+ * Instantiates a step view controller for this class or returns nil if undefined
+ */
+- (ORKStepViewController * _Nullable)instantiateStepViewController;
 
 @end
 

--- a/ResearchKit/Common/ORKStep.m
+++ b/ResearchKit/Common/ORKStep.m
@@ -59,6 +59,10 @@
     return [[self class] stepViewControllerClass];
 }
 
+- (ORKStepViewController * _Nullable)instantiateStepViewController {
+    return nil;
+}
+
 - (instancetype)copyWithIdentifier:(NSString *)identifier {
     ORKThrowInvalidArgumentExceptionIfNil(identifier)
     ORKStep *step = [self copy];

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1042,6 +1042,10 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     }
     
     if (!stepViewController) {
+        stepViewController = [step instantiateStepViewController];
+    }
+    
+    if (!stepViewController) {
         Class stepViewControllerClass = step.stepViewControllerClass;
         
         ORKStepResult *result = nil;


### PR DESCRIPTION
Allow steps that are not a part of ResearchKit to have access to a method for instantiating the view controller since the `-stepViewControllerClass` is internal (and not designed for an implementation that uses swift).