### PR TITLE
Add finishedSpokenInstruction to active step

### DIFF
--- a/ResearchKit/ActiveTasks/ORKActiveStep.h
+++ b/ResearchKit/ActiveTasks/ORKActiveStep.h
@@ -172,6 +172,14 @@ The default value of this property is `NO`.
 @property (nonatomic, copy, nullable) NSString *spokenInstruction;
 
 /**
+ Localized text that represents an instructional voice prompt for when the step finishes.
+ 
+ Instructional speech begins when the step finishes. If VoiceOver is active,
+ the instruction is spoken by VoiceOver.
+ */
+@property (nonatomic, copy, nullable) NSString *finishedSpokenInstruction;
+
+/**
  An image to be displayed below the instructions for the step.
  
  The image can be stretched to fit the available space. When choosing a size

--- a/ResearchKit/ActiveTasks/ORKActiveStep.m
+++ b/ResearchKit/ActiveTasks/ORKActiveStep.m
@@ -62,7 +62,9 @@
 }
 
 - (BOOL)hasVoice {
-    return  (_spokenInstruction != nil && _spokenInstruction.length > 0);
+    BOOL hasSpokenInstruction = (_spokenInstruction != nil && _spokenInstruction.length > 0);
+    BOOL hasFinishedSpokenInstruction = (_finishedSpokenInstruction != nil && _finishedSpokenInstruction.length > 0);
+    return  (hasSpokenInstruction || hasFinishedSpokenInstruction);
 }
 
 - (BOOL)isRestorable {
@@ -94,6 +96,7 @@
     step.shouldUseNextAsSkipButton = self.shouldUseNextAsSkipButton;
     step.shouldContinueOnFinish = self.shouldContinueOnFinish;
     step.spokenInstruction = self.spokenInstruction;
+    step.finishedSpokenInstruction = self.finishedSpokenInstruction;
     step.recorderConfigurations = [self.recorderConfigurations copy];
     step.image = self.image;
     return step;
@@ -113,6 +116,7 @@
         ORK_DECODE_BOOL(aDecoder, shouldUseNextAsSkipButton);
         ORK_DECODE_BOOL(aDecoder, shouldContinueOnFinish);
         ORK_DECODE_OBJ_CLASS(aDecoder, spokenInstruction, NSString);
+        ORK_DECODE_OBJ_CLASS(aDecoder, finishedSpokenInstruction, NSString);
         ORK_DECODE_IMAGE(aDecoder, image);
         ORK_DECODE_OBJ_ARRAY(aDecoder, recorderConfigurations, ORKRecorderConfiguration);
     }
@@ -133,6 +137,7 @@
     ORK_ENCODE_BOOL(aCoder, shouldContinueOnFinish);
     ORK_ENCODE_IMAGE(aCoder, image);
     ORK_ENCODE_OBJ(aCoder, spokenInstruction);
+    ORK_ENCODE_OBJ(aCoder, finishedSpokenInstruction);
     ORK_ENCODE_OBJ(aCoder, recorderConfigurations);
 }
 
@@ -142,6 +147,7 @@
     __typeof(self) castObject = object;
     return (isParentSame &&
             ORKEqualObjects(self.spokenInstruction, castObject.spokenInstruction) &&
+            ORKEqualObjects(self.finishedSpokenInstruction, castObject.finishedSpokenInstruction) &&
             ORKEqualObjects(self.recorderConfigurations, castObject.recorderConfigurations) &&
             ORKEqualObjects(self.image, castObject.image) &&
             (self.stepDuration == castObject.stepDuration) &&

--- a/ResearchKit/ActiveTasks/ORKActiveStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKActiveStepViewController.m
@@ -362,6 +362,9 @@
     if (self.activeStep.shouldVibrateOnFinish) {
         AudioServicesPlayAlertSound(kSystemSoundID_Vibrate);
     }
+    if (self.activeStep.hasVoice && self.activeStep.finishedSpokenInstruction) {
+        [[ORKVoiceEngine sharedVoiceEngine] speakText:self.activeStep.finishedSpokenInstruction];
+    }
     if (!self.activeStep.startsFinished) {
         if (self.activeStep.shouldContinueOnFinish) {
             [self goForward];


### PR DESCRIPTION
The finished spoken instruction property allows a step to announce that it is completed. This is useful in the case where the phone screen is not visible such as a walking activity (where the phone is in the participant's phone) or a hand tremor measurement (where the screen is not facing the participant).

I have pulled it out into it's own PR in an effort to make the addition of our tremor, two-handed tapping and walking modules able to be submitted independently of one another.