### PR TITLE
ORKResult start/end dates should not be nullable

### DIFF
--- a/ResearchKit/Common/ORKResult.h
+++ b/ResearchKit/Common/ORKResult.h
@@ -112,7 +112,7 @@ ORK_CLASS_AVAILABLE
  Note that for instantaneous items, `startDate` and `endDate` can have the same value, and should
  generally correspond to the end of the instantaneous data collection period.
  */
-@property (nonatomic, copy, nullable) NSDate *startDate;
+@property (nonatomic, copy) NSDate *startDate;
 
 /**
  The time when the task, step, or data collection stopped.
@@ -123,7 +123,7 @@ ORK_CLASS_AVAILABLE
  Note that for instantaneous items, `startDate` and `endDate` can have the same value, and should
  generally correspond to the end of the instantaneous data collection period. 
  */
-@property (nonatomic, copy, nullable) NSDate *endDate;
+@property (nonatomic, copy) NSDate *endDate;
 
 /**
  Metadata that describes the conditions under which the result was acquired.


### PR DESCRIPTION
By default, these values are set on instantiation to `now`. Not allowing null values for these simplifies archiving of results for upload to a server that is expecting non-nil values.