### PR TITLE
Fix a bug in task navigation that assumes first step is instruction

### DIFF
--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -873,7 +873,10 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     }
     
     ORKStep *step = viewController.step;
-    [self updateLastBeginningInstructionStepIdentifierForStep:step goForward:goForward];
+    if ([step isKindOfClass:[ORKInstructionStep class]]) {
+        // Do NOT assume that the first step is an instruction step
+        [self updateLastBeginningInstructionStepIdentifierForStep:step goForward:goForward];
+    }
     
     
     if ([self isStepLastBeginningInstructionStep:step]) {


### PR DESCRIPTION
Sometimes the first step in a custom `ORKTask` is *not* an instruction step. The result was that this method would update the text on an internal instruction step to "Get Started" which is not accurate.