### PR TITLE
Expose method for instantiating an answer format for confirmation of another field.

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -1269,6 +1269,18 @@ ORK_CLASS_AVAILABLE
  */
 @property(nonatomic,getter=isSecureTextEntry) BOOL secureTextEntry;
 
+/**
+ Returns an answer format that can be used for confirming a text entry.
+ 
+ This answer format is intended to be used with an `ORKFormStep` in order to confirm a previous 
+ formItem input. Example usage includes a password or participant identifier that is used to 
+ anonymously identify a study participant.
+ 
+ This answer format produces an `ORKBooleanQuestionResult` object.
+ */
+- (ORKAnswerFormat *)confirmationAnswerFormatWithOriginalItemIdentifier:(NSString *)originalItemIdentifier
+                                                           errorMessage:(NSString *)errorMessage;
+
 @end
 
 

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -1269,18 +1269,6 @@ ORK_CLASS_AVAILABLE
  */
 @property(nonatomic,getter=isSecureTextEntry) BOOL secureTextEntry;
 
-/**
- Returns an answer format that can be used for confirming a text entry.
- 
- This answer format is intended to be used with an `ORKFormStep` in order to confirm a previous 
- formItem input. Example usage includes a password or participant identifier that is used to 
- anonymously identify a study participant.
- 
- This answer format produces an `ORKBooleanQuestionResult` object.
- */
-- (ORKAnswerFormat *)confirmationAnswerFormatWithOriginalItemIdentifier:(NSString *)originalItemIdentifier
-                                                           errorMessage:(NSString *)errorMessage;
-
 @end
 
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -2073,6 +2073,8 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 - (ORKAnswerFormat *)confirmationAnswerFormatWithOriginalItemIdentifier:(NSString *)originalItemIdentifier
                                                            errorMessage:(NSString *)errorMessage {
     
+    NSAssert(!self.multipleLines, @"Confirmation Answer Format is not currently defined for ORKTextAnswerFormat with multiple lines.");
+    
     ORKTextAnswerFormat *fmt = [[ORKConfirmTextAnswerFormat alloc] initWithOriginalItemIdentifier:originalItemIdentifier errorMessage:errorMessage];
     
     // Copy from ORKTextAnswerFormat being confirmed

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -2069,6 +2069,26 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     return string;
 }
 
+
+- (ORKAnswerFormat *)confirmationAnswerFormatWithOriginalItemIdentifier:(NSString *)originalItemIdentifier
+                                                           errorMessage:(NSString *)errorMessage {
+    
+    ORKTextAnswerFormat *fmt = [[ORKConfirmTextAnswerFormat alloc] initWithOriginalItemIdentifier:originalItemIdentifier errorMessage:errorMessage];
+    
+    // Copy from ORKTextAnswerFormat being confirmed
+    fmt->_maximumLength = _maximumLength;
+    fmt->_keyboardType = _keyboardType;
+    fmt->_multipleLines = _multipleLines;
+    fmt->_secureTextEntry = _secureTextEntry;
+    
+    // Always set to no autocorrection
+    fmt->_autocapitalizationType = UITextAutocapitalizationTypeNone;
+    fmt->_autocorrectionType = UITextAutocorrectionTypeNo;
+    fmt->_spellCheckingType = UITextSpellCheckingTypeNo;
+    
+    return fmt;
+}
+
 #pragma mark NSSecureCoding
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -2080,9 +2080,9 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     fmt->_keyboardType = _keyboardType;
     fmt->_multipleLines = _multipleLines;
     fmt->_secureTextEntry = _secureTextEntry;
+    fmt->_autocapitalizationType = _autocapitalizationType;
     
-    // Always set to no autocorrection
-    fmt->_autocapitalizationType = UITextAutocapitalizationTypeNone;
+    // Always set to no autocorrection or spell checking
     fmt->_autocorrectionType = UITextAutocorrectionTypeNo;
     fmt->_spellCheckingType = UITextSpellCheckingTypeNo;
     

--- a/ResearchKit/Common/ORKAnswerFormat_Internal.h
+++ b/ResearchKit/Common/ORKAnswerFormat_Internal.h
@@ -147,6 +147,13 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTimeIntervalAnswerFormat)
 
 @end
 
+@protocol ORKConfirmAnswerFormatProvider <NSObject>
+
+- (ORKAnswerFormat *)confirmationAnswerFormatWithOriginalItemIdentifier:(NSString *)originalItemIdentifier
+                                                           errorMessage:(NSString *)errorMessage;
+
+@end
+
 
 @interface ORKScaleAnswerFormat () <ORKScaleAnswerFormatProvider>
 
@@ -198,7 +205,7 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKTimeIntervalAnswerFormat)
 @end
 
 
-@interface ORKTextAnswerFormat ()
+@interface ORKTextAnswerFormat () <ORKConfirmAnswerFormatProvider>
 
 @end
 

--- a/ResearchKit/Common/ORKFormStep.h
+++ b/ResearchKit/Common/ORKFormStep.h
@@ -185,6 +185,19 @@ ORK_CLASS_AVAILABLE
  */
 @property (nonatomic, copy, readonly, nullable) ORKAnswerFormat *answerFormat;
 
+/**
+ Returns an form item that can be used for confirming a text entry.
+ 
+ This form item is intended to be used with an `ORKFormStep` in order to confirm a previous
+ formItem input. Example usage includes a password or participant identifier that is used to
+ anonymously identify a study participant.
+ 
+ The answer format for this item produces an `ORKBooleanQuestionResult` object.
+ */
+- (ORKFormItem *)confirmationAnswerFormItemWithIdentifier:(NSString *)identifier
+                                                     text:(nullable NSString *)text
+                                             errorMessage:(NSString *)errorMessage;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKFormStep.h
+++ b/ResearchKit/Common/ORKFormStep.h
@@ -192,7 +192,18 @@ ORK_CLASS_AVAILABLE
  formItem input. Example usage includes a password or participant identifier that is used to
  anonymously identify a study participant.
  
+ Currently, only `ORKTextAnswerFormat` is supported. Unsupported `ORKAnswerFormat` types will
+ throw an exception.
+ 
  The answer format for this item produces an `ORKBooleanQuestionResult` object.
+ 
+ @param identifier      The identifier for the `ORKFormItem` that is returned.
+ @param text            The text for the `ORKFormItem` that is returned.
+ @param errorMessage    The error message to display if the fields do not match
+ 
+ @return                An `ORKFormItem` with the indicated identifier and text and an ORKAnswerFormat 
+                        that is appropriate for confirming the input form item.
+ 
  */
 - (ORKFormItem *)confirmationAnswerFormItemWithIdentifier:(NSString *)identifier
                                                      text:(nullable NSString *)text

--- a/ResearchKit/Common/ORKFormStep.m
+++ b/ResearchKit/Common/ORKFormStep.m
@@ -36,6 +36,7 @@
 #import "ORKAnswerFormat_Internal.h"
 #import "ORKStep_Private.h"
 #import "ORKFormStepViewController.h"
+#import "ORKDefines_Private.h"
 
 
 @implementation ORKFormStep
@@ -161,6 +162,26 @@
         _text = [sectionTitle copy];
     }
     return self;
+}
+
+- (ORKFormItem *)confirmationAnswerFormItemWithIdentifier:(NSString *)identifier
+                                                     text:(nullable NSString *)text
+                                             errorMessage:(NSString *)errorMessage {
+    
+    if (![self.answerFormat conformsToProtocol:@protocol(ORKConfirmAnswerFormatProvider)]) {
+        @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                       reason:[NSString stringWithFormat:@"Answer format %@ does not conform to confirmation protocol", self.answerFormat]
+                                     userInfo:nil];
+    }
+    
+    ORKAnswerFormat *answerFormat = [(id <ORKConfirmAnswerFormatProvider>)self.answerFormat
+                                     confirmationAnswerFormatWithOriginalItemIdentifier:self.identifier
+                                     errorMessage:errorMessage];
+    ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:identifier
+                                                           text:text
+                                                   answerFormat:answerFormat
+                                                       optional:self.optional];
+    return item;
 }
 
 + (BOOL)supportsSecureCoding {

--- a/ResearchKit/Onboarding/ORKRegistrationStep.m
+++ b/ResearchKit/Onboarding/ORKRegistrationStep.m
@@ -62,6 +62,7 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
         [formItems addObject:item];
     }
     
+    ORKTextAnswerFormat *passwordAnswerFormat;
     {
         ORKTextAnswerFormat *answerFormat = [ORKAnswerFormat textAnswerFormat];
         answerFormat.multipleLines = NO;
@@ -69,6 +70,7 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
         answerFormat.autocapitalizationType = UITextAutocapitalizationTypeNone;
         answerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
         answerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+        passwordAnswerFormat = answerFormat;
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKRegistrationFormItemIdentifierPassword
                                                                text:ORKLocalizedString(@"PASSWORD_FORM_ITEM_TITLE", nil)
@@ -80,14 +82,9 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
     }
     
     {
-        ORKConfirmTextAnswerFormat *answerFormat = [[ORKConfirmTextAnswerFormat alloc]
-                                                    initWithOriginalItemIdentifier:ORKRegistrationFormItemIdentifierPassword
-                                                    errorMessage:ORKLocalizedString(@"CONFIRM_PASSWORD_ERROR_MESSAGE", nil)];
-        answerFormat.multipleLines = NO;
-        answerFormat.secureTextEntry = YES;
-        answerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
-        answerFormat.autocapitalizationType = UITextAutocapitalizationTypeNone;
-        answerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
+        ORKAnswerFormat *answerFormat = [passwordAnswerFormat
+                                         confirmationAnswerFormatWithOriginalItemIdentifier:ORKRegistrationFormItemIdentifierPassword
+                                         errorMessage:ORKLocalizedString(@"CONFIRM_PASSWORD_ERROR_MESSAGE", nil)];
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKRegistrationFormItemIdentifierConfirmPassword
                                                                text:ORKLocalizedString(@"CONFIRM_PASSWORD_FORM_ITEM_TITLE", nil)

--- a/ResearchKit/Onboarding/ORKRegistrationStep.m
+++ b/ResearchKit/Onboarding/ORKRegistrationStep.m
@@ -62,7 +62,7 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
         [formItems addObject:item];
     }
     
-    ORKTextAnswerFormat *passwordAnswerFormat;
+    ORKFormItem *passwordFormItem;
     {
         ORKTextAnswerFormat *answerFormat = [ORKAnswerFormat textAnswerFormat];
         answerFormat.multipleLines = NO;
@@ -70,26 +70,19 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
         answerFormat.autocapitalizationType = UITextAutocapitalizationTypeNone;
         answerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
         answerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
-        passwordAnswerFormat = answerFormat;
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKRegistrationFormItemIdentifierPassword
                                                                text:ORKLocalizedString(@"PASSWORD_FORM_ITEM_TITLE", nil)
                                                        answerFormat:answerFormat
                                                            optional:NO];
         item.placeholder = ORKLocalizedString(@"PASSWORD_FORM_ITEM_PLACEHOLDER", nil);
+        passwordFormItem = item;
         
         [formItems addObject:item];
     }
     
     {
-        ORKAnswerFormat *answerFormat = [passwordAnswerFormat
-                                         confirmationAnswerFormatWithOriginalItemIdentifier:ORKRegistrationFormItemIdentifierPassword
-                                         errorMessage:ORKLocalizedString(@"CONFIRM_PASSWORD_ERROR_MESSAGE", nil)];
-        
-        ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKRegistrationFormItemIdentifierConfirmPassword
-                                                               text:ORKLocalizedString(@"CONFIRM_PASSWORD_FORM_ITEM_TITLE", nil)
-                                                       answerFormat:answerFormat
-                                                           optional:NO];
+        ORKFormItem *item = [passwordFormItem confirmationAnswerFormItemWithIdentifier:ORKRegistrationFormItemIdentifierConfirmPassword text:ORKLocalizedString(@"CONFIRM_PASSWORD_FORM_ITEM_TITLE", nil) errorMessage:ORKLocalizedString(@"CONFIRM_PASSWORD_ERROR_MESSAGE", nil)];
         item.placeholder = ORKLocalizedString(@"CONFIRM_PASSWORD_FORM_ITEM_PLACEHOLDER", nil);
         
         [formItems addObject:item];

--- a/ResearchKit/Onboarding/ORKRegistrationStep.m
+++ b/ResearchKit/Onboarding/ORKRegistrationStep.m
@@ -82,7 +82,9 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
     }
     
     {
-        ORKFormItem *item = [passwordFormItem confirmationAnswerFormItemWithIdentifier:ORKRegistrationFormItemIdentifierConfirmPassword text:ORKLocalizedString(@"CONFIRM_PASSWORD_FORM_ITEM_TITLE", nil) errorMessage:ORKLocalizedString(@"CONFIRM_PASSWORD_ERROR_MESSAGE", nil)];
+        ORKFormItem *item = [passwordFormItem confirmationAnswerFormItemWithIdentifier:ORKRegistrationFormItemIdentifierConfirmPassword
+                                                text:ORKLocalizedString(@"CONFIRM_PASSWORD_FORM_ITEM_TITLE", nil)
+                                                errorMessage:ORKLocalizedString(@"CONFIRM_PASSWORD_ERROR_MESSAGE", nil)];
         item.placeholder = ORKLocalizedString(@"CONFIRM_PASSWORD_FORM_ITEM_PLACEHOLDER", nil);
         
         [formItems addObject:item];

--- a/ResearchKitTests/ORKAnswerFormatTests.m
+++ b/ResearchKitTests/ORKAnswerFormatTests.m
@@ -59,4 +59,49 @@
     XCTAssertFalse([[ORKEmailAnswerFormat emailAnswerFormat] isAnswerValidWithString:@"12345"]);
 }
 
+- (void)testConfirmAnswerFormat {
+    
+    // Setup an answer format
+    ORKTextAnswerFormat *answerFormat = [ORKAnswerFormat textAnswerFormat];
+    answerFormat.multipleLines = NO;
+    answerFormat.secureTextEntry = YES;
+    answerFormat.keyboardType = UIKeyboardTypeASCIICapable;
+    answerFormat.maximumLength = 12;
+    answerFormat.validationRegex = @"^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[$@$!%*?&])[A-Za-z\\d$@$!%*?&]{10,}";
+    answerFormat.invalidMessage = @"Invalid password";
+    
+    // Note: setting these up incorrectly for a password to test that the values are *not* copied.
+    // DO NOT setup a real password field with these options.
+    answerFormat.autocapitalizationType = UITextAutocapitalizationTypeSentences;
+    answerFormat.autocorrectionType = UITextAutocorrectionTypeDefault;
+    answerFormat.spellCheckingType = UITextSpellCheckingTypeDefault;
+    
+    // -- method under test
+    ORKAnswerFormat *confirmFormat = [answerFormat confirmationAnswerFormatWithOriginalItemIdentifier:@"password" errorMessage:@"Passwords do not match"];
+    
+    // ORKAnswerFormat that is returned should be a subclass of ORKTextAnswerFormat.
+    // The actual subclass that is returned is private to the API and should not be accessed directly.
+    XCTAssertNotNil(confirmFormat);
+    XCTAssertTrue([confirmFormat isKindOfClass:[ORKTextAnswerFormat class]]);
+    if (![confirmFormat isKindOfClass:[ORKTextAnswerFormat class]]) { return; }
+    
+    ORKTextAnswerFormat *confirmAnswer = (ORKTextAnswerFormat*)confirmFormat;
+    
+    // These properties should match the original format
+    XCTAssertFalse(confirmAnswer.multipleLines);
+    XCTAssertTrue(confirmAnswer.secureTextEntry);
+    XCTAssertEqual(confirmAnswer.keyboardType, UIKeyboardTypeASCIICapable);
+    XCTAssertEqual(confirmAnswer.maximumLength, 12);
+    
+    // These properties should always be set to not autocorrect
+    XCTAssertEqual(confirmAnswer.autocapitalizationType, UITextAutocapitalizationTypeNone);
+    XCTAssertEqual(confirmAnswer.autocorrectionType, UITextAutocorrectionTypeNo);
+    XCTAssertEqual(confirmAnswer.spellCheckingType, UITextSpellCheckingTypeNo);
+    
+    // These properties should be nil
+    XCTAssertNil(confirmAnswer.validationRegex);
+    XCTAssertNil(confirmAnswer.invalidMessage);
+    
+}
+
 @end

--- a/ResearchKitTests/ORKAnswerFormatTests.m
+++ b/ResearchKitTests/ORKAnswerFormatTests.m
@@ -76,8 +76,20 @@
     answerFormat.autocorrectionType = UITextAutocorrectionTypeDefault;
     answerFormat.spellCheckingType = UITextSpellCheckingTypeDefault;
     
+    
+    ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"foo" text:@"enter value" answerFormat:answerFormat optional:NO];
+    
     // -- method under test
-    ORKAnswerFormat *confirmFormat = [answerFormat confirmationAnswerFormatWithOriginalItemIdentifier:@"password" errorMessage:@"Passwords do not match"];
+    ORKFormItem *confirmItem = [item confirmationAnswerFormItemWithIdentifier:@"bar"
+                                                                         text:@"enter again"
+                                                                 errorMessage:@"doesn't match"];
+    
+    XCTAssertEqualObjects(confirmItem.identifier, @"bar");
+    XCTAssertEqualObjects(confirmItem.text, @"enter again");
+    XCTAssertFalse(confirmItem.optional);
+    
+    // Inspect the answer format
+    ORKAnswerFormat *confirmFormat = confirmItem.answerFormat;
     
     // ORKAnswerFormat that is returned should be a subclass of ORKTextAnswerFormat.
     // The actual subclass that is returned is private to the API and should not be accessed directly.

--- a/ResearchKitTests/ORKAnswerFormatTests.m
+++ b/ResearchKitTests/ORKAnswerFormatTests.m
@@ -38,6 +38,13 @@
 
 @end
 
+@protocol ORKComfirmAnswerFormat_Private <NSObject>
+
+@property (nonatomic, copy, readonly) NSString *originalItemIdentifier;
+@property (nonatomic, copy, readonly) NSString *errorMessage;
+
+@end
+
 @implementation ORKAnswerFormatTests
 
 - (void)testValidEmailAnswerFormat {
@@ -116,6 +123,37 @@
     // These properties should be nil
     XCTAssertNil(confirmAnswer.validationRegex);
     XCTAssertNil(confirmAnswer.invalidMessage);
+    
+    // Check that the confirmation answer format responds to the internal methods
+    XCTAssertTrue([confirmFormat respondsToSelector:@selector(originalItemIdentifier)]);
+    XCTAssertTrue([confirmFormat respondsToSelector:@selector(errorMessage)]);
+    if (![confirmFormat respondsToSelector:@selector(originalItemIdentifier)] ||
+        ![confirmFormat respondsToSelector:@selector(errorMessage)]) {
+        return;
+    }
+    
+    NSString *originalItemIdentifier = [(id)confirmFormat originalItemIdentifier];
+    XCTAssertEqualObjects(originalItemIdentifier, @"foo");
+    
+    NSString *errorMessage = [(id)confirmFormat errorMessage];
+    XCTAssertEqualObjects(errorMessage, @"doesn't match");
+    
+}
+
+- (void)testConfirmAnswerFormat_Optional_YES {
+    
+    // Setup an answer format
+    ORKTextAnswerFormat *answerFormat = [ORKAnswerFormat textAnswerFormat];
+    
+    ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"foo" text:@"enter value" answerFormat:answerFormat optional:YES];
+    
+    // -- method under test
+    ORKFormItem *confirmItem = [item confirmationAnswerFormItemWithIdentifier:@"bar"
+                                                                         text:@"enter again"
+                                                                 errorMessage:@"doesn't match"];
+    
+    // Check that the confirm item optional value matches the input item
+    XCTAssertTrue(confirmItem.optional);
     
 }
 

--- a/ResearchKitTests/ORKAnswerFormatTests.m
+++ b/ResearchKitTests/ORKAnswerFormatTests.m
@@ -144,6 +144,7 @@
     
     // Setup an answer format
     ORKTextAnswerFormat *answerFormat = [ORKAnswerFormat textAnswerFormat];
+    answerFormat.multipleLines = NO;
     
     ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"foo" text:@"enter value" answerFormat:answerFormat optional:YES];
     
@@ -154,6 +155,21 @@
     
     // Check that the confirm item optional value matches the input item
     XCTAssertTrue(confirmItem.optional);
+    
+}
+
+- (void)testConfirmAnswerFormat_MultipleLines_YES {
+    
+    // Setup an answer format
+    ORKTextAnswerFormat *answerFormat = [ORKAnswerFormat textAnswerFormat];
+    answerFormat.multipleLines = YES;
+    
+    ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"foo" text:@"enter value" answerFormat:answerFormat optional:YES];
+    
+    // -- method under test
+    XCTAssertThrows([item confirmationAnswerFormItemWithIdentifier:@"bar"
+                                                              text:@"enter again"
+                                                      errorMessage:@"doesn't match"]);
     
 }
 

--- a/ResearchKitTests/ORKAnswerFormatTests.m
+++ b/ResearchKitTests/ORKAnswerFormatTests.m
@@ -69,10 +69,10 @@
     answerFormat.maximumLength = 12;
     answerFormat.validationRegex = @"^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[$@$!%*?&])[A-Za-z\\d$@$!%*?&]{10,}";
     answerFormat.invalidMessage = @"Invalid password";
+    answerFormat.autocapitalizationType = UITextAutocapitalizationTypeAllCharacters;
     
     // Note: setting these up incorrectly for a password to test that the values are *not* copied.
     // DO NOT setup a real password field with these options.
-    answerFormat.autocapitalizationType = UITextAutocapitalizationTypeSentences;
     answerFormat.autocorrectionType = UITextAutocorrectionTypeDefault;
     answerFormat.spellCheckingType = UITextSpellCheckingTypeDefault;
     
@@ -93,8 +93,11 @@
     XCTAssertEqual(confirmAnswer.keyboardType, UIKeyboardTypeASCIICapable);
     XCTAssertEqual(confirmAnswer.maximumLength, 12);
     
+    // This property should match the input answer format so that cases that
+    // require all-upper or all-lower (for whatever reason) can be met.
+    XCTAssertEqual(confirmAnswer.autocapitalizationType, UITextAutocapitalizationTypeAllCharacters);
+    
     // These properties should always be set to not autocorrect
-    XCTAssertEqual(confirmAnswer.autocapitalizationType, UITextAutocapitalizationTypeNone);
     XCTAssertEqual(confirmAnswer.autocorrectionType, UITextAutocorrectionTypeNo);
     XCTAssertEqual(confirmAnswer.spellCheckingType, UITextSpellCheckingTypeNo);
     

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -85,6 +85,7 @@ DefineStringKey(CollectionViewCellReuseIdentifier);
 
 DefineStringKey(EmbeddedReviewTaskIdentifier);
 DefineStringKey(StandaloneReviewTaskIdentifier);
+DefineStringKey(ConfirmationFormTaskIdentifier);
 
 DefineStringKey(StepWillDisappearTaskIdentifier);
 DefineStringKey(StepWillDisappearFirstStepIdentifier);
@@ -369,6 +370,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                            @"Toggle Tint Color",
                            @"Wait Task",
                            @"Step Will Disappear",
+                           @"Confirmation Form Item"
                            ],
                        ];
 }
@@ -573,6 +575,8 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         return [self makeLocationTask];
     } else if ([identifier isEqualToString:StepWillDisappearTaskIdentifier]) {
         return [self makeStepWillDisappearTask];
+    } else if ([identifier isEqualToString:ConfirmationFormTaskIdentifier]) {
+        return [self makeConfirmationFormTask];
     }
 
     return nil;
@@ -3762,6 +3766,77 @@ stepViewControllerWillAppear:(ORKStepViewController *)stepViewController {
     
     ORKOrderedTask *locationTask = [[ORKOrderedTask alloc] initWithIdentifier:StepWillDisappearTaskIdentifier steps:@[step1, stepLast]];
     return locationTask;
+}
+
+#pragma mark - Confirmation Form Item
+
+- (IBAction)confirmationFormItemButtonTapped:(id)sender {
+    [self beginTaskWithIdentifier:ConfirmationFormTaskIdentifier];
+}
+
+- (ORKOrderedTask *)makeConfirmationFormTask {
+    NSMutableArray *steps = [[NSMutableArray alloc] init];
+    
+    ORKInstructionStep *step1 = [[ORKInstructionStep alloc] initWithIdentifier:@"confirmationForm.step1"];
+    step1.title = @"Confirmation Form Items Survey";
+    [steps addObject:step1];
+    
+    // Create a step for entering password with confirmation
+    ORKFormStep *step2 = [[ORKFormStep alloc] initWithIdentifier:@"confirmationForm.step2" title:@"Password" text:nil];
+    [steps addObject:step2];
+    
+    {
+        ORKTextAnswerFormat *answerFormat = [ORKAnswerFormat textAnswerFormat];
+        answerFormat.multipleLines = NO;
+        answerFormat.secureTextEntry = YES;
+        answerFormat.autocapitalizationType = UITextAutocapitalizationTypeNone;
+        answerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
+        answerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+        
+        ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"password"
+                                                               text:@"Password"
+                                                       answerFormat:answerFormat
+                                                           optional:NO];
+        item.placeholder = @"Enter password";
+
+        ORKFormItem *confirmationItem = [item confirmationAnswerFormItemWithIdentifier:@"password.confirmation"
+                                                                                  text:@"Confirm"
+                                                                          errorMessage:@"Passwords do not match"];
+        confirmationItem.placeholder = @"Enter password again";
+        
+        step2.formItems = @[item, confirmationItem];
+    }
+    
+    // Create a step for entering participant id
+    ORKFormStep *step3 = [[ORKFormStep alloc] initWithIdentifier:@"confirmationForm.step3" title:@"Participant ID" text:nil];
+    [steps addObject:step3];
+    
+    {
+        ORKTextAnswerFormat *answerFormat = [ORKAnswerFormat textAnswerFormat];
+        answerFormat.multipleLines = NO;
+        answerFormat.autocapitalizationType = UITextAutocapitalizationTypeAllCharacters;
+        answerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
+        answerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+        
+        ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"participantID"
+                                                               text:@"Participant ID"
+                                                       answerFormat:answerFormat
+                                                           optional:YES];
+        item.placeholder = @"Enter Participant ID";
+        
+        ORKFormItem *confirmationItem = [item confirmationAnswerFormItemWithIdentifier:@"participantID.confirmation"
+                                                                                  text:@"Confirm"
+                                                                          errorMessage:@"IDs do not match"];
+        confirmationItem.placeholder = @"Enter ID again";
+        
+        step3.formItems = @[item, confirmationItem];
+    }
+    
+    ORKCompletionStep *step4 = [[ORKCompletionStep alloc] initWithIdentifier:@"confirmationForm.lastStep"];
+    step4.title = @"Survey Complete";
+    [steps addObject:step4];
+    
+    return [[ORKOrderedTask alloc] initWithIdentifier:ConfirmationFormTaskIdentifier steps:steps];
 }
 
 @end


### PR DESCRIPTION
This answer format is intended to be used with an `ORKFormStep` in order to confirm a previous formItem input. Example usage includes a password or participant identifier that is used to anonymously identify a study participant.

Note: I intentionally decided *against* exposing `ORKConfirmTextAnswerFormat` publicly. Because it requires referencing another form item, it is requires special-case handling in `ORKFormStepViewController`. 