### PR TITLE
Allow steps to instantiate the view controller

### DIFF
--- a/ResearchKit/Common/ORKStep.h
+++ b/ResearchKit/Common/ORKStep.h
@@ -37,6 +37,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 ORK_EXTERN NSString *const ORKNullStepIdentifier ORK_AVAILABLE_DECL;
 
+@class ORKStepViewController;
+@class ORKResult;
+
 @protocol ORKTask;
 
 /**
@@ -178,6 +181,18 @@ ORK_CLASS_AVAILABLE
  properties, and must call super.
  */
 - (void)validateParameters;
+
+/**
+ Instantiates a step view controller for this class.
+ 
+ This method is called when a step is about to be presented. The default implementation returns
+ a view controller that is appropriate to this step. 
+ 
+ @param result    The result associated with this step
+ 
+ @return A newly initialized step view controller.
+ */
+- (ORKStepViewController *)instantiateStepViewControllerWithResult:(ORKResult *)result;
 
 @end
 

--- a/ResearchKit/Common/ORKStep.h
+++ b/ResearchKit/Common/ORKStep.h
@@ -183,6 +183,12 @@ ORK_CLASS_AVAILABLE
 - (void)validateParameters;
 
 /**
+ Returns the class that the task view controller should instantiate to display
+ this step.
+ */
+- (Class)stepViewControllerClass;
+
+/**
  Instantiates a step view controller for this class.
  
  This method is called when a step is about to be presented. The default implementation returns

--- a/ResearchKit/Common/ORKStep.h
+++ b/ResearchKit/Common/ORKStep.h
@@ -192,7 +192,12 @@ ORK_CLASS_AVAILABLE
  Instantiates a step view controller for this class.
  
  This method is called when a step is about to be presented. The default implementation returns
- a view controller that is appropriate to this step. 
+ a view controller that is appropriate to this step by allocating an instance of `ORKStepViewController`
+ using the `-stepViewControllerClass` method and initializing that instance by calling `initWithIdentifier:result:`
+ on the provided `ORKStepViewController` class instance.
+ 
+ Override this method if you need to customize the behavior before presenting the step or if 
+ the view controller is presented using a nib or storyboard.
  
  @param result    The result associated with this step
  

--- a/ResearchKit/Common/ORKStep.m
+++ b/ResearchKit/Common/ORKStep.m
@@ -34,6 +34,7 @@
 #import "ORKStep_Private.h"
 #import "ORKStepViewController.h"
 #import "ORKOrderedTask.h"
+#import "ORKStepViewController_Internal.h"
 
 
 @implementation ORKStep
@@ -57,6 +58,18 @@
 
 - (Class)stepViewControllerClass {
     return [[self class] stepViewControllerClass];
+}
+
+- (ORKStepViewController *)instantiateStepViewControllerWithResult:(ORKResult *)result {
+    Class stepViewControllerClass = [self stepViewControllerClass];
+    
+    ORKStepViewController *stepViewController = [[stepViewControllerClass alloc] initWithStep:self result:result];
+    
+    // Set the restoration info using the given class
+    stepViewController.restorationIdentifier = self.identifier;
+    stepViewController.restorationClass = stepViewControllerClass;
+    
+    return stepViewController;
 }
 
 - (instancetype)copyWithIdentifier:(NSString *)identifier {

--- a/ResearchKit/Common/ORKStepViewController.h
+++ b/ResearchKit/Common/ORKStepViewController.h
@@ -193,6 +193,16 @@ ORK_CLASS_AVAILABLE
 - (instancetype)initWithStep:(nullable ORKStep *)step;
 
 /**
+ Returns a new step view controller for the specified step.
+ 
+ @param step    The step to be presented.
+ @param result  The current step result for this step.
+ 
+ @return A newly initialized step view controller.
+ */
+- (instancetype)initWithStep:(ORKStep *)step result:(ORKResult *)result;
+
+/**
  The step presented by the step view controller.
  
  If you use a storyboard to initialize the step view controller, `initWithStep:` isn't called,

--- a/ResearchKit/Common/ORKStepViewController_Internal.h
+++ b/ResearchKit/Common/ORKStepViewController_Internal.h
@@ -68,8 +68,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)notifyDelegateOnResultChange;
 
-- (instancetype)initWithStep:(ORKStep *)step result:(ORKResult *)result;
-
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil NS_DESIGNATED_INITIALIZER;
 
 - (void)showValidityAlertWithMessage:(NSString *)text;

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1038,22 +1038,16 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     ORKStepViewController *stepViewController = nil;
     
     if ([self.delegate respondsToSelector:@selector(taskViewController:viewControllerForStep:)]) {
+        // NOTE: While the delegate does not have direct access to the defaultResultSource,
+        // it is assumed that it can set results as needed on the custom implementation of an
+        // ORKStepViewController that it returns.
         stepViewController = [self.delegate taskViewController:self viewControllerForStep:step];
     }
     
+    // If the delegate did not return a step view controller then instantiate one
     if (!stepViewController) {
-        Class stepViewControllerClass = step.stepViewControllerClass;
         
-        ORKStepResult *result = nil;
-        result = _managedResults[step.identifier];
-        if (!result ) {
-            result = [self.defaultResultSource stepResultForStepIdentifier:step.identifier];
-        }
-        
-        if (!result) {
-            result = [[ORKStepResult alloc] initWithIdentifier:step.identifier];
-        }
-        
+        // Special-case the ORKReviewStep
         if ([step isKindOfClass:[ORKReviewStep class]]) {
             ORKReviewStep *reviewStep = (ORKReviewStep *)step;
             NSArray *steps = [self stepsForReviewStep:reviewStep];
@@ -1061,15 +1055,44 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
             stepViewController = [[ORKReviewStepViewController alloc] initWithReviewStep:(ORKReviewStep *) step steps:steps resultSource:resultSource];
             ORKReviewStepViewController *reviewStepViewController = (ORKReviewStepViewController *) stepViewController;
             reviewStepViewController.reviewDelegate = self;
-        } else {
-            stepViewController = [[stepViewControllerClass alloc] initWithStep:step result:result];
         }
-        
-        stepViewController.restorationIdentifier = step.identifier;
-        stepViewController.restorationClass = stepViewControllerClass;
-        
-    } else if (![stepViewController isKindOfClass:[ORKStepViewController class]]) {
+        else {
+            
+            // Get the step result associated with this step
+            ORKStepResult *result = nil;
+            result = _managedResults[step.identifier];
+            if (!result ) {
+                result = [_defaultResultSource stepResultForStepIdentifier:step.identifier];
+            }
+            
+            if (!result) {
+                result = [[ORKStepResult alloc] initWithIdentifier:step.identifier];
+            }
+            
+            // Allow the step to instantiate the view controller. This will allow either the default
+            // implementation using an override of the internal method `-stepViewControllerClass` or
+            // allow for storyboard implementations.
+            stepViewController = [step instantiateStepViewControllerWithResult:result];
+        }
+    }
+    
+    // Throw an exception if the created step view controller is not a subclass of ORKStepViewController
+    ORKThrowInvalidArgumentExceptionIfNil(stepViewController);
+    if (![stepViewController isKindOfClass:[ORKStepViewController class]]) {
         @throw [NSException exceptionWithName:NSGenericException reason:[NSString stringWithFormat:@"View controller should be of class %@", [ORKStepViewController class]] userInfo:@{@"viewController": stepViewController}];
+    }
+    
+    // If this is a restorable task view controller, check that the restoration identifier and class
+    // are set on the step result. If not, do so here. This gives the instantiator the opportunity to
+    // set this value, but ensures that it is set to the default if the instantiator does not do so.
+    if ([self.delegate respondsToSelector:@selector(taskViewControllerSupportsSaveAndRestore:)] &&
+        [self.delegate taskViewControllerSupportsSaveAndRestore:self]){
+        if (stepViewController.restorationIdentifier == nil) {
+            stepViewController.restorationIdentifier = step.identifier;
+        }
+        if (stepViewController.restorationClass == nil) {
+            stepViewController.restorationClass = [stepViewController class];
+        }
     }
     
     stepViewController.outputDirectory = self.outputDirectory;

--- a/ResearchKitTests/ORKStepTests.m
+++ b/ResearchKitTests/ORKStepTests.m
@@ -38,10 +38,12 @@
 
 @end
 
-@interface TestStep : ORKStep
+@interface DragonPokerStep : ORKStep
+@property (nonatomic) NSDate *playDate;
 @end
 
-@interface TestStepViewController : ORKStepViewController
+@interface DragonPokerStepViewController : ORKStepViewController
+@property (nonatomic) BOOL shouldShowCancelButton;
 @end
 
 
@@ -117,7 +119,8 @@
 }
 
 - (void)testInstantiateStepViewControllerWithResult {
-    TestStep *step = [[TestStep alloc] initWithIdentifier:@"test"];
+    DragonPokerStep *step = [[DragonPokerStep alloc] initWithIdentifier:@"test"];
+    step.playDate = [NSDate date];
     ORKStepResult *result = [[ORKStepResult alloc] initWithIdentifier:step.identifier];
     ORKStepViewController *stepViewController = [step instantiateStepViewControllerWithResult:result];
     XCTAssertNotNil(stepViewController);
@@ -125,14 +128,28 @@
 
 @end
 
-@implementation TestStep
+@implementation DragonPokerStep
 
+/// Example implementation of an override of the class method
+/// In this example, only show the cancel button on Tuesdays
 - (ORKStepViewController *)instantiateStepViewControllerWithResult:(ORKResult *)result {
-    // Example implementation of an override of the class method
-    return [[TestStepViewController alloc] initWithStep:self];
+    DragonPokerStepViewController *viewController = [[DragonPokerStepViewController alloc] initWithStep:self result:result];
+    NSDateComponents *components = [[NSCalendar currentCalendar] components:NSCalendarUnitWeekday fromDate:self.playDate];
+    viewController.shouldShowCancelButton = components.weekday == 2;
+    return viewController;
 }
 
 @end
 
-@implementation TestStepViewController
+@implementation DragonPokerStepViewController
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    
+    // Hide the cancel button if it should not be shown.
+    if (!self.shouldShowCancelButton) {
+        self.cancelButtonItem = [[UIBarButtonItem alloc] initWithCustomView:[[UIView alloc] initWithFrame:CGRectZero]];
+    }
+}
+
 @end

--- a/ResearchKitTests/ORKStepTests.m
+++ b/ResearchKitTests/ORKStepTests.m
@@ -38,14 +38,6 @@
 
 @end
 
-@interface DragonPokerStep : ORKStep
-@property (nonatomic) NSDate *playDate;
-@end
-
-@interface DragonPokerStepViewController : ORKStepViewController
-@property (nonatomic) BOOL shouldShowCancelButton;
-@end
-
 
 @implementation ORKStepTests
 
@@ -118,38 +110,6 @@
     XCTAssertThrows([validReactionTimeStep validateParameters]);
 }
 
-- (void)testInstantiateStepViewControllerWithResult {
-    DragonPokerStep *step = [[DragonPokerStep alloc] initWithIdentifier:@"test"];
-    step.playDate = [NSDate date];
-    ORKStepResult *result = [[ORKStepResult alloc] initWithIdentifier:step.identifier];
-    ORKStepViewController *stepViewController = [step instantiateStepViewControllerWithResult:result];
-    XCTAssertNotNil(stepViewController);
-}
-
 @end
 
-@implementation DragonPokerStep
 
-/// Example implementation of an override of the class method
-/// In this example, only show the cancel button on Tuesdays
-- (ORKStepViewController *)instantiateStepViewControllerWithResult:(ORKResult *)result {
-    DragonPokerStepViewController *viewController = [[DragonPokerStepViewController alloc] initWithStep:self result:result];
-    NSDateComponents *components = [[NSCalendar currentCalendar] components:NSCalendarUnitWeekday fromDate:self.playDate];
-    viewController.shouldShowCancelButton = components.weekday == 2;
-    return viewController;
-}
-
-@end
-
-@implementation DragonPokerStepViewController
-
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-    
-    // Hide the cancel button if it should not be shown.
-    if (!self.shouldShowCancelButton) {
-        self.cancelButtonItem = [[UIBarButtonItem alloc] initWithCustomView:[[UIView alloc] initWithFrame:CGRectZero]];
-    }
-}
-
-@end

--- a/ResearchKitTests/ORKStepTests.m
+++ b/ResearchKitTests/ORKStepTests.m
@@ -38,6 +38,12 @@
 
 @end
 
+@interface TestStep : ORKStep
+@end
+
+@interface TestStepViewController : ORKStepViewController
+@end
+
 
 @implementation ORKStepTests
 
@@ -110,4 +116,23 @@
     XCTAssertThrows([validReactionTimeStep validateParameters]);
 }
 
+- (void)testInstantiateStepViewControllerWithResult {
+    TestStep *step = [[TestStep alloc] initWithIdentifier:@"test"];
+    ORKStepResult *result = [[ORKStepResult alloc] initWithIdentifier:step.identifier];
+    ORKStepViewController *stepViewController = [step instantiateStepViewControllerWithResult:result];
+    XCTAssertNotNil(stepViewController);
+}
+
+@end
+
+@implementation TestStep
+
+- (ORKStepViewController *)instantiateStepViewControllerWithResult:(ORKResult *)result {
+    // Example implementation of an override of the class method
+    return [[TestStepViewController alloc] initWithStep:self];
+}
+
+@end
+
+@implementation TestStepViewController
 @end

--- a/Testing/ORKTest/ORKTest.xcodeproj/project.pbxproj
+++ b/Testing/ORKTest/ORKTest.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		FFF010721D21F1EA0054B430 /* ContinueButtonExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FFF0106F1D21F1EA0054B430 /* ContinueButtonExampleViewController.m */; };
 		FFF010731D21F1EA0054B430 /* FooterView.m in Sources */ = {isa = PBXBuildFile; fileRef = FFF010711D21F1EA0054B430 /* FooterView.m */; };
 		FFF010751D21F2030054B430 /* ContinueButtonExample.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FFF010741D21F2030054B430 /* ContinueButtonExample.storyboard */; };
+		FF5CA60E1D272CF4001660A3 /* DragonPokerStep.m in Sources */ = {isa = PBXBuildFile; fileRef = FF5CA60D1D272CF4001660A3 /* DragonPokerStep.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -134,6 +135,8 @@
 		FFF010701D21F1EA0054B430 /* FooterView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FooterView.h; sourceTree = "<group>"; };
 		FFF010711D21F1EA0054B430 /* FooterView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FooterView.m; sourceTree = "<group>"; };
 		FFF010741D21F2030054B430 /* ContinueButtonExample.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = ContinueButtonExample.storyboard; path = "ORKTest/Supporting Files/ContinueButtonExample.storyboard"; sourceTree = SOURCE_ROOT; };
+		FF5CA60C1D272CF4001660A3 /* DragonPokerStep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DragonPokerStep.h; sourceTree = "<group>"; };
+		FF5CA60D1D272CF4001660A3 /* DragonPokerStep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DragonPokerStep.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -232,6 +235,8 @@
 				FFF010711D21F1EA0054B430 /* FooterView.m */,
 				86717ADC1AC0C53800AC2A23 /* DynamicTask.h */,
 				86717ADD1AC0C53800AC2A23 /* DynamicTask.m */,
+				FF5CA60C1D272CF4001660A3 /* DragonPokerStep.h */,
+				FF5CA60D1D272CF4001660A3 /* DragonPokerStep.m */,
 			);
 			name = CustomizationExamples;
 			sourceTree = "<group>";
@@ -434,6 +439,7 @@
 				86717AE81AC0C53800AC2A23 /* DynamicTask.m in Sources */,
 				BC9A27181B81743900BDA84D /* ChartDataSources.swift in Sources */,
 				BC9A27191B81743900BDA84D /* ChartListViewController.swift in Sources */,
+				FF5CA60E1D272CF4001660A3 /* DragonPokerStep.m in Sources */,
 				BC9A271A1B81743900BDA84D /* ChartTableViewCells.swift in Sources */,
 				BCB0809E1B83E9B300A3F400 /* TaskFactory.swift in Sources */,
 				FFF010731D21F1EA0054B430 /* FooterView.m in Sources */,

--- a/Testing/ORKTest/ORKTest/DragonPokerStep.h
+++ b/Testing/ORKTest/ORKTest/DragonPokerStep.h
@@ -1,0 +1,39 @@
+/*
+ Copyright (c) 2016, Sage Bionetworks
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <ResearchKit/ResearchKit.h>
+
+/// Example implementation of an override of the class method -instantiateStepViewControllerWithResult:
+/// In this example, only show the cancel button on Tuesdays
+
+@interface DragonPokerStep : ORKFormStep
+
+@end
+

--- a/Testing/ORKTest/ORKTest/DragonPokerStep.m
+++ b/Testing/ORKTest/ORKTest/DragonPokerStep.m
@@ -1,0 +1,85 @@
+/*
+ Copyright (c) 2016, Sage Bionetworks
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "DragonPokerStep.h"
+
+@interface DragonPokerStep ()
+
+@property (nonatomic) NSDate *playDate;
+
+@end
+
+@interface DragonPokerStepViewController : ORKFormStepViewController
+
+@property (nonatomic) BOOL shouldShowCancelButton;
+
+@end
+
+@implementation DragonPokerStep
+
+- (instancetype)initWithIdentifier:(NSString *)identifier {
+    self = [super initWithIdentifier:identifier];
+    if (self) {
+        ORKFormItem *formItem = [[ORKFormItem alloc] initWithIdentifier:@"question1" text:@"Are you tall?" answerFormat:[ORKAnswerFormat booleanAnswerFormat]];
+        self.formItems = @[formItem];
+    }
+    return self;
+}
+
+- (NSDate *)playDate {
+    if (_playDate == nil) {
+        _playDate = [NSDate date];
+    }
+    return _playDate;
+}
+
+- (ORKStepViewController *)instantiateStepViewControllerWithResult:(ORKResult *)result {
+    
+    DragonPokerStepViewController *viewController = [[DragonPokerStepViewController alloc] initWithStep:self result:result];
+    NSDateComponents *components = [[NSCalendar currentCalendar] components:NSCalendarUnitWeekday fromDate:self.playDate];
+    viewController.shouldShowCancelButton = components.weekday == 2;
+    
+    return viewController;
+}
+
+@end
+
+@implementation DragonPokerStepViewController
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    
+    // Hide the cancel button if it should not be shown.
+    if (!self.shouldShowCancelButton) {
+        self.cancelButtonItem = [[UIBarButtonItem alloc] initWithCustomView:[[UIView alloc] initWithFrame:CGRectZero]];
+    }
+}
+
+@end

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -466,6 +466,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                                             shortSpeechInstruction:nil
                                                           duration:10
                                                  recordingSettings:nil
+                                                   checkAudioLevel:YES
                                                            options:(ORKPredefinedTaskOption)0];
         return task;
     } else if ([identifier isEqualToString:ToneAudiometryTaskIdentifier]) {

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -37,6 +37,7 @@
 #import "DynamicTask.h"
 #import "AppDelegate.h"
 #import "ORKTest-Swift.h"
+#import "DragonPokerStep.h"
 
 
 #define DefineStringKey(x) static NSString *const x = @#x
@@ -52,6 +53,7 @@ DefineStringKey(VerificationTaskIdentifier);
 DefineStringKey(DatePickingTaskIdentifier);
 DefineStringKey(ImageCaptureTaskIdentifier);
 DefineStringKey(ImageChoicesTaskIdentifier);
+DefineStringKey(InstantiateCustomVCTaskIdentifier);
 DefineStringKey(LocationTaskIdentifier);
 DefineStringKey(ScalesTaskIdentifier);
 DefineStringKey(MiniFormTaskIdentifier);
@@ -372,6 +374,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                            @"Step Will Disappear",
                            @"Confirmation Form Item",
                            @"Continue Button",
+                           @"Instantiate Custom VC",
                            ],
                        ];
 }
@@ -570,14 +573,16 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         return [self makeEmbeddedReviewTask];
     } else if ([identifier isEqualToString:StandaloneReviewTaskIdentifier]) {
         return [self makeStandaloneReviewTask];
-    } if ([identifier isEqualToString:WaitTaskIdentifier]) {
+    } else if ([identifier isEqualToString:WaitTaskIdentifier]) {
         return [self makeWaitingTask];
-    }else if ([identifier isEqualToString:LocationTaskIdentifier]) {
+    } else if ([identifier isEqualToString:LocationTaskIdentifier]) {
         return [self makeLocationTask];
     } else if ([identifier isEqualToString:StepWillDisappearTaskIdentifier]) {
         return [self makeStepWillDisappearTask];
     } else if ([identifier isEqualToString:ConfirmationFormTaskIdentifier]) {
         return [self makeConfirmationFormTask];
+    } else if ([identifier isEqualToString:InstantiateCustomVCTaskIdentifier]) {
+        return [self makeInstantiateCustomVCTask];
     }
 
     return nil;
@@ -3855,6 +3860,25 @@ stepViewControllerWillAppear:(ORKStepViewController *)stepViewController {
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"ContinueButtonExample" bundle:nil];
     UIViewController *vc = [storyboard instantiateInitialViewController];
     [self presentViewController:vc animated:YES completion:nil];
+}
+
+#pragma mark - Instantiate Custom Step View Controller Example
+
+- (IBAction)instantiateCustomVcButtonTapped:(id)sender {
+    [self beginTaskWithIdentifier:InstantiateCustomVCTaskIdentifier];
+}
+
+- (ORKOrderedTask *)makeInstantiateCustomVCTask {
+    
+    ORKInstructionStep *step1 = [[ORKInstructionStep alloc] initWithIdentifier:@"locationTask.step1"];
+    step1.title = @"Instantiate Custom View Controller";
+    step1.text = @"The next step uses a custom subclass of an ORKFormStepViewController.";
+    
+    DragonPokerStep *dragonStep = [[DragonPokerStep alloc] initWithIdentifier:@"dragonStep"];
+    
+    ORKStep *lastStep = [[ORKCompletionStep alloc] initWithIdentifier:@"done"];
+    
+    return [[ORKOrderedTask alloc] initWithIdentifier:InstantiateCustomVCTaskIdentifier steps:@[step1, dragonStep, lastStep]];
 }
 
 @end


### PR DESCRIPTION
`- (Class)stepViewControllerClass` is defined as an internal method and is not exposed in the public API. This implementation allows for subclasses of ORKStep to return a view controller that is appropriate to their design.

In response to the explanation given in https://github.com/ResearchKit/ResearchKit/pull/719 for closing that pull request: Overriding a method that is marked as internal is brittle (internal methods cannot be assumed to remain and are not marked as deprecated when they might go away with a future release). Additionally, doing so with a Swift implementation will fail when the app is archived.