### PR TITLE
Changes to allow for more flexible onboarding UI

### DIFF
--- a/ResearchKit/Consent/ORKConsentReviewStep.h
+++ b/ResearchKit/Consent/ORKConsentReviewStep.h
@@ -31,7 +31,6 @@
 
 #import <ResearchKit/ResearchKit.h>
 
-
 NS_ASSUME_NONNULL_BEGIN
 
 @class ORKConsentDocument;
@@ -59,7 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
  present the task in a task view controller.
  */
 ORK_CLASS_AVAILABLE
-@interface ORKConsentReviewStep : ORKStep
+@interface ORKConsentReviewStep : ORKFormStep
 
 /// @name Initialization.
 

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -64,6 +64,7 @@ typedef NS_ENUM(NSInteger, ORKConsentReviewPhase) {
     NSString *_signatureLast;
     UIImage *_signatureImage;
     BOOL _documentReviewed;
+    NSArray *_formResults;
     
     NSUInteger _currentPageIndex;
 }
@@ -99,7 +100,8 @@ typedef NS_ENUM(NSInteger, ORKConsentReviewPhase) {
     if (step.consentDocument) {
         [indices addObject:@(ORKConsentReviewPhaseReviewDocument)];
     }
-    if (step.signature.requiresName) {
+    if (step.signature.requiresName || (step.formItems.count > 0)) {
+        // Add the form if either the name is required OR there are custom form items be be included
         [indices addObject:@(ORKConsentReviewPhaseName)];
     }
     if (step.signature.requiresSignatureImage) {
@@ -165,27 +167,41 @@ static NSString *const _FamilyNameIdentifier = @"family";
                                                              text:self.step.text];
     formStep.useSurveyMode = NO;
     
-    ORKTextAnswerFormat *nameAnswerFormat = [ORKTextAnswerFormat textAnswerFormat];
-    nameAnswerFormat.multipleLines = NO;
-    nameAnswerFormat.autocapitalizationType = UITextAutocapitalizationTypeWords;
-    nameAnswerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
-    nameAnswerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
-    ORKFormItem *givenNameFormItem = [[ORKFormItem alloc] initWithIdentifier:_GivenNameIdentifier
-                                                              text:ORKLocalizedString(@"CONSENT_NAME_GIVEN", nil)
-                                                      answerFormat:nameAnswerFormat];
-    givenNameFormItem.placeholder = ORKLocalizedString(@"CONSENT_NAME_PLACEHOLDER", nil);
+    ORKConsentReviewStep *step = [self consentReviewStep];
+    NSMutableArray *formItems = [NSMutableArray new];
     
-    ORKFormItem *familyNameFormItem = [[ORKFormItem alloc] initWithIdentifier:_FamilyNameIdentifier
-                                                             text:ORKLocalizedString(@"CONSENT_NAME_FAMILY", nil)
-                                                     answerFormat:nameAnswerFormat];
-    familyNameFormItem.placeholder = ORKLocalizedString(@"CONSENT_NAME_PLACEHOLDER", nil);
+    // If the signature requires adding the name, then create form items for given and family name
+    if (step.signature.requiresName) {
+        
+        ORKTextAnswerFormat *nameAnswerFormat = [ORKTextAnswerFormat textAnswerFormat];
+        nameAnswerFormat.multipleLines = NO;
+        nameAnswerFormat.autocapitalizationType = UITextAutocapitalizationTypeWords;
+        nameAnswerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
+        nameAnswerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+        ORKFormItem *givenNameFormItem = [[ORKFormItem alloc] initWithIdentifier:_GivenNameIdentifier
+                                                                  text:ORKLocalizedString(@"CONSENT_NAME_GIVEN", nil)
+                                                          answerFormat:nameAnswerFormat];
+        givenNameFormItem.placeholder = ORKLocalizedString(@"CONSENT_NAME_PLACEHOLDER", nil);
+        
+        ORKFormItem *familyNameFormItem = [[ORKFormItem alloc] initWithIdentifier:_FamilyNameIdentifier
+                                                                 text:ORKLocalizedString(@"CONSENT_NAME_FAMILY", nil)
+                                                         answerFormat:nameAnswerFormat];
+        familyNameFormItem.placeholder = ORKLocalizedString(@"CONSENT_NAME_PLACEHOLDER", nil);
+        
+        givenNameFormItem.optional = NO;
+        familyNameFormItem.optional = NO;
     
-    givenNameFormItem.optional = NO;
-    familyNameFormItem.optional = NO;
+        if (ORKCurrentLocalePresentsFamilyNameFirst()) {
+            [formItems addObjectsFromArray:@[familyNameFormItem, givenNameFormItem]];
+        }
+        else {
+            [formItems addObjectsFromArray:@[givenNameFormItem, familyNameFormItem]];
+        }
+    }
     
-    NSArray *formItems = @[givenNameFormItem, familyNameFormItem];
-    if (ORKCurrentLocalePresentsFamilyNameFirst()) {
-        formItems = @[familyNameFormItem, givenNameFormItem];
+    // If the step has any form items defined on it, then show them in addition to or in replacement of the name form items
+    if (step.formItems.count > 0) {
+        [formItems addObjectsFromArray:step.formItems];
     }
     
     [formStep setFormItems:formItems];
@@ -301,7 +317,13 @@ static NSString *const _FamilyNameIdentifier = @"family";
     result.consented = _documentReviewed;
     result.startDate = parentResult.startDate;
     result.endDate = parentResult.endDate;
-    parentResult.results = @[result];
+    
+    NSArray *results = @[result];
+    if (_formResults.count > 0) {
+        results = [results arrayByAddingObjectsFromArray:_formResults];
+    }
+    
+    parentResult.results = results;
     
     return parentResult;
 }
@@ -389,6 +411,7 @@ static NSString *const _FamilyNameIdentifier = @"family";
         _signatureFirst = (NSString *)fnr.textAnswer;
         ORKTextQuestionResult *lnr = (ORKTextQuestionResult *)[result resultForIdentifier:_FamilyNameIdentifier];
         _signatureLast = (NSString *)lnr.textAnswer;
+        _formResults = [result.results copy];
         [self notifyDelegateOnResultChange];
     }
 }
@@ -431,6 +454,7 @@ static NSString *const _FamilyNameIdentifier = @"family";
     _signatureLast = nil;
     _signatureImage = nil;
     _documentReviewed = NO;
+    _formResults = nil;
     [self notifyDelegateOnResultChange];
     
     [self goForward];
@@ -455,6 +479,8 @@ static NSString *const _ORKSignatureLastRestoreKey = @"signatureLast";
 static NSString *const _ORKSignatureImageRestoreKey = @"signatureImage";
 static NSString *const _ORKDocumentReviewedRestoreKey = @"documentReviewed";
 static NSString *const _ORKCurrentPageIndexRestoreKey = @"currentPageIndex";
+static NSString *const _ORKFormResultsKey = @"formResults";
+static NSString *const _ORKPageIndicesKey = @"pageIndices";
 
 - (void)encodeRestorableStateWithCoder:(NSCoder *)coder {
     [super encodeRestorableStateWithCoder:coder];
@@ -465,6 +491,8 @@ static NSString *const _ORKCurrentPageIndexRestoreKey = @"currentPageIndex";
     [coder encodeObject:_signatureImage forKey:_ORKSignatureImageRestoreKey];
     [coder encodeBool:_documentReviewed forKey:_ORKDocumentReviewedRestoreKey];
     [coder encodeInteger:_currentPageIndex forKey:_ORKCurrentPageIndexRestoreKey];
+    [coder encodeObject:_formResults forKey:_ORKFormResultsKey];
+    [coder encodeObject:_pageIndices forKey:_ORKPageIndicesKey];
 }
 
 - (void)decodeRestorableStateWithCoder:(NSCoder *)coder {
@@ -478,6 +506,8 @@ static NSString *const _ORKCurrentPageIndexRestoreKey = @"currentPageIndex";
     _signatureImage = [coder decodeObjectOfClass:[NSString class] forKey:_ORKSignatureImageRestoreKey];
     _documentReviewed = [coder decodeBoolForKey:_ORKDocumentReviewedRestoreKey];
     _currentPageIndex = [coder decodeIntegerForKey:_ORKCurrentPageIndexRestoreKey];
+    _pageIndices = [[coder decodeObjectOfClass:[NSArray class] forKey:_ORKPageIndicesKey] mutableCopy];
+    _formResults = [coder decodeObjectOfClass:[NSArray class] forKey:_ORKFormResultsKey];
     
     [self goToPage:_currentPageIndex animated:NO];
 }


### PR DESCRIPTION
In some cases, given name and family name are not appropriate information for a consent document. Our consent process sometimes takes a full name. In other countries there are legal constraints requiring that the user be de-indentified.  In many cases, the user can only consent if they are over 18. Making this step inherit from `ORKFormStep` allows greater flexibility within the consent process without having to hack in work-arounds. 