### PR TITLE
Added a optional ambient noise check to the voice task.

### DIFF
--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -514,7 +514,7 @@
 		FA7A9D341B0843A9005A2BEA /* ORKConsentSignatureFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7A9D321B0843A9005A2BEA /* ORKConsentSignatureFormatter.m */; };
 		FA7A9D371B09365F005A2BEA /* ORKConsentSectionFormatterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7A9D361B09365F005A2BEA /* ORKConsentSectionFormatterTests.m */; };
 		FA7A9D391B0969A7005A2BEA /* ORKConsentSignatureFormatterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7A9D381B0969A7005A2BEA /* ORKConsentSignatureFormatterTests.m */; };
-		FF36A48D1D1A0ACA00DE8470 /* ORKAudioLevelNavigationRule.h in Headers */ = {isa = PBXBuildFile; fileRef = FF36A48B1D1A0ACA00DE8470 /* ORKAudioLevelNavigationRule.h */; };
+		FF36A48D1D1A0ACA00DE8470 /* ORKAudioLevelNavigationRule.h in Headers */ = {isa = PBXBuildFile; fileRef = FF36A48B1D1A0ACA00DE8470 /* ORKAudioLevelNavigationRule.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF36A48E1D1A0ACA00DE8470 /* ORKAudioLevelNavigationRule.m in Sources */ = {isa = PBXBuildFile; fileRef = FF36A48C1D1A0ACA00DE8470 /* ORKAudioLevelNavigationRule.m */; };
 /* End PBXBuildFile section */
 

--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -514,6 +514,8 @@
 		FA7A9D341B0843A9005A2BEA /* ORKConsentSignatureFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7A9D321B0843A9005A2BEA /* ORKConsentSignatureFormatter.m */; };
 		FA7A9D371B09365F005A2BEA /* ORKConsentSectionFormatterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7A9D361B09365F005A2BEA /* ORKConsentSectionFormatterTests.m */; };
 		FA7A9D391B0969A7005A2BEA /* ORKConsentSignatureFormatterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7A9D381B0969A7005A2BEA /* ORKConsentSignatureFormatterTests.m */; };
+		FF36A48D1D1A0ACA00DE8470 /* ORKAudioLevelNavigationRule.h in Headers */ = {isa = PBXBuildFile; fileRef = FF36A48B1D1A0ACA00DE8470 /* ORKAudioLevelNavigationRule.h */; };
+		FF36A48E1D1A0ACA00DE8470 /* ORKAudioLevelNavigationRule.m in Sources */ = {isa = PBXBuildFile; fileRef = FF36A48C1D1A0ACA00DE8470 /* ORKAudioLevelNavigationRule.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1071,6 +1073,8 @@
 		FA7A9D321B0843A9005A2BEA /* ORKConsentSignatureFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKConsentSignatureFormatter.m; sourceTree = "<group>"; };
 		FA7A9D361B09365F005A2BEA /* ORKConsentSectionFormatterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKConsentSectionFormatterTests.m; sourceTree = "<group>"; };
 		FA7A9D381B0969A7005A2BEA /* ORKConsentSignatureFormatterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKConsentSignatureFormatterTests.m; sourceTree = "<group>"; };
+		FF36A48B1D1A0ACA00DE8470 /* ORKAudioLevelNavigationRule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKAudioLevelNavigationRule.h; sourceTree = "<group>"; };
+		FF36A48C1D1A0ACA00DE8470 /* ORKAudioLevelNavigationRule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKAudioLevelNavigationRule.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1910,6 +1914,8 @@
 				86C40B011A8D7C5B00081FAC /* ORKAudioStepViewController.m */,
 				86C40AFC1A8D7C5B00081FAC /* ORKAudioContentView.h */,
 				86C40AFD1A8D7C5B00081FAC /* ORKAudioContentView.m */,
+				FF36A48B1D1A0ACA00DE8470 /* ORKAudioLevelNavigationRule.h */,
+				FF36A48C1D1A0ACA00DE8470 /* ORKAudioLevelNavigationRule.m */,
 			);
 			name = Audio;
 			sourceTree = "<group>";
@@ -2482,6 +2488,7 @@
 				86C40E1E1A8D7C5C00081FAC /* ORKConsentSignature.h in Headers */,
 				24898B0D1B7186C000B0E7E7 /* ORKScaleRangeImageView.h in Headers */,
 				CBD34A5A1BB207FC00F204EA /* ORKSurveyAnswerCellForLocation.h in Headers */,
+				FF36A48D1D1A0ACA00DE8470 /* ORKAudioLevelNavigationRule.h in Headers */,
 				86C40C5E1A8D7C5C00081FAC /* ORKWalkingTaskStepViewController.h in Headers */,
 				86C40D2C1A8D7C5C00081FAC /* ORKHeadlineLabel.h in Headers */,
 				86C40D1C1A8D7C5C00081FAC /* ORKFormSectionTitleLabel.h in Headers */,
@@ -2839,6 +2846,7 @@
 				86C40CFC1A8D7C5C00081FAC /* ORKCaption1Label.m in Sources */,
 				86C40E001A8D7C5C00081FAC /* ORKConsentDocument.m in Sources */,
 				D442397A1AF17F5100559D96 /* ORKImageCaptureStep.m in Sources */,
+				FF36A48E1D1A0ACA00DE8470 /* ORKAudioLevelNavigationRule.m in Sources */,
 				86C40CDE1A8D7C5C00081FAC /* ORKTintedImageView.m in Sources */,
 				86B781BC1AA668ED00688151 /* ORKTimeIntervalPicker.m in Sources */,
 				86B781BE1AA668ED00688151 /* ORKValuePicker.m in Sources */,

--- a/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.h
+++ b/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015, Apple Inc. All rights reserved.
+ Copyright (c) 2016, Apple Inc. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.h
+++ b/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.h
@@ -1,0 +1,64 @@
+/*
+ Copyright (c) 2015, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "ORKStepNavigationRule.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ORKAudioLevelNavigationRule : ORKStepNavigationRule
+
+/**
+ Returns an initialized direct-step navigation rule using the specified destination step identifier.
+ 
+ @param audioLevelStepIdentifier   The identifier of the step with the audio file to check.
+ @param defaultStepIdentifier   The identifier of the destination step if audio test passes.
+ 
+ @return A audio level step navigation rule.
+ */
+- (instancetype)initWithAudioLevelStepIdentifier:(NSString *)audioLevelStepIdentifier
+                           defaultStepIdentifier:(NSString *)defaultStepIdentifier
+                               recordingSettings:(NSDictionary *)recordingSettings NS_DESIGNATED_INITIALIZER;
+
+/**
+ Returns a new direct-step navigation rule initialized from data in a given unarchiver.
+ 
+ @param aDecoder    The coder from which to initialize the step navigation rule.
+ 
+ @return A new direct-step navigation rule.
+ */
+- (instancetype)initWithCoder:(NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;
+
+@property (nonatomic, copy, readonly) NSString *audioLevelStepIdentifier;
+@property (nonatomic, copy, readonly) NSString *defaultStepIdentifier;
+@property (nonatomic, copy, readonly) NSDictionary *recordingSettings;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.h
+++ b/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.h
@@ -33,6 +33,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+ORK_CLASS_AVAILABLE
 @interface ORKAudioLevelNavigationRule : ORKStepNavigationRule
 
 /**

--- a/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.h
+++ b/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.h
@@ -39,12 +39,12 @@ NS_ASSUME_NONNULL_BEGIN
  Returns an initialized direct-step navigation rule using the specified destination step identifier.
  
  @param audioLevelStepIdentifier   The identifier of the step with the audio file to check.
- @param defaultStepIdentifier   The identifier of the destination step if audio test passes.
+ @param destinationStepIdentifier  The identifier of the destination step if audio test passes.
  
  @return A audio level step navigation rule.
  */
 - (instancetype)initWithAudioLevelStepIdentifier:(NSString *)audioLevelStepIdentifier
-                           defaultStepIdentifier:(NSString *)defaultStepIdentifier
+                       destinationStepIdentifier:(NSString *)destinationStepIdentifier
                                recordingSettings:(NSDictionary *)recordingSettings NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithCoder:(NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, copy, readonly) NSString *audioLevelStepIdentifier;
-@property (nonatomic, copy, readonly) NSString *defaultStepIdentifier;
+@property (nonatomic, copy, readonly) NSString *destinationStepIdentifier;
 @property (nonatomic, copy, readonly) NSDictionary *recordingSettings;
 
 @end

--- a/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.h
+++ b/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.h
@@ -29,7 +29,7 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "ORKStepNavigationRule.h"
+#import <ResearchKit/ORKStepNavigationRule.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.h
+++ b/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.h
@@ -1,5 +1,6 @@
 /*
- Copyright (c) 2016, Apple Inc. All rights reserved.
+ Copyright (c) 2016, Sage Bionetworks
+ Copyright (c) 2016, Apple Inc.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.m
+++ b/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.m
@@ -59,6 +59,7 @@ Float32 const kVolumeClamp = 60.0;
 {
     ORKThrowInvalidArgumentExceptionIfNil(audioLevelStepIdentifier);
     ORKThrowInvalidArgumentExceptionIfNil(defaultStepIdentifier);
+    ORKThrowInvalidArgumentExceptionIfNil(recordingSettings);
     self = [super init_ork];
     if (self) {
         _audioLevelStepIdentifier = [audioLevelStepIdentifier copy];

--- a/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.m
+++ b/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015, Apple Inc. All rights reserved.
+ Copyright (c) 2016, Apple Inc. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.m
+++ b/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.m
@@ -47,7 +47,7 @@ Float32 const kVolumeClamp = 60.0;
 @interface ORKAudioLevelNavigationRule ()
 
 @property (nonatomic, copy, readwrite) NSString *audioLevelStepIdentifier;
-@property (nonatomic, copy, readwrite) NSString *defaultStepIdentifier;
+@property (nonatomic, copy, readwrite) NSString *destinationStepIdentifier;
 @property (nonatomic, copy, readwrite) NSDictionary *recordingSettings;
 
 @end
@@ -55,16 +55,16 @@ Float32 const kVolumeClamp = 60.0;
 @implementation ORKAudioLevelNavigationRule
 
 - (instancetype)initWithAudioLevelStepIdentifier:(NSString *)audioLevelStepIdentifier
-                           defaultStepIdentifier:(NSString *)defaultStepIdentifier
+                       destinationStepIdentifier:(NSString *)destinationStepIdentifier
                                recordingSettings:(NSDictionary *)recordingSettings
 {
     ORKThrowInvalidArgumentExceptionIfNil(audioLevelStepIdentifier);
-    ORKThrowInvalidArgumentExceptionIfNil(defaultStepIdentifier);
+    ORKThrowInvalidArgumentExceptionIfNil(destinationStepIdentifier);
     ORKThrowInvalidArgumentExceptionIfNil(recordingSettings);
     self = [super init_ork];
     if (self) {
         _audioLevelStepIdentifier = [audioLevelStepIdentifier copy];
-        _defaultStepIdentifier = [defaultStepIdentifier copy];
+        _destinationStepIdentifier = [destinationStepIdentifier copy];
         _recordingSettings = [recordingSettings copy];
     }
     return self;
@@ -80,7 +80,7 @@ Float32 const kVolumeClamp = 60.0;
     self = [super initWithCoder:aDecoder];
     if (self) {
         ORK_DECODE_OBJ_CLASS(aDecoder, audioLevelStepIdentifier, NSString);
-        ORK_DECODE_OBJ_CLASS(aDecoder, defaultStepIdentifier, NSString);
+        ORK_DECODE_OBJ_CLASS(aDecoder, destinationStepIdentifier, NSString);
         ORK_DECODE_OBJ_CLASS(aDecoder, recordingSettings, NSDictionary);
     }
     return self;
@@ -89,14 +89,14 @@ Float32 const kVolumeClamp = 60.0;
 - (void)encodeWithCoder:(NSCoder *)aCoder {
     [super encodeWithCoder:aCoder];
     ORK_ENCODE_OBJ(aCoder, audioLevelStepIdentifier);
-    ORK_ENCODE_OBJ(aCoder, defaultStepIdentifier);
+    ORK_ENCODE_OBJ(aCoder, destinationStepIdentifier);
     ORK_ENCODE_OBJ(aCoder, recordingSettings);
 }
 
 #pragma mark NSCopying
 
 - (instancetype)copyWithZone:(NSZone *)zone {
-    typeof(self) rule = [[[self class] allocWithZone:zone] initWithAudioLevelStepIdentifier:self.audioLevelStepIdentifier defaultStepIdentifier:self.defaultStepIdentifier recordingSettings:self.recordingSettings];
+    typeof(self) rule = [[[self class] allocWithZone:zone] initWithAudioLevelStepIdentifier:self.audioLevelStepIdentifier destinationStepIdentifier:self.destinationStepIdentifier recordingSettings:self.recordingSettings];
     return rule;
 }
 
@@ -105,12 +105,12 @@ Float32 const kVolumeClamp = 60.0;
     __typeof(self) castObject = object;
     return (isParentSame
             && ORKEqualObjects(self.audioLevelStepIdentifier, castObject.audioLevelStepIdentifier)
-            && ORKEqualObjects(self.defaultStepIdentifier, castObject.defaultStepIdentifier)
+            && ORKEqualObjects(self.destinationStepIdentifier, castObject.destinationStepIdentifier)
             && ORKEqualObjects(self.recordingSettings, castObject.recordingSettings));
 }
 
 - (NSUInteger)hash {
-    return [_audioLevelStepIdentifier hash] ^ [_defaultStepIdentifier hash] ^ [_recordingSettings hash];
+    return [_audioLevelStepIdentifier hash] ^ [_destinationStepIdentifier hash] ^ [_recordingSettings hash];
 }
 
 #pragma mark - Required overrides
@@ -128,7 +128,7 @@ Float32 const kVolumeClamp = 60.0;
         return nil;
     }
     
-    return self.defaultStepIdentifier;
+    return self.destinationStepIdentifier;
 }
 
 - (BOOL)checkAudioLevelFromSoundFile:(NSURL *)fileURL

--- a/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.m
+++ b/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.m
@@ -1,0 +1,204 @@
+/*
+ Copyright (c) 2015, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "ORKAudioLevelNavigationRule.h"
+#import "ORKStepNavigationRule_Private.h"
+#import "ORKStepNavigationRule_Internal.h"
+
+#import <AVFoundation/AVFoundation.h>
+
+#import "ORKHelpers.h"
+#import "ORKResult.h"
+#import "ORKResultPredicate.h"
+
+Float32 const kVolumeThreshold = 0.45;
+UInt16  const kLinearPCMBitDepth = 16;
+Float32 const kMaxAmplitude = 32767.0;
+Float32 const kVolumeClamp = 60.0;
+
+@interface ORKAudioLevelNavigationRule ()
+
+@property (nonatomic, copy, readwrite) NSString *audioLevelStepIdentifier;
+@property (nonatomic, copy, readwrite) NSString *defaultStepIdentifier;
+@property (nonatomic, copy, readwrite) NSDictionary *recordingSettings;
+
+@end
+
+@implementation ORKAudioLevelNavigationRule
+
+- (instancetype)initWithAudioLevelStepIdentifier:(NSString *)audioLevelStepIdentifier
+                           defaultStepIdentifier:(NSString *)defaultStepIdentifier
+                               recordingSettings:(NSDictionary *)recordingSettings
+{
+    ORKThrowInvalidArgumentExceptionIfNil(audioLevelStepIdentifier);
+    ORKThrowInvalidArgumentExceptionIfNil(defaultStepIdentifier);
+    self = [super init_ork];
+    if (self) {
+        _audioLevelStepIdentifier = [audioLevelStepIdentifier copy];
+        _defaultStepIdentifier = [defaultStepIdentifier copy];
+        _recordingSettings = [recordingSettings copy];
+    }
+    return self;
+}
+
+#pragma mark NSSecureCoding
+
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        ORK_DECODE_OBJ_CLASS(aDecoder, audioLevelStepIdentifier, NSString);
+        ORK_DECODE_OBJ_CLASS(aDecoder, defaultStepIdentifier, NSString);
+        ORK_DECODE_OBJ_CLASS(aDecoder, recordingSettings, NSDictionary);
+    }
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [super encodeWithCoder:aCoder];
+    ORK_ENCODE_OBJ(aCoder, audioLevelStepIdentifier);
+    ORK_ENCODE_OBJ(aCoder, defaultStepIdentifier);
+    ORK_ENCODE_OBJ(aCoder, recordingSettings);
+}
+
+#pragma mark NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+    typeof(self) rule = [[[self class] allocWithZone:zone] initWithAudioLevelStepIdentifier:self.audioLevelStepIdentifier defaultStepIdentifier:self.defaultStepIdentifier recordingSettings:self.recordingSettings];
+    return rule;
+}
+
+- (BOOL)isEqual:(id)object {
+    BOOL isParentSame = [super isEqual:object];
+    __typeof(self) castObject = object;
+    return (isParentSame
+            && ORKEqualObjects(self.audioLevelStepIdentifier, castObject.audioLevelStepIdentifier)
+            && ORKEqualObjects(self.defaultStepIdentifier, castObject.defaultStepIdentifier)
+            && ORKEqualObjects(self.recordingSettings, castObject.recordingSettings));
+}
+
+- (NSUInteger)hash {
+    return [_audioLevelStepIdentifier hash] ^ [_defaultStepIdentifier hash] ^ [_recordingSettings hash];
+}
+
+#pragma mark - Required overrides
+
+- (NSString *)identifierForDestinationStepWithTaskResult:(ORKTaskResult *)taskResult {
+    
+    // Get the result file
+    ORKStepResult *stepResult = (ORKStepResult *)[taskResult resultForIdentifier:self.audioLevelStepIdentifier];
+    ORKFileResult *audioLevelResult = (ORKFileResult *)[stepResult.results firstObject];
+    
+    // Check the volume
+    if ((audioLevelResult.fileURL != nil) && [self checkAudioLevelFromSoundFile:audioLevelResult.fileURL]) {
+        // Returning nil will drop through to the next step (which should be the the step that has the instructions
+        // for moving to a quieter room).
+        return nil;
+    }
+    
+    return self.defaultStepIdentifier;
+}
+
+- (BOOL)checkAudioLevelFromSoundFile:(NSURL *)fileURL
+{
+    // Setup reader
+    AVURLAsset * urlAsset = [AVURLAsset URLAssetWithURL:fileURL options:nil];
+    if (urlAsset.tracks.count == 0) {
+        NSLog(@"No tracks found for urlAsset: %@", fileURL);
+        return NO;
+    }
+    
+    NSError * error = nil;
+    AVAssetReader * reader = [[AVAssetReader alloc] initWithAsset:urlAsset error:&error];
+    AVAssetTrack * track = [urlAsset.tracks objectAtIndex:0];
+    NSDictionary * outputSettings = @{   AVFormatIDKey                  : @(kAudioFormatLinearPCM),
+                                         AVLinearPCMBitDepthKey         : @(kLinearPCMBitDepth),
+                                         AVLinearPCMIsBigEndianKey      : @(NO),
+                                         AVLinearPCMIsFloatKey          : @(NO),
+                                         AVLinearPCMIsNonInterleaved    : @(NO)};
+    AVAssetReaderTrackOutput* output = [[AVAssetReaderTrackOutput alloc] initWithTrack:track outputSettings:outputSettings];
+    [reader addOutput:output];
+    
+    // Setup initial values - Assume 2 channels if not in recording settings
+    const UInt32 channelCount = (UInt32)[self.recordingSettings[AVNumberOfChannelsKey] unsignedIntegerValue] ?: 2;
+    const UInt32 bytesPerSample = 2 * channelCount;
+    
+    // setup criteria block - Use a high-pass filter and a rolling average of the amplitude
+    // normalized to be < 1
+    __block Float32 rollingAvg = 0;
+    __block UInt64 totalCount = 0;
+    void (^processVolume)(Float32) = ^(Float32 amplitude) {
+        if (amplitude != 0) {
+            Float32 dB = 20 * log10(ABS(amplitude)/kMaxAmplitude);
+            float clampedValue = MAX(dB/kVolumeClamp, -1) + 1;
+            totalCount++;
+            rollingAvg = (rollingAvg * (totalCount - 1) + clampedValue) / totalCount;
+        }
+    };
+    
+    // While there are samples to read and the number of samples above the decibel threshold
+    // is less than the total number of allowed samples over the limit, keep going
+    [reader startReading];
+    while (reader.status == AVAssetReaderStatusReading) {
+        
+        AVAssetReaderTrackOutput * trackOutput = (AVAssetReaderTrackOutput *)[reader.outputs objectAtIndex:0];
+        CMSampleBufferRef sampleBufferRef = [trackOutput copyNextSampleBuffer];
+        
+        if (sampleBufferRef){
+            CMBlockBufferRef blockBufferRef = CMSampleBufferGetDataBuffer(sampleBufferRef);
+            size_t length = CMBlockBufferGetDataLength(blockBufferRef);
+            
+            NSMutableData * data = [NSMutableData dataWithLength:length];
+            CMBlockBufferCopyDataBytes(blockBufferRef, 0, length, data.mutableBytes);
+            
+            SInt16 * samples = (SInt16 *) data.mutableBytes;
+            UInt64 sampleCount = length / bytesPerSample;
+            for (UInt32 i = 0; i < sampleCount ; i++) {
+                Float32 left = (Float32) *samples++;
+                processVolume(left);
+                if (channelCount == 2) {
+                    Float32 right = (Float32) *samples++;
+                    processVolume(right);
+                }
+            }
+            
+            CMSampleBufferInvalidate(sampleBufferRef);
+            CFRelease(sampleBufferRef);
+        }
+    }
+    
+    return rollingAvg > kVolumeThreshold;
+}
+
+
+@end

--- a/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.m
+++ b/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.m
@@ -1,5 +1,6 @@
 /*
- Copyright (c) 2016, Apple Inc. All rights reserved.
+ Copyright (c) 2016, Sage Bionetworks
+ Copyright (c) 2016, Apple Inc.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/ResearchKit/Charts/ORKBarGraphChartView.h
+++ b/ResearchKit/Charts/ORKBarGraphChartView.h
@@ -42,6 +42,7 @@
  using the `referenceLineColor` property. You can customize the plot colors by implementing the
  `-graphChartView:colorForPlotIndex:` method in the data source.
  */
+ORK_CLASS_AVAILABLE
 @interface ORKBarGraphChartView : ORKGraphChartView
 
 /**

--- a/ResearchKit/Common/ORKOrderedTask.h
+++ b/ResearchKit/Common/ORKOrderedTask.h
@@ -257,7 +257,7 @@ typedef NS_OPTIONS(NSUInteger, ORKPredefinedTaskOption) {
  @param duration                The length of the count down timer that runs while audio data is
  collected.
  @param recordingSettings       See "AV Foundation Audio Settings Constants" for possible values.
- @param checkAudioLevel         If `YES` the add navigational rules to check the background noise level.
+ @param checkAudioLevel         If `YES` then add navigational rules to check the background noise level.
  @param options                 Options that affect the features of the predefined task.
  
  @return An active audio task that can be presented with an `ORKTaskViewController` object.

--- a/ResearchKit/Common/ORKOrderedTask.h
+++ b/ResearchKit/Common/ORKOrderedTask.h
@@ -34,6 +34,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class ORKNavigableOrderedTask;
+
 /**
  The `ORKOrderedTask` class implements all the methods in the `ORKTask` protocol and represents a 
  task that assumes a fixed order for its steps.
@@ -288,7 +290,7 @@ typedef NS_OPTIONS(NSUInteger, ORKPredefinedTaskOption) {
  
  @return An active audio task that can be presented with an `ORKTaskViewController` object.
  */
-+ (ORKOrderedTask *)audioLevelNavigableTaskWithIdentifier:(NSString *)identifier
++ (ORKNavigableOrderedTask *)audioLevelNavigableTaskWithIdentifier:(NSString *)identifier
                                    intendedUseDescription:(nullable NSString *)intendedUseDescription
                                         speechInstruction:(nullable NSString *)speechInstruction
                                    shortSpeechInstruction:(nullable NSString *)shortSpeechInstruction

--- a/ResearchKit/Common/ORKOrderedTask.h
+++ b/ResearchKit/Common/ORKOrderedTask.h
@@ -228,40 +228,7 @@ typedef NS_OPTIONS(NSUInteger, ORKPredefinedTaskOption) {
                                         options:(ORKPredefinedTaskOption)options;
 
 
-/**
- Returns a predefined task that enables an audio recording.
- 
- In an audio recording task, the participant is asked to make some kind of sound
- with their voice, and the audio data is collected.
- 
- An audio task can be used to measure properties of the user's voice, such as
- frequency range, or the ability to pronounce certain sounds.
- 
- Data collected in this task consists of audio information.
- 
- @param identifier              The task identifier to use for this task, appropriate to the study.
- @param intendedUseDescription  A localized string describing the intended use of the data
-                                    collected. If the value of this parameter is `nil`, default
-                                    localized text is used.
- @param speechInstruction       Instructional content describing what the user needs to do when
-                                    recording begins. If the value of this parameter is `nil`,
-                                    default localized text is used.
- @param shortSpeechInstruction  Instructional content shown during audio recording. If the value of
-                                    this parameter is `nil`, default localized text is used.
- @param duration                The length of the count down timer that runs while audio data is
-                                    collected.
- @param recordingSettings       See "AV Foundation Audio Settings Constants" for possible values.
- @param options                 Options that affect the features of the predefined task.
- 
- @return An active audio task that can be presented with an `ORKTaskViewController` object.
- */
-+ (ORKOrderedTask *)audioTaskWithIdentifier:(NSString *)identifier
-                     intendedUseDescription:(nullable NSString *)intendedUseDescription
-                          speechInstruction:(nullable NSString *)speechInstruction
-                     shortSpeechInstruction:(nullable NSString *)shortSpeechInstruction
-                                   duration:(NSTimeInterval)duration
-                          recordingSettings:(nullable NSDictionary *)recordingSettings
-                                    options:(ORKPredefinedTaskOption)options;
+
 
 /**
  Returns a predefined task that enables an audio recording WITH a check of the audio level.
@@ -290,13 +257,25 @@ typedef NS_OPTIONS(NSUInteger, ORKPredefinedTaskOption) {
  
  @return An active audio task that can be presented with an `ORKTaskViewController` object.
  */
-+ (ORKNavigableOrderedTask *)audioLevelNavigableTaskWithIdentifier:(NSString *)identifier
-                                   intendedUseDescription:(nullable NSString *)intendedUseDescription
-                                        speechInstruction:(nullable NSString *)speechInstruction
-                                   shortSpeechInstruction:(nullable NSString *)shortSpeechInstruction
-                                                 duration:(NSTimeInterval)duration
-                                        recordingSettings:(nullable NSDictionary *)recordingSettings
-                                                  options:(ORKPredefinedTaskOption)options;
++ (ORKNavigableOrderedTask *)audioTaskWithIdentifier:(NSString *)identifier
+                              intendedUseDescription:(nullable NSString *)intendedUseDescription
+                                   speechInstruction:(nullable NSString *)speechInstruction
+                              shortSpeechInstruction:(nullable NSString *)shortSpeechInstruction
+                                            duration:(NSTimeInterval)duration
+                                   recordingSettings:(nullable NSDictionary *)recordingSettings
+                                     checkAudioLevel:(BOOL)checkAudioLevel
+                                             options:(ORKPredefinedTaskOption)options;
+
+/**
+ @Deprecated
+ */
++ (ORKOrderedTask *)audioTaskWithIdentifier:(NSString *)identifier
+                     intendedUseDescription:(nullable NSString *)intendedUseDescription
+                          speechInstruction:(nullable NSString *)speechInstruction
+                     shortSpeechInstruction:(nullable NSString *)shortSpeechInstruction
+                                   duration:(NSTimeInterval)duration
+                          recordingSettings:(nullable NSDictionary *)recordingSettings
+                                    options:(ORKPredefinedTaskOption)options __deprecated;
 
 /**
  Returns a predefined task that consists of two finger tapping.

--- a/ResearchKit/Common/ORKOrderedTask.h
+++ b/ResearchKit/Common/ORKOrderedTask.h
@@ -262,6 +262,41 @@ typedef NS_OPTIONS(NSUInteger, ORKPredefinedTaskOption) {
                                     options:(ORKPredefinedTaskOption)options;
 
 /**
+ Returns a predefined task that enables an audio recording WITH a check of the audio level.
+ 
+ In an audio recording task, the participant is asked to make some kind of sound
+ with their voice, and the audio data is collected.
+ 
+ An audio task can be used to measure properties of the user's voice, such as
+ frequency range, or the ability to pronounce certain sounds.
+ 
+ Data collected in this task consists of audio information.
+ 
+ @param identifier              The task identifier to use for this task, appropriate to the study.
+ @param intendedUseDescription  A localized string describing the intended use of the data
+ collected. If the value of this parameter is `nil`, default
+ localized text is used.
+ @param speechInstruction       Instructional content describing what the user needs to do when
+ recording begins. If the value of this parameter is `nil`,
+ default localized text is used.
+ @param shortSpeechInstruction  Instructional content shown during audio recording. If the value of
+ this parameter is `nil`, default localized text is used.
+ @param duration                The length of the count down timer that runs while audio data is
+ collected.
+ @param recordingSettings       See "AV Foundation Audio Settings Constants" for possible values.
+ @param options                 Options that affect the features of the predefined task.
+ 
+ @return An active audio task that can be presented with an `ORKTaskViewController` object.
+ */
++ (ORKOrderedTask *)audioLevelNavigableTaskWithIdentifier:(NSString *)identifier
+                                   intendedUseDescription:(nullable NSString *)intendedUseDescription
+                                        speechInstruction:(nullable NSString *)speechInstruction
+                                   shortSpeechInstruction:(nullable NSString *)shortSpeechInstruction
+                                                 duration:(NSTimeInterval)duration
+                                        recordingSettings:(nullable NSDictionary *)recordingSettings
+                                                  options:(ORKPredefinedTaskOption)options;
+
+/**
  Returns a predefined task that consists of two finger tapping.
  
  In a two finger tapping task, the participant is asked to rhythmically and alternately tap two

--- a/ResearchKit/Common/ORKOrderedTask.h
+++ b/ResearchKit/Common/ORKOrderedTask.h
@@ -239,6 +239,10 @@ typedef NS_OPTIONS(NSUInteger, ORKPredefinedTaskOption) {
  An audio task can be used to measure properties of the user's voice, such as
  frequency range, or the ability to pronounce certain sounds.
  
+ If `checkAudioLevel == YES` then a navigation rule is added to do a simple check of the background
+ noise level. If the background noise is too loud, then the participant is instructed to move to a 
+ quieter location before trying again.
+ 
  Data collected in this task consists of audio information.
  
  @param identifier              The task identifier to use for this task, appropriate to the study.
@@ -253,6 +257,7 @@ typedef NS_OPTIONS(NSUInteger, ORKPredefinedTaskOption) {
  @param duration                The length of the count down timer that runs while audio data is
  collected.
  @param recordingSettings       See "AV Foundation Audio Settings Constants" for possible values.
+ @param checkAudioLevel         If `YES` the add navigational rules to check the background noise level.
  @param options                 Options that affect the features of the predefined task.
  
  @return An active audio task that can be presented with an `ORKTaskViewController` object.

--- a/ResearchKit/Common/ORKOrderedTask.m
+++ b/ResearchKit/Common/ORKOrderedTask.m
@@ -398,7 +398,8 @@ void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
     return task;
 }
 
-+ (ORKOrderedTask *)audioLevelNavigableTaskWithIdentifier:(NSString *)identifier
+/// Copyright (c) 2016, Sage Bionetworks
++ (ORKNavigableOrderedTask *)audioLevelNavigableTaskWithIdentifier:(NSString *)identifier
                                    intendedUseDescription:(NSString *)intendedUseDescription
                                         speechInstruction:(NSString *)speechInstruction
                                    shortSpeechInstruction:(NSString *)shortSpeechInstruction

--- a/ResearchKit/Common/ORKOrderedTask.m
+++ b/ResearchKit/Common/ORKOrderedTask.m
@@ -429,7 +429,7 @@ void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
     
     ORKNavigableOrderedTask *task = [[ORKNavigableOrderedTask alloc] initWithIdentifier:identifier steps:steps];
     
-    ORKAudioLevelNavigationRule *audioRule = [[ORKAudioLevelNavigationRule alloc] initWithAudioLevelStepIdentifier:audioStep.identifier defaultStepIdentifier:ORKAudioStepIdentifier recordingSettings:recordingSettings];
+    ORKAudioLevelNavigationRule *audioRule = [[ORKAudioLevelNavigationRule alloc] initWithAudioLevelStepIdentifier:audioStep.identifier destinationStepIdentifier:ORKAudioStepIdentifier recordingSettings:recordingSettings];
     ORKDirectStepNavigationRule *loopRule = [[ORKDirectStepNavigationRule alloc] initWithDestinationStepIdentifier:audioStep.identifier];
     
     [task setNavigationRule:audioRule forTriggerStepIdentifier:audioStep.identifier];

--- a/ResearchKit/Common/ORKOrderedTask_Private.h
+++ b/ResearchKit/Common/ORKOrderedTask_Private.h
@@ -42,6 +42,7 @@ FOUNDATION_EXPORT NSString *const ORKInstruction0StepIdentifier;
 FOUNDATION_EXPORT NSString *const ORKInstruction1StepIdentifier;
 FOUNDATION_EXPORT NSString *const ORKCountdownStepIdentifier;
 FOUNDATION_EXPORT NSString *const ORKAudioStepIdentifier;
+FOUNDATION_EXPORT NSString *const ORKAudioTooLoudStepIdentifier;
 FOUNDATION_EXPORT NSString *const ORKTappingStepIdentifier;
 FOUNDATION_EXPORT NSString *const ORKConclusionStepIdentifier;
 FOUNDATION_EXPORT NSString *const ORKFitnessWalkStepIdentifier;

--- a/ResearchKit/Common/ORKStepNavigationRule.h
+++ b/ResearchKit/Common/ORKStepNavigationRule.h
@@ -273,7 +273,7 @@ ORK_CLASS_AVAILABLE
 
 @end
 
-
+ORK_CLASS_AVAILABLE
 @interface ORKPredicateSkipStepNavigationRule : ORKSkipStepNavigationRule
 
 /**

--- a/ResearchKit/Localized/en.lproj/ResearchKit.strings
+++ b/ResearchKit/Localized/en.lproj/ResearchKit.strings
@@ -244,6 +244,9 @@
 "AUDIO_INTENDED_USE" = "This activity evaluates your voice by recording it with the microphone at the bottom of your phone.";
 "AUDIO_TOO_LOUD_LABEL" = "Too Loud";
 "AUDIO_GENERIC_ERROR_LABEL" = "Unable to record audio";
+"AUDIO_LEVEL_CHECK_LABEL" = "Please wait while we check the background noise level.";
+"AUDIO_TOO_LOUD_MESSAGE" = "The ambient noise level is too loud to record your voice. Please move somewhere quieter and try again.";
+"AUDIO_TOO_LOUD_ACTION_NEXT" = "Tap Next when ready.";
 
 /* Tone audiometry active task. */
 "TONE_AUDIOMETRY_TASK_TITLE" = "Tone Audiometry";

--- a/ResearchKit/ResearchKit_Private.h
+++ b/ResearchKit/ResearchKit_Private.h
@@ -68,6 +68,7 @@
 #import <ResearchKit/ORKTowerOfHanoiStep.h>
 
 #import <ResearchKit/ORKAudioStepViewController.h>
+#import <ResearchKit/ORKAudioLevelNavigationRule.h>
 #import <ResearchKit/ORKToneAudiometryStepViewController.h>
 #import <ResearchKit/ORKToneAudiometryPracticeStepViewController.h>
 #import <ResearchKit/ORKSpatialSpanMemoryStepViewController.h>

--- a/ResearchKitTests/ORKTaskTests.m
+++ b/ResearchKitTests/ORKTaskTests.m
@@ -1393,6 +1393,38 @@ static ORKStepResult *(^getStepResult)(NSString *, Class, ORKQuestionType, id) =
     
 }
 
+- (void)testAudioTask_WithSoundCheck {
+    ORKNavigableOrderedTask *task = [ORKOrderedTask audioTaskWithIdentifier:@"audio" intendedUseDescription:nil speechInstruction:nil shortSpeechInstruction:nil duration:20 recordingSettings:nil checkAudioLevel:YES options:0];
+    
+    NSArray *expectedStepIdentifiers = @[ORKInstruction0StepIdentifier,
+                                         ORKInstruction1StepIdentifier,
+                                         ORKCountdownStepIdentifier,
+                                         ORKAudioTooLoudStepIdentifier,
+                                         ORKAudioStepIdentifier,
+                                         ORKConclusionStepIdentifier];
+    NSArray *stepIdentifiers = [task.steps valueForKey:@"identifier"];
+    XCTAssertEqual(stepIdentifiers.count, expectedStepIdentifiers.count);
+    XCTAssertEqualObjects(stepIdentifiers, expectedStepIdentifiers);
+    
+    XCTAssertNotNil([task navigationRuleForTriggerStepIdentifier:ORKCountdownStepIdentifier]);
+    XCTAssertNotNil([task navigationRuleForTriggerStepIdentifier:ORKAudioTooLoudStepIdentifier]);
+}
+
+- (void)testAudioTask_NoSoundCheck {
+    
+    ORKNavigableOrderedTask *task = [ORKOrderedTask audioTaskWithIdentifier:@"audio" intendedUseDescription:nil speechInstruction:nil shortSpeechInstruction:nil duration:20 recordingSettings:nil checkAudioLevel:NO options:0];
+    
+    NSArray *expectedStepIdentifiers = @[ORKInstruction0StepIdentifier,
+                                         ORKInstruction1StepIdentifier,
+                                         ORKCountdownStepIdentifier,
+                                         ORKAudioStepIdentifier,
+                                         ORKConclusionStepIdentifier];
+    NSArray *stepIdentifiers = [task.steps valueForKey:@"identifier"];
+    XCTAssertEqual(stepIdentifiers.count, expectedStepIdentifiers.count);
+    XCTAssertEqualObjects(stepIdentifiers, expectedStepIdentifiers);
+    XCTAssertEqual(task.stepNavigationRules.count, 0);
+}
+
 @end
 
 @implementation MethodObject

--- a/Testing/ORKTest/ORKTest/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTest/ORKESerialization.m
@@ -351,6 +351,16 @@ ret =
          },(@{
               PROPERTY(destinationStepIdentifier, NSString, NSObject, NO, nil, nil),
               })),
+   ENTRY(ORKAudioLevelNavigationRule,
+         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
+             ORKAudioLevelNavigationRule *rule = [[ORKAudioLevelNavigationRule alloc] initWithAudioLevelStepIdentifier:GETPROP(dict, audioLevelStepIdentifier)                                                                                             destinationStepIdentifier:GETPROP(dict, destinationStepIdentifier)
+                                                                                                     recordingSettings:GETPROP(dict, recordingSettings)];
+             return rule;
+         },(@{
+              PROPERTY(audioLevelStepIdentifier, NSString, NSObject, NO, nil, nil),
+              PROPERTY(destinationStepIdentifier, NSString, NSObject, NO, nil, nil),
+              PROPERTY(recordingSettings, NSDictionary, NSObject, NO, nil, nil),
+              })),
    ENTRY(ORKOrderedTask,
          ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
              ORKOrderedTask *task = [[ORKOrderedTask alloc] initWithIdentifier:GETPROP(dict, identifier)

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -85,7 +85,6 @@ enum TaskListRow: Int, CustomStringConvertible {
     case Passcode
     
     case Audio
-    case AudioWithSoundCheck
     case Fitness
     case HolePegTest
     case PSAT
@@ -144,7 +143,6 @@ enum TaskListRow: Int, CustomStringConvertible {
             TaskListRowSection(title: "Active Tasks", rows:
                 [
                     .Audio,
-                    .AudioWithSoundCheck,
                     .Fitness,
                     .HolePegTest,
                     .PSAT,
@@ -230,9 +228,6 @@ enum TaskListRow: Int, CustomStringConvertible {
             
         case .Audio:
             return NSLocalizedString("Audio", comment: "")
-            
-        case .AudioWithSoundCheck:
-            return NSLocalizedString("Audio With Sound Check", comment: "")
             
         case .Fitness:
             return NSLocalizedString("Fitness Check", comment: "")
@@ -483,9 +478,6 @@ enum TaskListRow: Int, CustomStringConvertible {
         case .Audio:
             return audioTask
             
-        case .AudioWithSoundCheck:
-            return audioWithSoundCheckTask
-
         case .Fitness:
             return fitnessTask
             
@@ -1123,14 +1115,8 @@ enum TaskListRow: Int, CustomStringConvertible {
     
     /// This task presents the Audio pre-defined active task.
     private var audioTask: ORKTask {
-        return ORKOrderedTask.audioTaskWithIdentifier(String(Identifier.AudioTask), intendedUseDescription: exampleDescription, speechInstruction: exampleSpeechInstruction, shortSpeechInstruction: exampleSpeechInstruction, duration: 20, recordingSettings: nil, options: [])
+        return ORKOrderedTask.audioTaskWithIdentifier(String(Identifier.AudioTask), intendedUseDescription: exampleDescription, speechInstruction: exampleSpeechInstruction, shortSpeechInstruction: exampleSpeechInstruction, duration: 20, recordingSettings: nil, checkAudioLevel: true, options: [])
     }
-    
-    /// This task presents the Audio pre-defined active task.
-    private var audioWithSoundCheckTask: ORKTask {
-        return ORKOrderedTask.audioLevelNavigableTaskWithIdentifier(String(Identifier.AudioTask), intendedUseDescription: exampleDescription, speechInstruction: exampleSpeechInstruction, shortSpeechInstruction: exampleSpeechInstruction, duration: 20, recordingSettings: nil, options: [])
-    }
-
 
     /**
         This task presents the Fitness pre-defined active task. For this example,

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -85,6 +85,7 @@ enum TaskListRow: Int, CustomStringConvertible {
     case Passcode
     
     case Audio
+    case AudioWithSoundCheck
     case Fitness
     case HolePegTest
     case PSAT
@@ -143,6 +144,7 @@ enum TaskListRow: Int, CustomStringConvertible {
             TaskListRowSection(title: "Active Tasks", rows:
                 [
                     .Audio,
+                    .AudioWithSoundCheck,
                     .Fitness,
                     .HolePegTest,
                     .PSAT,
@@ -228,6 +230,9 @@ enum TaskListRow: Int, CustomStringConvertible {
             
         case .Audio:
             return NSLocalizedString("Audio", comment: "")
+            
+        case .AudioWithSoundCheck:
+            return NSLocalizedString("Audio With Sound Check", comment: "")
             
         case .Fitness:
             return NSLocalizedString("Fitness Check", comment: "")
@@ -477,6 +482,9 @@ enum TaskListRow: Int, CustomStringConvertible {
             
         case .Audio:
             return audioTask
+            
+        case .AudioWithSoundCheck:
+            return audioWithSoundCheckTask
 
         case .Fitness:
             return fitnessTask
@@ -1117,6 +1125,12 @@ enum TaskListRow: Int, CustomStringConvertible {
     private var audioTask: ORKTask {
         return ORKOrderedTask.audioTaskWithIdentifier(String(Identifier.AudioTask), intendedUseDescription: exampleDescription, speechInstruction: exampleSpeechInstruction, shortSpeechInstruction: exampleSpeechInstruction, duration: 20, recordingSettings: nil, options: [])
     }
+    
+    /// This task presents the Audio pre-defined active task.
+    private var audioWithSoundCheckTask: ORKTask {
+        return ORKOrderedTask.audioLevelNavigableTaskWithIdentifier(String(Identifier.AudioTask), intendedUseDescription: exampleDescription, speechInstruction: exampleSpeechInstruction, shortSpeechInstruction: exampleSpeechInstruction, duration: 20, recordingSettings: nil, options: [])
+    }
+
 
     /**
         This task presents the Fitness pre-defined active task. For this example,


### PR DESCRIPTION
During user feedback and via researcher analysis, we were finding that the ambient noise in a room where the participant was attempting to record their voice was too loud. We added a navigation rule to the task to check for ambient noise level and direct the participant to move to a quieter location if necessary.