### PR TITLE
Added delegate method for discarding results without confirming cancel.

### DIFF
--- a/ResearchKit/Common/ORKTaskViewController.h
+++ b/ResearchKit/Common/ORKTaskViewController.h
@@ -118,6 +118,22 @@ task view controller and pass that data to `initWithTask:restorationData:` when 
 - (BOOL)taskViewControllerSupportsSaveAndRestore:(ORKTaskViewController *)taskViewController;
 
 /**
+ Asks the delegate if the cancel action should be confirmed
+ 
+ The task view controller calls this method to determine whether or not to confirm
+ result save or discard when user attempts to cancel a task that is in progress.
+ 
+ If this method is not implemented, the task view controller assumes that cancel should be confirmed.
+ If this method returns `YES`, then cancel action will be confirmed.
+ If this method returns `NO`, then the results will immediately be discarded.
+ 
+ @param taskViewController  The calling `ORKTaskViewController` instance.
+ 
+ @return `YES` to confirm cancel action; `NO` to immediately discard the results.
+ */
+- (BOOL)taskViewControllerShouldConfirmCancel:(ORKTaskViewController *)taskViewController;
+
+/**
  Asks the delegate if there is Learn More content for this step.
  
  The task view controller calls this method to determine whether a

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1107,6 +1107,15 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
 }
 
 - (void)presentCancelOptions:(BOOL)saveable sender:(UIBarButtonItem *)sender {
+    
+    if ([self.delegate respondsToSelector:@selector(taskViewControllerShouldConfirmCancel:)] &&
+        ![self.delegate taskViewControllerShouldConfirmCancel:self]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self finishWithReason:ORKTaskViewControllerFinishReasonDiscarded error:nil];
+        });
+        return;
+    }
+    
     BOOL supportSaving = NO;
     if ([self.delegate respondsToSelector:@selector(taskViewControllerSupportsSaveAndRestore:)]) {
         supportSaving = [self.delegate taskViewControllerSupportsSaveAndRestore:self];


### PR DESCRIPTION
Adding this `optional` delegate method removes the necessity to jump through a number of hoops and implement a custom button item (text and action) for the cancel button in `-stepViewControllerWillAppear:` delegate method.