### PR TITLE
Fix audio-prompts-coming-from-earpiece bug

### DIFF
--- a/ResearchKit/ActiveTasks/ORKAudioRecorder.m
+++ b/ResearchKit/ActiveTasks/ORKAudioRecorder.m
@@ -81,9 +81,12 @@
     return self;
 }
 
-- (void)restoreSavedAudioSessionCategory:(NSError **)error {
+- (void)restoreSavedAudioSessionCategory {
     if (_savedSessionCategory) {
-        [[AVAudioSession sharedInstance] setCategory:_savedSessionCategory error:error];
+        NSError *error;
+        if (![[AVAudioSession sharedInstance] setCategory:_savedSessionCategory error:&error]) {
+            ORK_Log_Error(@"Failed to restore the audio session category: %@", [error localizedDescription]);
+        }
         _savedSessionCategory = nil;
     }
 }
@@ -201,18 +204,14 @@
         
         [self applyFileProtection:ORKFileProtectionComplete toFileAtURL:[self recordingFileURL]];
 #endif
-        
+        [self restoreSavedAudioSessionCategory];
     }
 }
 
 - (void)finishRecordingWithError:(NSError *)error {
     [self doStopRecording];
-    
-    NSError *resetError;
-    [self restoreSavedAudioSessionCategory:&resetError];
-    
-    [super finishRecordingWithError:(error ?: resetError)];
-    
+
+    [super finishRecordingWithError:error];
 }
 
 - (NSString *)extension {

--- a/ResearchKit/ActiveTasks/ORKAudioRecorder.m
+++ b/ResearchKit/ActiveTasks/ORKAudioRecorder.m
@@ -81,9 +81,9 @@
     return self;
 }
 
-- (void)restoreSavedAudioSessionCategory {
+- (void)restoreSavedAudioSessionCategory:(NSError **)error {
     if (_savedSessionCategory) {
-        [[AVAudioSession sharedInstance] setCategory:_savedSessionCategory error:nil];
+        [[AVAudioSession sharedInstance] setCategory:_savedSessionCategory error:error];
         _savedSessionCategory = nil;
     }
 }
@@ -201,14 +201,18 @@
         
         [self applyFileProtection:ORKFileProtectionComplete toFileAtURL:[self recordingFileURL]];
 #endif
-        [self restoreSavedAudioSessionCategory];
+        
     }
 }
 
 - (void)finishRecordingWithError:(NSError *)error {
     [self doStopRecording];
     
-    [super finishRecordingWithError:error];
+    NSError *resetError;
+    [self restoreSavedAudioSessionCategory:&resetError];
+    
+    [super finishRecordingWithError:(error ?: resetError)];
+    
 }
 
 - (NSString *)extension {

--- a/ResearchKit/ActiveTasks/ORKAudioRecorder.m
+++ b/ResearchKit/ActiveTasks/ORKAudioRecorder.m
@@ -42,6 +42,8 @@
 
 @property (nonatomic, copy) NSDictionary *recorderSettings;
 
+@property (nonatomic, strong) NSString *savedSessionCategory;
+
 @end
 
 
@@ -79,6 +81,13 @@
     return self;
 }
 
+- (void)restoreSavedAudioSessionCategory {
+    if (_savedSessionCategory) {
+        [[AVAudioSession sharedInstance] setCategory:_savedSessionCategory error:nil];
+        _savedSessionCategory = nil;
+    }
+}
+
 - (void)start {
     if (self.outputDirectory == nil) {
         @throw [NSException exceptionWithName:NSDestinationInvalidException reason:@"audioRecorder requires an output directory" userInfo:nil];
@@ -95,6 +104,7 @@
         
         
         AVAudioSession *audioSession = [AVAudioSession sharedInstance];
+        _savedSessionCategory = audioSession.category;
         if (![audioSession setCategory:AVAudioSessionCategoryPlayAndRecord error:&error]) {
             [self finishRecordingWithError:error];
             return;
@@ -191,6 +201,7 @@
         
         [self applyFileProtection:ORKFileProtectionComplete toFileAtURL:[self recordingFileURL]];
 #endif
+        [self restoreSavedAudioSessionCategory];
     }
 }
 

--- a/ResearchKit/ActiveTasks/ORKAudioRecorder.m
+++ b/ResearchKit/ActiveTasks/ORKAudioRecorder.m
@@ -42,7 +42,7 @@
 
 @property (nonatomic, copy) NSDictionary *recorderSettings;
 
-@property (nonatomic, strong) NSString *savedSessionCategory;
+@property (nonatomic, copy) NSString *savedSessionCategory;
 
 @end
 


### PR DESCRIPTION
save the current AVAudioSession category before starting voice recording and then restore afterward.

We discovered a bug where running a voice task followed by a walking task would cause the spoken instructions to use the incorrect speaker. This fix addresses that issue.