### PR TITLE
Fix ORKHealthQuantityTypeRecorder to allow for iOS 10 and iOS 8 support

### DIFF
--- a/ResearchKit/ActiveTasks/ORKHealthQuantityTypeRecorder.m
+++ b/ResearchKit/ActiveTasks/ORKHealthQuantityTypeRecorder.m
@@ -43,6 +43,8 @@
     HKHealthStore *_healthStore;
     NSPredicate *_samplePredicate;
     HKObserverQuery *_observerQuery;
+    /// Either the HKQueryAnchor object *or* NSUInteger value are tracked since the initializer for
+    /// iOS 8 and iOS 9 use different objects. Only one will actually be referenced in the initalizer.
     HKQueryAnchor *_anchor;
     NSUInteger _anchorValue;
     HKQuantitySample *_lastSample;

--- a/ResearchKit/ActiveTasks/ORKHealthQuantityTypeRecorder.m
+++ b/ResearchKit/ActiveTasks/ORKHealthQuantityTypeRecorder.m
@@ -50,9 +50,10 @@
 
 @end
 
+#ifdef __IPHONE_10_0
 /// Add a protocol defining the initializer for iOS 8 apps. This signature was deprecated in iOS 9
 /// and deleted in iOS 10.
-@protocol HKAnchoredObjectQuery_8 <NSObject>
+@interface HKAnchoredObjectQuery (iOS8)
 - (instancetype)initWithType:(HKSampleType *)type
                    predicate:(NSPredicate *)predicate
                       anchor:(NSUInteger)anchor
@@ -62,6 +63,7 @@
                                        NSUInteger newAnchor,
                                        NSError *error))handler NS_DEPRECATED_IOS(8_0, 9_0);
 @end
+#endif
 
 @implementation ORKHealthQuantityTypeRecorder
 
@@ -169,10 +171,11 @@ static const NSInteger _HealthAnchoredQueryLimit = 100;
     }
     else if ([HKAnchoredObjectQuery instancesRespondToSelector:@selector(initWithType:predicate:anchor:limit:completionHandler:)]) {
         
-        anchoredQuery = [(id <HKAnchoredObjectQuery_8>)[HKAnchoredObjectQuery alloc] initWithType:_quantityType
-                                                                                        predicate:_samplePredicate
-                                                                                           anchor:_anchorValue
-                                                                                            limit:_HealthAnchoredQueryLimit completionHandler:
+        anchoredQuery = [[HKAnchoredObjectQuery alloc] initWithType:_quantityType
+                                                          predicate:_samplePredicate
+                                                             anchor:_anchorValue
+                                                              limit:_HealthAnchoredQueryLimit
+                                                  completionHandler:
                          ^(HKAnchoredObjectQuery *query, NSArray<__kindof HKSample *> *results, NSUInteger newAnchor, NSError *error) {
                              handleResults(results, nil, newAnchor, error);
                          }];

--- a/ResearchKit/ActiveTasks/ORKHealthQuantityTypeRecorder.m
+++ b/ResearchKit/ActiveTasks/ORKHealthQuantityTypeRecorder.m
@@ -60,7 +60,7 @@
            completionHandler:(void (^)(HKAnchoredObjectQuery *query,
                                        NSArray<__kindof HKSample *> *results,
                                        NSUInteger newAnchor,
-                                       NSError *error))handler;
+                                       NSError *error))handler NS_DEPRECATED_IOS(8_0, 9_0);
 @end
 
 @implementation ORKHealthQuantityTypeRecorder


### PR DESCRIPTION
This is a fix for https://github.com/ResearchKit/ResearchKit/issues/713

It can be safely pulled into ResearchKit *now* while still targeting iOS 8.

With Xcode 8 and iOS 10, the `init` method used in iOS 8 has been deleted. Future versions of the iOS 10 beta may include this or they may not. This implementation allows for reverse-compatibility to iOS 8 (for apps that require supporting that version) while using the newer `init` method introduced in iOS 9 for both iOS 9 and iOS 10.