### PR TITLE
Add optional property to ORKQuestionResult to record the question text.

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -439,9 +439,14 @@ NSNumberFormatterStyle ORKNumberFormattingStyleConvert(ORKNumberFormattingStyle 
 }
 
 - (ORKQuestionResult *)resultWithIdentifier:(NSString *)identifier answer:(id)answer {
+    return [self resultWithIdentifier:identifier answer:answer text:nil];
+}
+
+- (ORKQuestionResult *)resultWithIdentifier:(NSString *)identifier answer:(id)answer text:(nullable NSString *)text {
     ORKQuestionResult *questionResult = [[[self questionResultClass] alloc] initWithIdentifier:identifier];
     questionResult.answer = answer;
     questionResult.questionType = self.questionType;
+    questionResult.questionText = text;
     return questionResult;
 }
 

--- a/ResearchKit/Common/ORKAnswerFormat_Internal.h
+++ b/ResearchKit/Common/ORKAnswerFormat_Internal.h
@@ -86,7 +86,7 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTimeIntervalAnswerFormat)
 
 - (nonnull Class)questionResultClass;
 
-- (ORKQuestionResult *)resultWithIdentifier:(NSString *)identifier answer:(id)answer;
+- (ORKQuestionResult *)resultWithIdentifier:(NSString *)identifier answer:(id)answer text:(nullable NSString *)text;
 
 - (nullable NSString *)stringForAnswer:(id)answer;
 

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -704,7 +704,7 @@
             NSAssert(answer == nil || answer == ORKNullAnswerValue() || systemTimeZone!=nil, @"systemTimeZone NOT saved");
         }
         
-        ORKQuestionResult *result = [item.answerFormat resultWithIdentifier:item.identifier answer:answer];
+        ORKQuestionResult *result = [item.answerFormat resultWithIdentifier:item.identifier answer:answer text:item.text];
         ORKAnswerFormat *impliedAnswerFormat = [item impliedAnswerFormat];
         
         if ([impliedAnswerFormat isKindOfClass:[ORKDateAnswerFormat class]]) {

--- a/ResearchKit/Common/ORKQuestionStepViewController.m
+++ b/ResearchKit/Common/ORKQuestionStepViewController.m
@@ -421,7 +421,7 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
     ORKQuestionStep *questionStep = self.questionStep;
     
     if (self.answer) {
-        ORKQuestionResult *result = [questionStep.answerFormat resultWithIdentifier:questionStep.identifier answer:self.answer];
+        ORKQuestionResult *result = [questionStep.answerFormat resultWithIdentifier:questionStep.identifier answer:self.answer text:questionStep.text];
         ORKAnswerFormat *impliedAnswerFormat = [questionStep impliedAnswerFormat];
         
         if ([impliedAnswerFormat isKindOfClass:[ORKDateAnswerFormat class]]) {

--- a/ResearchKit/Common/ORKResult.h
+++ b/ResearchKit/Common/ORKResult.h
@@ -837,6 +837,8 @@ ORK_CLASS_AVAILABLE
 ORK_CLASS_AVAILABLE
 @interface ORKQuestionResult : ORKResult
 
+@property (nonatomic, copy, nullable) NSString *questionText;
+
 /**
  A value that indicates the type of question the result came from.
  

--- a/ResearchKit/Common/ORKResult.m
+++ b/ResearchKit/Common/ORKResult.m
@@ -1211,12 +1211,14 @@ const NSUInteger NumberOfPaddingSpacesForIndentationLevel = 4;
 - (void)encodeWithCoder:(NSCoder *)aCoder {
     [super encodeWithCoder:aCoder];
     ORK_ENCODE_ENUM(aCoder, questionType);
+    ORK_ENCODE_OBJ(aCoder, questionText);
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
         ORK_DECODE_ENUM(aDecoder, questionType);
+        ORK_DECODE_OBJ(aDecoder, questionText);
     }
     return self;
 }
@@ -1240,6 +1242,7 @@ const NSUInteger NumberOfPaddingSpacesForIndentationLevel = 4;
 - (instancetype)copyWithZone:(NSZone *)zone {
     ORKQuestionResult *result = [super copyWithZone:zone];
     result.questionType = self.questionType;
+    result.questionText = self.questionText;
     return result;
 }
 


### PR DESCRIPTION
Adding a nullable `questionText` property on an `ORKQuestionResult` allows for simpler schema handling when serializing a result for saving it to a server.