### PR TITLE
Add delegate method to task view controller for step will disappear

### DIFF
--- a/ResearchKit/Common/ORKTaskViewController.h
+++ b/ResearchKit/Common/ORKTaskViewController.h
@@ -212,6 +212,16 @@ task view controller and pass that data to `initWithTask:restorationData:` when 
 - (void)taskViewController:(ORKTaskViewController *)taskViewController stepViewControllerWillAppear:(ORKStepViewController *)stepViewController;
 
 /**
+ Tells the delegate that a step has finished.
+ 
+ The task view controller calls this method after a stepViewController has finished.
+ 
+ @param taskViewController  The calling `ORKTaskViewController` instance.
+ @param step                The `ORKStepViewController` that has just finished.
+ */
+- (void)taskViewController:(ORKTaskViewController *)taskViewController stepViewControllerWillDisappear:(ORKStepViewController *)stepViewController;
+
+/**
  Tells the delegate that the result has substantively changed.
  
  The task view controller calls this method when steps start or finish, or if an answer has

--- a/ResearchKit/Common/ORKTaskViewController.h
+++ b/ResearchKit/Common/ORKTaskViewController.h
@@ -212,14 +212,16 @@ task view controller and pass that data to `initWithTask:restorationData:` when 
 - (void)taskViewController:(ORKTaskViewController *)taskViewController stepViewControllerWillAppear:(ORKStepViewController *)stepViewController;
 
 /**
- Tells the delegate that a step has finished and will disappear.
+ Tells the delegate that a step will disappear.
  
- The task view controller calls this method after a stepViewController has finished.
+ This is called in the `ORKStepViewControllerDelegate` method for `stepViewController:didFinishWithNavigationDirection:`
+ after saving the result of the step to the task view controller and before navigating to the next/previous step.
  
  @param taskViewController  The calling `ORKTaskViewController` instance.
  @param step                The `ORKStepViewController` that has just finished.
+ @param direction           The `ORKStepViewControllerNavigationDirection` of navigation.
  */
-- (void)taskViewController:(ORKTaskViewController *)taskViewController stepViewControllerWillDisappear:(ORKStepViewController *)stepViewController;
+- (void)taskViewController:(ORKTaskViewController *)taskViewController stepViewControllerWillDisappear:(ORKStepViewController *)stepViewController navigationDirection:(ORKStepViewControllerNavigationDirection)direction;
 
 /**
  Tells the delegate that the result has substantively changed.

--- a/ResearchKit/Common/ORKTaskViewController.h
+++ b/ResearchKit/Common/ORKTaskViewController.h
@@ -212,7 +212,7 @@ task view controller and pass that data to `initWithTask:restorationData:` when 
 - (void)taskViewController:(ORKTaskViewController *)taskViewController stepViewControllerWillAppear:(ORKStepViewController *)stepViewController;
 
 /**
- Tells the delegate that a step has finished.
+ Tells the delegate that a step has finished and will disappear.
  
  The task view controller calls this method after a stepViewController has finished.
  

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1252,8 +1252,8 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     
     // Alert the delegate that the step is finished 
     STRONGTYPE(self.delegate) strongDelegate = self.delegate;
-    if ([strongDelegate respondsToSelector:@selector(taskViewController:stepViewControllerWillDisappear:)]) {
-        [strongDelegate taskViewController:self stepViewControllerWillDisappear: stepViewController];
+    if ([strongDelegate respondsToSelector:@selector(taskViewController:stepViewControllerWillDisappear:navigationDirection:)]) {
+        [strongDelegate taskViewController:self stepViewControllerWillDisappear:stepViewController navigationDirection:direction];
     }
     
     if (direction == ORKStepViewControllerNavigationDirectionForward) {

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1250,6 +1250,12 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
         [self setManagedResult:[stepViewController result] forKey:stepViewController.step.identifier];
     }
     
+    // Alert the delegate that the step is finished 
+    STRONGTYPE(self.delegate) strongDelegate = self.delegate;
+    if ([strongDelegate respondsToSelector:@selector(taskViewController:stepViewControllerWillDisappear:)]) {
+        [strongDelegate taskViewController:self stepViewControllerWillDisappear: stepViewController];
+    }
+    
     if (direction == ORKStepViewControllerNavigationDirectionForward) {
         [self flipToNextPageFrom:stepViewController];
     } else {

--- a/ResearchKitTests/ORKTaskTests.m
+++ b/ResearchKitTests/ORKTaskTests.m
@@ -41,6 +41,19 @@
 
 @end
 
+@interface MethodObject : NSObject
+@property (nonatomic) NSString *selectorName;
+@property (nonatomic) NSArray *arguments;
+@end
+
+@interface TestTaskViewControllerDelegate : NSObject <ORKTaskViewControllerDelegate>
+@property (nonatomic) NSMutableArray <MethodObject *> *methodCalled;
+@end
+
+@interface MockTaskViewController : ORKTaskViewController
+@property (nonatomic) NSMutableArray <MethodObject *> *methodCalled;
+@end
+
 
 @implementation ORKTaskTests {
     NSArray *_orderedTaskStepIdentifiers;
@@ -1336,6 +1349,81 @@ static ORKStepResult *(^getStepResult)(NSString *, Class, ORKQuestionType, id) =
     [self testResultPredicatesWithTaskIdentifier:nil
                            substitutionVariables:@{ORKResultPredicateTaskIdentifierVariableName: OrderedTaskIdentifier}
                                      taskResults:taskResults];
+}
+
+- (void)testStepViewControllerWillDisappear {
+    TestTaskViewControllerDelegate *delegate = [[TestTaskViewControllerDelegate alloc] init];
+    ORKOrderedTask *task = [ORKOrderedTask twoFingerTappingIntervalTaskWithIdentifier:@"test" intendedUseDescription:nil duration:30 options:0];
+    ORKTaskViewController *taskViewController = [[MockTaskViewController alloc] initWithTask:task taskRunUUID:nil];
+    taskViewController.delegate = delegate;
+    ORKInstructionStepViewController *stepViewController = [[ORKInstructionStepViewController alloc] initWithStep:task.steps.firstObject];
+    
+    //-- call method under test
+    [taskViewController stepViewController:stepViewController didFinishWithNavigationDirection:ORKStepViewControllerNavigationDirectionForward];
+    
+    // Check that the expected methods were called
+    XCTAssertEqual(delegate.methodCalled.count, 1);
+    XCTAssertEqualObjects(delegate.methodCalled.firstObject.selectorName, @"taskViewController:stepViewControllerWillDisappear:navigationDirection:");
+    NSArray *expectedArgs = @[taskViewController, stepViewController, @(ORKStepViewControllerNavigationDirectionForward)];
+    XCTAssertEqualObjects(delegate.methodCalled.firstObject.arguments, expectedArgs);
+    
+}
+
+@end
+
+@implementation MethodObject
+@end
+
+@implementation TestTaskViewControllerDelegate
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _methodCalled = [NSMutableArray new];
+    }
+    return self;
+}
+
+- (void)taskViewController:(ORKTaskViewController *)taskViewController didFinishWithReason:(ORKTaskViewControllerFinishReason)reason error:(NSError *)error {
+    
+    // Add results of method call
+    MethodObject *obj = [[MethodObject alloc] init];
+    obj.selectorName = NSStringFromSelector(@selector(taskViewController:didFinishWithReason:error:));
+    obj.arguments = @[taskViewController ?: [NSNull null],
+                      @(reason),
+                      error ?: [NSNull null]];
+    [self.methodCalled addObject:obj];
+}
+
+- (void)taskViewController:(ORKTaskViewController *)taskViewController stepViewControllerWillDisappear:(ORKStepViewController *)stepViewController navigationDirection:(ORKStepViewControllerNavigationDirection)direction {
+    // Add results of method call
+    MethodObject *obj = [[MethodObject alloc] init];
+    obj.selectorName = NSStringFromSelector(@selector(taskViewController:stepViewControllerWillDisappear:navigationDirection:));
+    obj.arguments = @[taskViewController ?: [NSNull null],
+                      stepViewController ?: [NSNull null],
+                      @(direction)];
+    [self.methodCalled addObject:obj];
+}
+
+@end
+
+@implementation MockTaskViewController
+
+- (void)flipToNextPageFrom:(ORKStepViewController *)fromController {
+    // Add results of method call
+    MethodObject *obj = [[MethodObject alloc] init];
+    obj.selectorName = NSStringFromSelector(@selector(flipToNextPageFrom:));
+    obj.arguments = @[fromController ?: [NSNull null]];
+    [self.methodCalled addObject:obj];
+}
+
+- (void)flipToPreviousPageFrom:(ORKStepViewController *)fromController {
+    // Add results of method call
+    MethodObject *obj = [[MethodObject alloc] init];
+    obj.selectorName = NSStringFromSelector(@selector(flipToPreviousPageFrom:));
+    obj.arguments = @[fromController ?: [NSNull null]];
+    [self.methodCalled addObject:obj];
 }
 
 @end

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -86,6 +86,9 @@ DefineStringKey(CollectionViewCellReuseIdentifier);
 DefineStringKey(EmbeddedReviewTaskIdentifier);
 DefineStringKey(StandaloneReviewTaskIdentifier);
 
+DefineStringKey(StepWillDisappearTaskIdentifier);
+DefineStringKey(StepWillDisappearFirstStepIdentifier);
+
 @interface SectionHeader: UICollectionReusableView
 
 - (void)configureHeaderWithTitle:(NSString *)title;
@@ -365,6 +368,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                            @"Test Charts Performance",
                            @"Toggle Tint Color",
                            @"Wait Task",
+                           @"Step Will Disappear",
                            ],
                        ];
 }
@@ -567,6 +571,8 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         return [self makeWaitingTask];
     }else if ([identifier isEqualToString:LocationTaskIdentifier]) {
         return [self makeLocationTask];
+    } else if ([identifier isEqualToString:StepWillDisappearTaskIdentifier]) {
+        return [self makeStepWillDisappearTask];
     }
 
     return nil;
@@ -3586,6 +3592,13 @@ stepViewControllerWillAppear:(ORKStepViewController *)stepViewController {
     }];
 }
 
+- (void)taskViewController:(ORKTaskViewController *)taskViewController stepViewControllerWillDisappear:(ORKStepViewController *)stepViewController navigationDirection:(ORKStepViewControllerNavigationDirection)direction {
+    if ([taskViewController.task.identifier isEqualToString:StepWillDisappearTaskIdentifier] &&
+        [stepViewController.step.identifier isEqualToString:StepWillDisappearFirstStepIdentifier]) {
+        taskViewController.view.tintColor = [UIColor magentaColor];
+    }
+}
+
 #pragma mark - UI state restoration
 
 /*
@@ -3729,6 +3742,25 @@ stepViewControllerWillAppear:(ORKStepViewController *)stepViewController {
     [steps addObject:step4];
     
     ORKOrderedTask *locationTask = [[ORKOrderedTask alloc] initWithIdentifier:LocationTaskIdentifier steps:steps];
+    return locationTask;
+}
+
+#pragma mark - Step Will Disappear Task Delegate example
+
+- (IBAction)stepWillDisappearButtonTapped:(id)sender {
+    [self beginTaskWithIdentifier:StepWillDisappearTaskIdentifier];
+}
+
+- (ORKOrderedTask *)makeStepWillDisappearTask {
+    
+    ORKInstructionStep *step1 = [[ORKInstructionStep alloc] initWithIdentifier:StepWillDisappearFirstStepIdentifier];
+    step1.title = @"Step Will Disappear Delegate Example";
+    step1.text = @"The tint color of the task view controller is changed to magenta in the `stepViewControllerWillDisappear:` method.";
+    
+    ORKCompletionStep *stepLast = [[ORKCompletionStep alloc] initWithIdentifier:@"stepLast"];
+    stepLast.title = @"Survey Complete";
+    
+    ORKOrderedTask *locationTask = [[ORKOrderedTask alloc] initWithIdentifier:StepWillDisappearTaskIdentifier steps:@[step1, stepLast]];
     return locationTask;
 }
 


### PR DESCRIPTION
See PR https://github.com/ResearchKit/ResearchKit/pull/733 for conversation.

In this case, our governance team required a change to the design for mPower to be made available in Luxembourg. We had to rearrange the onboarding steps and add our own custom implementation to meet their consent requirements. The app was failing the onboarding process because we were looking for the wrong step (we were using stepViewControllerWillAppear in the original AppCore implementation). The `stepViewControllerWillDisappear` method allows us to know when the `ORKConsentReviewStep` has finished which is really what we are interested in knowing.

