### PR TITLE
Add task module for measuring bilateral tapping speed 

### DIFF
--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -118,6 +118,8 @@
 		618DA0521A93D0D600E63AA8 /* ORKAccessibilityFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = 618DA04A1A93D0D600E63AA8 /* ORKAccessibilityFunctions.m */; };
 		618DA0541A93D0D600E63AA8 /* UIView+ORKAccessibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 618DA04B1A93D0D600E63AA8 /* UIView+ORKAccessibility.h */; };
 		618DA0561A93D0D600E63AA8 /* UIView+ORKAccessibility.m in Sources */ = {isa = PBXBuildFile; fileRef = 618DA04C1A93D0D600E63AA8 /* UIView+ORKAccessibility.m */; };
+		805685791C90C19500BF437A /* UIImage+ResearchKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 805685771C90C19500BF437A /* UIImage+ResearchKit.h */; };
+		8056857A1C90C19500BF437A /* UIImage+ResearchKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 805685781C90C19500BF437A /* UIImage+ResearchKit.m */; };
 		861D11A91AA691BB003C98A7 /* ORKScaleSliderView.h in Headers */ = {isa = PBXBuildFile; fileRef = 861D11A71AA691BB003C98A7 /* ORKScaleSliderView.h */; };
 		861D11AA1AA691BB003C98A7 /* ORKScaleSliderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 861D11A81AA691BB003C98A7 /* ORKScaleSliderView.m */; };
 		861D11AD1AA7951F003C98A7 /* ORKChoiceAnswerFormatHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 861D11AB1AA7951F003C98A7 /* ORKChoiceAnswerFormatHelper.h */; };
@@ -634,6 +636,8 @@
 		618DA04A1A93D0D600E63AA8 /* ORKAccessibilityFunctions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKAccessibilityFunctions.m; sourceTree = "<group>"; };
 		618DA04B1A93D0D600E63AA8 /* UIView+ORKAccessibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = "UIView+ORKAccessibility.h"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		618DA04C1A93D0D600E63AA8 /* UIView+ORKAccessibility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = "UIView+ORKAccessibility.m"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		805685771C90C19500BF437A /* UIImage+ResearchKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+ResearchKit.h"; sourceTree = "<group>"; };
+		805685781C90C19500BF437A /* UIImage+ResearchKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+ResearchKit.m"; sourceTree = "<group>"; };
 		861610BF1A8D8EDD00245F7A /* Artwork.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Artwork.xcassets; sourceTree = "<group>"; };
 		861D11A71AA691BB003C98A7 /* ORKScaleSliderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKScaleSliderView.h; sourceTree = "<group>"; };
 		861D11A81AA691BB003C98A7 /* ORKScaleSliderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKScaleSliderView.m; sourceTree = "<group>"; };
@@ -1571,6 +1575,8 @@
 				86C40BE81A8D7C5C00081FAC /* UIBarButtonItem+ORKBarButtonItem.m */,
 				86C40BE91A8D7C5C00081FAC /* UIResponder+ResearchKit.h */,
 				86C40BEA1A8D7C5C00081FAC /* UIResponder+ResearchKit.m */,
+				805685771C90C19500BF437A /* UIImage+ResearchKit.h */,
+				805685781C90C19500BF437A /* UIImage+ResearchKit.m */,
 			);
 			name = UIKitCategories;
 			sourceTree = "<group>";
@@ -2413,6 +2419,7 @@
 				86C40C421A8D7C5C00081FAC /* ORKSpatialSpanMemoryStep.h in Headers */,
 				86C40C6E1A8D7C5C00081FAC /* CMMotionActivity+ORKJSONDictionary.h in Headers */,
 				B11C54991A9EEF8800265E61 /* ORKConsentSharingStep.h in Headers */,
+				805685791C90C19500BF437A /* UIImage+ResearchKit.h in Headers */,
 				106FF2AE1B6FACA8004EACF2 /* ORKDirectionView.h in Headers */,
 				86C40DA61A8D7C5C00081FAC /* ORKSurveyAnswerCellForImageSelection.h in Headers */,
 				86C40D5E1A8D7C5C00081FAC /* ORKQuestionStep.h in Headers */,
@@ -2844,6 +2851,7 @@
 				147503B01AEE8071004B17F3 /* ORKAudioGenerator.m in Sources */,
 				86C40D7E1A8D7C5C00081FAC /* ORKScaleValueLabel.m in Sources */,
 				B12EA01A1B0D76AD00F9F554 /* ORKToneAudiometryPracticeStepViewController.m in Sources */,
+				8056857A1C90C19500BF437A /* UIImage+ResearchKit.m in Sources */,
 				86C40D901A8D7C5C00081FAC /* ORKStep.m in Sources */,
 				86C40D2E1A8D7C5C00081FAC /* ORKHeadlineLabel.m in Sources */,
 				FA7A9D341B0843A9005A2BEA /* ORKConsentSignatureFormatter.m in Sources */,

--- a/ResearchKit/ActiveTasks/ORKTappingContentView.h
+++ b/ResearchKit/ActiveTasks/ORKTappingContentView.h
@@ -40,6 +40,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setTapCount:(NSUInteger)tapCount;
 - (void)setProgress:(CGFloat)progress animated:(BOOL)animated;
 
+@property (nonatomic, assign) BOOL hasSkipButton;
+
 @property (nonatomic, strong, readonly) ORKRoundTappingButton *tapButton1;
 
 @property (nonatomic, strong, readonly) ORKRoundTappingButton *tapButton2;

--- a/ResearchKit/ActiveTasks/ORKTappingContentView.m
+++ b/ResearchKit/ActiveTasks/ORKTappingContentView.m
@@ -276,7 +276,7 @@
     self.layoutMargins = (UIEdgeInsets){.left = margin * 2, .right = margin * 2};
     
     static const CGFloat CaptionBaselineToTapCountBaseline = 56;
-    static const CGFloat TapButtonBottomToBottom = 36;
+    CGFloat tapButtonBottomToBottom = self.hasSkipButton ? 0 : 36;
     
     // On the iPhone, _progressView is positioned outside the bounds of this view, to be in-between the header and this view.
     // On the iPad, we want to stretch this out a bit so it feels less compressed.
@@ -294,7 +294,7 @@
     _topToProgressViewConstraint.constant = topToProgressViewOffset;
     _topToCaptionLabelConstraint.constant = topToCaptionLabelOffset;
     _captionLabelToTapCountLabelConstraint.constant = CaptionBaselineToTapCountBaseline;
-    _tapButtonToBottomConstraint.constant = TapButtonBottomToBottom;
+    _tapButtonToBottomConstraint.constant = tapButtonBottomToBottom;
 }
 
 - (void)updateConstraints {

--- a/ResearchKit/ActiveTasks/ORKTappingIntervalStep.m
+++ b/ResearchKit/ActiveTasks/ORKTappingIntervalStep.m
@@ -43,6 +43,7 @@
     self = [super initWithIdentifier:identifier];
     if (self) {
         self.shouldShowDefaultTimer = NO;
+        self.optional = NO; // default to *not* optional
     }
     return self;
 }

--- a/ResearchKit/ActiveTasks/ORKTappingIntervalStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKTappingIntervalStepViewController.m
@@ -93,6 +93,7 @@
     _expired = NO;
     
     _tappingContentView = [[ORKTappingContentView alloc] init];
+    _tappingContentView.hasSkipButton = self.step.optional;
     self.activeStepView.activeCustomView = _tappingContentView;
     
     [_tappingContentView.tapButton1 addTarget:self action:@selector(buttonPressed:forEvent:) forControlEvents:UIControlEventTouchDown];

--- a/ResearchKit/ActiveTasks/ORKTappingIntervalStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKTappingIntervalStepViewController.m
@@ -75,6 +75,7 @@
     // Don't show next button
     self.internalContinueButtonItem = nil;
     self.internalDoneButtonItem = nil;
+    self.internalSkipButtonItem.title = ORKLocalizedString(@"TAPPING_SKIP_TITLE", nil);
 }
 
 - (void)viewDidLoad {
@@ -179,6 +180,7 @@
 
 - (void)start {
     [super start];
+    self.skipButtonItem = nil;
     [_tappingContentView setProgress:0.001 animated:NO];
 }
 

--- a/ResearchKit/Common/ORKOrderedTask.h
+++ b/ResearchKit/Common/ORKOrderedTask.h
@@ -363,8 +363,8 @@ typedef NS_OPTIONS(NSUInteger, ORKPredefinedTaskHandOption) {
 + (ORKOrderedTask *)twoFingerTappingIntervalTaskWithIdentifier:(NSString *)identifier
                                         intendedUseDescription:(nullable NSString *)intendedUseDescription
                                                       duration:(NSTimeInterval)duration
-                                                       options:(ORKPredefinedTaskOption)options
-                                                   handOptions:(ORKPredefinedTaskHandOption)handOptions;
+                                                   handOptions:(ORKPredefinedTaskHandOption)handOptions
+                                                       options:(ORKPredefinedTaskOption)options;
 /**
  @Deprecated
  */

--- a/ResearchKit/Common/ORKOrderedTask.h
+++ b/ResearchKit/Common/ORKOrderedTask.h
@@ -158,6 +158,25 @@ typedef NS_OPTIONS(NSUInteger, ORKPredefinedTaskOption) {
     ORKPredefinedTaskOptionExcludeAudio = (1 << 7)
 } ORK_ENUM_AVAILABLE;
 
+/**
+ Values that identify the hand(s) to be used in an active task.
+ 
+ By default, the participant will be asked to use their most affected hand.
+ */
+typedef NS_OPTIONS(NSUInteger, ORKPredefinedTaskHandOption) {
+    /// Which hand to use is undefined
+    ORKPredefinedTaskHandOptionUndefined = 0,
+    
+    /// Task should test the left hand
+    ORKPredefinedTaskHandOptionLeft = 1 << 1,
+    
+    /// Task should test the right hand
+    ORKPredefinedTaskHandOptionRight = 1 << 2,
+    
+    /// Task should test both hands (random order)
+    ORKPredefinedTaskHandOptionBoth = ORKPredefinedTaskHandOptionLeft | ORKPredefinedTaskHandOptionRight,
+} ORK_ENUM_AVAILABLE;
+
 
 @interface ORKOrderedTask (ORKPredefinedActiveTask)
 
@@ -344,6 +363,33 @@ typedef NS_OPTIONS(NSUInteger, ORKPredefinedTaskOption) {
                                         intendedUseDescription:(nullable NSString *)intendedUseDescription
                                                       duration:(NSTimeInterval)duration
                                                        options:(ORKPredefinedTaskOption)options;
+/**
+ Returns a predefined task that consists of two finger tapping (Optionally with a hand specified)
+ 
+ In a two finger tapping task, the participant is asked to rhythmically and alternately tap two
+ targets on the device screen.
+ 
+ A two finger tapping task can be used to assess basic motor capabilities including speed, accuracy,
+ and rhythm.
+ 
+ Data collected in this task includes touch activity and accelerometer information.
+ 
+ @param identifier              The task identifier to use for this task, appropriate to the study.
+ @param intendedUseDescription  A localized string describing the intended use of the data
+ collected. If the value of this parameter is `nil`, the default
+ localized text will be displayed.
+ @param duration                The length of the count down timer that runs while touch data is
+ collected.
+ @param options                 Options that affect the features of the predefined task.
+ @param handOptions             Options for determining which hand(s) to test.
+ 
+ @return An active two finger tapping task that can be presented with an `ORKTaskViewController` object.
+ */
++ (ORKOrderedTask *)twoFingerTappingIntervalTaskWithIdentifier:(NSString *)identifier
+                                        intendedUseDescription:(nullable NSString *)intendedUseDescription
+                                                      duration:(NSTimeInterval)duration
+                                                       options:(ORKPredefinedTaskOption)options
+                                                   handOptions:(ORKPredefinedTaskHandOption)handOptions;
 
 /**
  Returns a predefined task that tests spatial span memory.

--- a/ResearchKit/Common/ORKOrderedTask.h
+++ b/ResearchKit/Common/ORKOrderedTask.h
@@ -339,31 +339,6 @@ typedef NS_OPTIONS(NSUInteger, ORKPredefinedTaskHandOption) {
                                     options:(ORKPredefinedTaskOption)options __deprecated;
 
 /**
- Returns a predefined task that consists of two finger tapping.
- 
- In a two finger tapping task, the participant is asked to rhythmically and alternately tap two
- targets on the device screen.
- 
- A two finger tapping task can be used to assess basic motor capabilities including speed, accuracy,
- and rhythm.
- 
- Data collected in this task includes touch activity and accelerometer information.
- 
- @param identifier              The task identifier to use for this task, appropriate to the study.
- @param intendedUseDescription  A localized string describing the intended use of the data
-                                    collected. If the value of this parameter is `nil`, the default
-                                    localized text will be displayed.
- @param duration                The length of the count down timer that runs while touch data is
-                                    collected.
- @param options                 Options that affect the features of the predefined task.
- 
- @return An active two finger tapping task that can be presented with an `ORKTaskViewController` object.
- */
-+ (ORKOrderedTask *)twoFingerTappingIntervalTaskWithIdentifier:(NSString *)identifier
-                                        intendedUseDescription:(nullable NSString *)intendedUseDescription
-                                                      duration:(NSTimeInterval)duration
-                                                       options:(ORKPredefinedTaskOption)options;
-/**
  Returns a predefined task that consists of two finger tapping (Optionally with a hand specified)
  
  In a two finger tapping task, the participant is asked to rhythmically and alternately tap two
@@ -390,6 +365,13 @@ typedef NS_OPTIONS(NSUInteger, ORKPredefinedTaskHandOption) {
                                                       duration:(NSTimeInterval)duration
                                                        options:(ORKPredefinedTaskOption)options
                                                    handOptions:(ORKPredefinedTaskHandOption)handOptions;
+/**
+ @Deprecated
+ */
++ (ORKOrderedTask *)twoFingerTappingIntervalTaskWithIdentifier:(NSString *)identifier
+                                        intendedUseDescription:(nullable NSString *)intendedUseDescription
+                                                      duration:(NSTimeInterval)duration
+                                                       options:(ORKPredefinedTaskOption)options __deprecated;
 
 /**
  Returns a predefined task that tests spatial span memory.

--- a/ResearchKit/Common/ORKOrderedTask.h
+++ b/ResearchKit/Common/ORKOrderedTask.h
@@ -165,7 +165,7 @@ typedef NS_OPTIONS(NSUInteger, ORKPredefinedTaskOption) {
  */
 typedef NS_OPTIONS(NSUInteger, ORKPredefinedTaskHandOption) {
     /// Which hand to use is undefined
-    ORKPredefinedTaskHandOptionUndefined = 0,
+    ORKPredefinedTaskHandOptionUnspecified = 0,
     
     /// Task should test the left hand
     ORKPredefinedTaskHandOptionLeft = 1 << 1,

--- a/ResearchKit/Common/ORKOrderedTask.h
+++ b/ResearchKit/Common/ORKOrderedTask.h
@@ -351,12 +351,12 @@ typedef NS_OPTIONS(NSUInteger, ORKPredefinedTaskHandOption) {
  
  @param identifier              The task identifier to use for this task, appropriate to the study.
  @param intendedUseDescription  A localized string describing the intended use of the data
- collected. If the value of this parameter is `nil`, the default
- localized text will be displayed.
+                                collected. If the value of this parameter is `nil`, the default
+                                localized text will be displayed.
  @param duration                The length of the count down timer that runs while touch data is
- collected.
- @param options                 Options that affect the features of the predefined task.
+                                collected.
  @param handOptions             Options for determining which hand(s) to test.
+ @param options                 Options that affect the features of the predefined task.
  
  @return An active two finger tapping task that can be presented with an `ORKTaskViewController` object.
  */

--- a/ResearchKit/Common/ORKOrderedTask.m
+++ b/ResearchKit/Common/ORKOrderedTask.m
@@ -61,6 +61,7 @@
 #import "ORKAccelerometerRecorder.h"
 #import "ORKAudioRecorder.h"
 #import "ORKWaitStep.h"
+#import "UIImage+ResearchKit.h"
 
 
 ORKTaskProgress ORKTaskProgressMake(NSUInteger current, NSUInteger total) {
@@ -292,6 +293,8 @@ NSString * const ORKCountdownStepIdentifier = @"countdown";
 NSString * const ORKAudioStepIdentifier = @"audio";
 NSString * const ORKAudioTooLoudStepIdentifier = @"audio.tooloud";
 NSString * const ORKTappingStepIdentifier = @"tapping";
+NSString * const ORKActiveTaskLeftHandIdentifier = @"left";
+NSString * const ORKActiveTaskRightHandIdentifier = @"right";
 NSString * const ORKConclusionStepIdentifier = @"conclusion";
 NSString * const ORKFitnessWalkStepIdentifier = @"fitness.walk";
 NSString * const ORKFitnessRestStepIdentifier = @"fitness.rest";
@@ -333,10 +336,24 @@ void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
                                        intendedUseDescription:(NSString *)intendedUseDescription
                                                      duration:(NSTimeInterval)duration
                                                       options:(ORKPredefinedTaskOption)options {
-    
+    return [self twoFingerTappingIntervalTaskWithIdentifier:identifier
+                                     intendedUseDescription:intendedUseDescription
+                                                   duration:duration
+                                                    options:options
+                                                handOptions:ORKPredefinedTaskHandOptionUndefined];
+}
+
+/// Copyright (c) 2016, Sage Bionetworks - Modified to track tapping speed for both hands
++ (ORKOrderedTask *)twoFingerTappingIntervalTaskWithIdentifier:(NSString *)identifier
+                                        intendedUseDescription:(NSString *)intendedUseDescription
+                                                      duration:(NSTimeInterval)duration
+                                                       options:(ORKPredefinedTaskOption)options
+                                                   handOptions:(ORKPredefinedTaskHandOption)handOptions
+{
     NSString *durationString = [ORKDurationStringFormatter() stringFromTimeInterval:duration];
     
     NSMutableArray *steps = [NSMutableArray array];
+    
     if (! (options & ORKPredefinedTaskOptionExcludeInstructions)) {
         {
             ORKInstructionStep *step = [[ORKInstructionStep alloc] initWithIdentifier:ORKInstruction0StepIdentifier];
@@ -353,39 +370,129 @@ void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
             
             ORKStepArrayAddStep(steps, step);
         }
+    }
+    
+    // Setup which hand to start with and how many hands to add based on the handOptions parameter
+    // Hand order is randomly determined.
+    NSUInteger handCount = ((handOptions & ORKPredefinedTaskHandOptionBoth) == ORKPredefinedTaskHandOptionBoth) ? 2 : 1;
+    BOOL undefinedHand = (handOptions == ORKPredefinedTaskHandOptionUndefined);
+    BOOL rightHand;
+    switch (handOptions) {
+        case ORKPredefinedTaskHandOptionLeft:
+            rightHand = NO; break;
+        case ORKPredefinedTaskHandOptionRight:
+        case ORKPredefinedTaskHandOptionUndefined:
+            rightHand = YES; break;
+        default:
+            rightHand = (arc4random()%2 == 0); break;
+    }
+    
+    for (NSUInteger hand=1; hand <= handCount; hand++)
+    {
+        NSString * (^appendIdentifier) (NSString *) = ^ (NSString * identifier) {
+            if (undefinedHand) {
+                return identifier;
+            }
+            else {
+                NSString *handIdentifier = rightHand ? ORKActiveTaskRightHandIdentifier : ORKActiveTaskLeftHandIdentifier;
+                return [NSString stringWithFormat:@"%@.%@", identifier, handIdentifier];
+            }
+        };
         
-        {
-            ORKInstructionStep *step = [[ORKInstructionStep alloc] initWithIdentifier:ORKInstruction1StepIdentifier];
-            step.title = ORKLocalizedString(@"TAPPING_TASK_TITLE", nil);
-            NSString *template =  ORKLocalizedString(@"TAPPING_INTRO_TEXT_2_FORMAT", nil);
+        if (! (options & ORKPredefinedTaskOptionExcludeInstructions)) {
+            ORKInstructionStep *step = [[ORKInstructionStep alloc] initWithIdentifier:appendIdentifier(ORKInstruction1StepIdentifier)];
             
-            step.text = [NSString stringWithFormat:template, durationString];
-            step.detailText = ORKLocalizedString(@"TAPPING_CALL_TO_ACTION", nil);
+            // Set the title based on the hand
+            if (undefinedHand) {
+                step.title = ORKLocalizedString(@"TAPPING_TASK_TITLE", nil);
+            }
+            else if (rightHand) {
+                step.title = ORKLocalizedString(@"TAPPING_TASK_TITLE_RIGHT", nil);
+            }
+            else {
+                step.title = ORKLocalizedString(@"TAPPING_TASK_TITLE_LEFT", nil);
+            }
             
+            // Set the instructions for the tapping test screen that is displayed prior to each hand test
+            NSString *restText = ORKLocalizedString(@"TAPPING_INTRO_TEXT_2_REST_PHONE", nil);
+            NSString *tappingTextFormat = ORKLocalizedString(@"TAPPING_INTRO_TEXT_2_FORMAT", nil);
+            NSString *tappingText = [NSString stringWithFormat:tappingTextFormat, durationString];
+            NSString *handText = nil;
+            
+            if (hand == 1) {
+                if (undefinedHand) {
+                    handText = ORKLocalizedString(@"TAPPING_INTRO_TEXT_2_MOST_AFFECTED", nil);
+                }
+                else if (rightHand) {
+                    handText = ORKLocalizedString(@"TAPPING_INTRO_TEXT_2_RIGHT_FIRST", nil);
+                }
+                else {
+                    handText = ORKLocalizedString(@"TAPPING_INTRO_TEXT_2_LEFT_FIRST", nil);
+                }
+            }
+            else {
+                if (rightHand) {
+                    handText = ORKLocalizedString(@"TAPPING_INTRO_TEXT_2_RIGHT_SECOND", nil);
+                }
+                else {
+                    handText = ORKLocalizedString(@"TAPPING_INTRO_TEXT_2_LEFT_SECOND", nil);
+                }
+            }
+            
+            step.text = [NSString stringWithFormat:@"%@ %@ %@", restText, handText, tappingText];
+            
+            // Continue button will be different from first hand and second hand
+            if (hand == 1) {
+                step.detailText = ORKLocalizedString(@"TAPPING_CALL_TO_ACTION", nil);
+            }
+            else {
+                step.detailText = ORKLocalizedString(@"TAPPING_CALL_TO_ACTION_NEXT", nil);
+            }
+            
+            // Set the image
             UIImage *im1 = [UIImage imageNamed:@"handtapping01" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
             UIImage *im2 = [UIImage imageNamed:@"handtapping02" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
-            
-            step.image = [UIImage animatedImageWithImages:@[im1, im2] duration:1];
+            UIImage *imageAnimation = [UIImage animatedImageWithImages:@[im1, im2] duration:1];
+
+            if (rightHand || undefinedHand) {
+                step.image = imageAnimation;
+            }
+            else {
+                step.image = [imageAnimation ork_flippedImage:UIImageOrientationUpMirrored];
+            }
             step.shouldTintImages = YES;
             
             ORKStepArrayAddStep(steps, step);
         }
-    }
-    
-    {
-        NSMutableArray *recorderConfigurations = [NSMutableArray arrayWithCapacity:5];
-        if (! (ORKPredefinedTaskOptionExcludeAccelerometer & options)) {
-            [recorderConfigurations addObject:[[ORKAccelerometerRecorderConfiguration alloc] initWithIdentifier:ORKAccelerometerRecorderIdentifier
-                                                                                                      frequency:100]];
+
+        // TAPPING STEP
+        {
+            NSMutableArray *recorderConfigurations = [NSMutableArray arrayWithCapacity:5];
+            if (! (ORKPredefinedTaskOptionExcludeAccelerometer & options)) {
+                [recorderConfigurations addObject:[[ORKAccelerometerRecorderConfiguration alloc] initWithIdentifier:ORKAccelerometerRecorderIdentifier
+                                                                                                          frequency:100]];
+            }
+            
+            ORKTappingIntervalStep *step = [[ORKTappingIntervalStep alloc] initWithIdentifier:appendIdentifier(ORKTappingStepIdentifier)];
+            if (undefinedHand) {
+                step.title = ORKLocalizedString(@"TAPPING_INSTRUCTION", nil);
+            }
+            else if (rightHand) {
+                step.title = ORKLocalizedString(@"TAPPING_INSTRUCTION_RIGHT", nil);
+            }
+            else {
+                step.title = ORKLocalizedString(@"TAPPING_INSTRUCTION_LEFT", nil);
+            }
+            step.stepDuration = duration;
+            step.shouldContinueOnFinish = YES;
+            step.recorderConfigurations = recorderConfigurations;
+            step.optional = (handCount == 2);
+            
+            ORKStepArrayAddStep(steps, step);
         }
         
-        ORKTappingIntervalStep *step = [[ORKTappingIntervalStep alloc] initWithIdentifier:ORKTappingStepIdentifier];
-        step.title = ORKLocalizedString(@"TAPPING_INSTRUCTION", nil);
-        step.stepDuration = duration;
-        step.shouldContinueOnFinish = YES;
-        step.recorderConfigurations = recorderConfigurations;
-        
-        ORKStepArrayAddStep(steps, step);
+        // Flip to the other hand (ignored if handCount == 1)
+        rightHand = !rightHand;
     }
     
     if (! (options & ORKPredefinedTaskOptionExcludeConclusion)) {

--- a/ResearchKit/Common/ORKOrderedTask.m
+++ b/ResearchKit/Common/ORKOrderedTask.m
@@ -391,8 +391,7 @@ void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
         NSString * (^appendIdentifier) (NSString *) = ^ (NSString * identifier) {
             if (undefinedHand) {
                 return identifier;
-            }
-            else {
+            } else {
                 NSString *handIdentifier = rightHand ? ORKActiveTaskRightHandIdentifier : ORKActiveTaskLeftHandIdentifier;
                 return [NSString stringWithFormat:@"%@.%@", identifier, handIdentifier];
             }
@@ -404,11 +403,9 @@ void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
             // Set the title based on the hand
             if (undefinedHand) {
                 step.title = ORKLocalizedString(@"TAPPING_TASK_TITLE", nil);
-            }
-            else if (rightHand) {
+            } else if (rightHand) {
                 step.title = ORKLocalizedString(@"TAPPING_TASK_TITLE_RIGHT", nil);
-            }
-            else {
+            } else {
                 step.title = ORKLocalizedString(@"TAPPING_TASK_TITLE_LEFT", nil);
             }
             
@@ -421,19 +418,15 @@ void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
             if (hand == 1) {
                 if (undefinedHand) {
                     handText = ORKLocalizedString(@"TAPPING_INTRO_TEXT_2_MOST_AFFECTED", nil);
-                }
-                else if (rightHand) {
+                } else if (rightHand) {
                     handText = ORKLocalizedString(@"TAPPING_INTRO_TEXT_2_RIGHT_FIRST", nil);
-                }
-                else {
+                } else {
                     handText = ORKLocalizedString(@"TAPPING_INTRO_TEXT_2_LEFT_FIRST", nil);
                 }
-            }
-            else {
+            } else {
                 if (rightHand) {
                     handText = ORKLocalizedString(@"TAPPING_INTRO_TEXT_2_RIGHT_SECOND", nil);
-                }
-                else {
+                } else {
                     handText = ORKLocalizedString(@"TAPPING_INTRO_TEXT_2_LEFT_SECOND", nil);
                 }
             }
@@ -443,8 +436,7 @@ void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
             // Continue button will be different from first hand and second hand
             if (hand == 1) {
                 step.detailText = ORKLocalizedString(@"TAPPING_CALL_TO_ACTION", nil);
-            }
-            else {
+            } else {
                 step.detailText = ORKLocalizedString(@"TAPPING_CALL_TO_ACTION_NEXT", nil);
             }
             
@@ -455,8 +447,7 @@ void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
 
             if (rightHand || undefinedHand) {
                 step.image = imageAnimation;
-            }
-            else {
+            } else {
                 step.image = [imageAnimation ork_flippedImage:UIImageOrientationUpMirrored];
             }
             step.shouldTintImages = YES;
@@ -475,11 +466,9 @@ void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
             ORKTappingIntervalStep *step = [[ORKTappingIntervalStep alloc] initWithIdentifier:appendIdentifier(ORKTappingStepIdentifier)];
             if (undefinedHand) {
                 step.title = ORKLocalizedString(@"TAPPING_INSTRUCTION", nil);
-            }
-            else if (rightHand) {
+            } else if (rightHand) {
                 step.title = ORKLocalizedString(@"TAPPING_INSTRUCTION_RIGHT", nil);
-            }
-            else {
+            } else {
                 step.title = ORKLocalizedString(@"TAPPING_INSTRUCTION_LEFT", nil);
             }
             step.stepDuration = duration;

--- a/ResearchKit/Common/ORKOrderedTask.m
+++ b/ResearchKit/Common/ORKOrderedTask.m
@@ -2,6 +2,8 @@
  Copyright (c) 2015, Apple Inc. All rights reserved.
  Copyright (c) 2016, Sage Bionetworks - Added walk back and forth module
  
+ Copyright (c) 2016, Sage Bionetworks - Modified two finger tapping to track tapping speed for both hands
+ 
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
  
@@ -339,17 +341,16 @@ void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
     return [self twoFingerTappingIntervalTaskWithIdentifier:identifier
                                      intendedUseDescription:intendedUseDescription
                                                    duration:duration
-                                                    options:options
-                                                handOptions:ORKPredefinedTaskHandOptionUndefined];
+                                                handOptions:ORKPredefinedTaskHandOptionUndefined
+                                                    options:options];
 }
 
-/// Copyright (c) 2016, Sage Bionetworks - Modified to track tapping speed for both hands
 + (ORKOrderedTask *)twoFingerTappingIntervalTaskWithIdentifier:(NSString *)identifier
                                         intendedUseDescription:(NSString *)intendedUseDescription
                                                       duration:(NSTimeInterval)duration
-                                                       options:(ORKPredefinedTaskOption)options
                                                    handOptions:(ORKPredefinedTaskHandOption)handOptions
-{
+                                                       options:(ORKPredefinedTaskOption)options {
+    
     NSString *durationString = [ORKDurationStringFormatter() stringFromTimeInterval:duration];
     
     NSMutableArray *steps = [NSMutableArray array];

--- a/ResearchKit/Common/ORKOrderedTask.m
+++ b/ResearchKit/Common/ORKOrderedTask.m
@@ -339,7 +339,7 @@ void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
     return [self twoFingerTappingIntervalTaskWithIdentifier:identifier
                                      intendedUseDescription:intendedUseDescription
                                                    duration:duration
-                                                handOptions:ORKPredefinedTaskHandOptionUndefined
+                                                handOptions:0
                                                     options:options];
 }
 
@@ -374,13 +374,13 @@ void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
     // Setup which hand to start with and how many hands to add based on the handOptions parameter
     // Hand order is randomly determined.
     NSUInteger handCount = ((handOptions & ORKPredefinedTaskHandOptionBoth) == ORKPredefinedTaskHandOptionBoth) ? 2 : 1;
-    BOOL undefinedHand = (handOptions == ORKPredefinedTaskHandOptionUndefined);
+    BOOL undefinedHand = (handOptions == 0);
     BOOL rightHand;
     switch (handOptions) {
         case ORKPredefinedTaskHandOptionLeft:
             rightHand = NO; break;
         case ORKPredefinedTaskHandOptionRight:
-        case ORKPredefinedTaskHandOptionUndefined:
+        case ORKPredefinedTaskHandOptionUnspecified:
             rightHand = YES; break;
         default:
             rightHand = (arc4random()%2 == 0); break;

--- a/ResearchKit/Common/ORKOrderedTask.m
+++ b/ResearchKit/Common/ORKOrderedTask.m
@@ -1,8 +1,6 @@
 /*
  Copyright (c) 2015, Apple Inc. All rights reserved.
- Copyright (c) 2016, Sage Bionetworks - Added walk back and forth module
- 
- Copyright (c) 2016, Sage Bionetworks - Modified two finger tapping to track tapping speed for both hands
+ Copyright (c) 2016, Sage Bionetworks
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -388,8 +386,8 @@ void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
             rightHand = (arc4random()%2 == 0); break;
     }
     
-    for (NSUInteger hand=1; hand <= handCount; hand++)
-    {
+    for (NSUInteger hand = 1; hand <= handCount; hand++) {
+        
         NSString * (^appendIdentifier) (NSString *) = ^ (NSString * identifier) {
             if (undefinedHand) {
                 return identifier;
@@ -417,7 +415,7 @@ void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
             // Set the instructions for the tapping test screen that is displayed prior to each hand test
             NSString *restText = ORKLocalizedString(@"TAPPING_INTRO_TEXT_2_REST_PHONE", nil);
             NSString *tappingTextFormat = ORKLocalizedString(@"TAPPING_INTRO_TEXT_2_FORMAT", nil);
-            NSString *tappingText = [NSString stringWithFormat:tappingTextFormat, durationString];
+            NSString *tappingText = [NSString localizedStringWithFormat:tappingTextFormat, durationString];
             NSString *handText = nil;
             
             if (hand == 1) {
@@ -440,7 +438,7 @@ void ORKStepArrayAddStep(NSMutableArray *array, ORKStep *step) {
                 }
             }
             
-            step.text = [NSString stringWithFormat:@"%@ %@ %@", restText, handText, tappingText];
+            step.text = [NSString localizedStringWithFormat:@"%@ %@ %@", restText, handText, tappingText];
             
             // Continue button will be different from first hand and second hand
             if (hand == 1) {

--- a/ResearchKit/Common/UIImage+ResearchKit.h
+++ b/ResearchKit/Common/UIImage+ResearchKit.h
@@ -1,0 +1,37 @@
+/*
+ Copyright (c) 2015, Sage Bionetworks
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface UIImage (ResearchKit)
+
+- (UIImage *)ork_flippedImage:(UIImageOrientation)orientation;
+
+@end

--- a/ResearchKit/Common/UIImage+ResearchKit.m
+++ b/ResearchKit/Common/UIImage+ResearchKit.m
@@ -1,0 +1,135 @@
+/*
+ Copyright (c) 2015, Sage Bionetworks
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "UIImage+ResearchKit.h"
+
+@implementation UIImage (ResearchKit)
+
+- (UIImage *)ork_flippedImage:(UIImageOrientation)orientation
+{
+    if (self.images.count > 0) {
+        NSMutableArray <UIImage *> *images = [self.images mutableCopy];
+        [images enumerateObjectsUsingBlock:^(UIImage * _Nonnull image, NSUInteger idx, BOOL * _Nonnull stop __unused) {
+            [images replaceObjectAtIndex:idx
+                              withObject:[image ork_flippedImage:orientation]];
+        }];
+        return [UIImage animatedImageWithImages:images duration:self.duration];
+    } else {
+        // [UIImage imageWithCGImage:self.CGImage scale:self.scale orientation:orientation] doesn't seem
+        // to work with images that are vector PDF rather than PNG, so...
+        CGRect bounds = CGRectMake(0., 0., self.size.width, self.size.height);
+        CGAffineTransform transform = CGAffineTransformIdentity;
+        switch(orientation)
+        {
+            case UIImageOrientationUp:
+            {
+                transform = CGAffineTransformIdentity;
+            }
+                break;
+                
+            case UIImageOrientationUpMirrored:
+            {
+                transform = CGAffineTransformMakeTranslation(self.size.width, 0.);
+                transform = CGAffineTransformScale(transform, -1.0f, 1.0f);
+            }
+                break;
+                
+            case UIImageOrientationDown:
+            {
+                transform = CGAffineTransformMakeTranslation(self.size.width, self.size.height);
+                transform = CGAffineTransformRotate(transform, M_PI);
+            }
+                break;
+                
+            case UIImageOrientationDownMirrored:
+            {
+                transform = CGAffineTransformMakeTranslation (0., self.size.height);
+                transform = CGAffineTransformScale(transform, 1.0f, -1.0f);
+            }
+                break;
+                
+            case UIImageOrientationLeftMirrored:
+            {
+                CGFloat boundHeight = bounds.size.height;
+                bounds.size.height = bounds.size.width;
+                bounds.size.width = boundHeight;
+                transform = CGAffineTransformMakeTranslation (self.size.height, self.size.width);
+                transform = CGAffineTransformScale(transform, -1.0f, 1.0f);
+                transform = CGAffineTransformRotate(transform, 3.0f * M_PI/ 2.0f);
+            }
+                break;
+                
+            case UIImageOrientationLeft:
+            {
+                CGFloat boundHeight = bounds.size.height;
+                bounds.size.height = bounds.size.width;
+                bounds.size.width = boundHeight;
+                transform = CGAffineTransformMakeTranslation (0.0f, self.size.width);
+                transform = CGAffineTransformRotate(transform, 3.0f * M_PI / 2.0f);
+            }
+                break;
+                
+            case UIImageOrientationRightMirrored:
+            {
+                CGFloat boundHeight = bounds.size.height;
+                bounds.size.height = bounds.size.width;
+                bounds.size.width = boundHeight;
+                transform = CGAffineTransformMakeScale(-1.0f, 1.0f);
+                transform = CGAffineTransformRotate(transform, M_PI / 2.0f);
+            }
+                break;
+                
+            case UIImageOrientationRight:
+            {
+                CGFloat boundHeight = bounds.size.height;
+                bounds.size.height = bounds.size.width;
+                bounds.size.width = boundHeight;
+                transform = CGAffineTransformMakeTranslation(self.size.height, 0.0f);
+                transform = CGAffineTransformRotate(transform, M_PI  / 2.0f);
+            }
+                break;
+                
+        }
+
+        UIGraphicsBeginImageContext(self.size);
+        CGContextRef context = UIGraphicsGetCurrentContext();
+        
+        CGContextConcatCTM(context, transform);
+
+        [self drawInRect:CGRectMake(0.f, 0.f, self.size.width, self.size.height)];
+        
+        UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+        
+        return newImage;
+    }
+}
+
+@end

--- a/ResearchKit/Common/UIImage+ResearchKit.m
+++ b/ResearchKit/Common/UIImage+ResearchKit.m
@@ -32,8 +32,8 @@
 
 @implementation UIImage (ResearchKit)
 
-- (UIImage *)ork_flippedImage:(UIImageOrientation)orientation
-{
+- (UIImage *)ork_flippedImage:(UIImageOrientation)orientation {
+    
     if (self.images.count > 0) {
         NSMutableArray <UIImage *> *images = [self.images mutableCopy];
         [images enumerateObjectsUsingBlock:^(UIImage * _Nonnull image, NSUInteger idx, BOOL * _Nonnull stop __unused) {
@@ -46,76 +46,58 @@
         // to work with images that are vector PDF rather than PNG, so...
         CGRect bounds = CGRectMake(0., 0., self.size.width, self.size.height);
         CGAffineTransform transform = CGAffineTransformIdentity;
-        switch(orientation)
-        {
-            case UIImageOrientationUp:
-            {
+        switch(orientation) {
+            case UIImageOrientationUp: {
                 transform = CGAffineTransformIdentity;
-            }
-                break;
+            } break;
                 
-            case UIImageOrientationUpMirrored:
-            {
+            case UIImageOrientationUpMirrored: {
                 transform = CGAffineTransformMakeTranslation(self.size.width, 0.);
                 transform = CGAffineTransformScale(transform, -1.0f, 1.0f);
-            }
-                break;
+            } break;
                 
-            case UIImageOrientationDown:
-            {
+            case UIImageOrientationDown: {
                 transform = CGAffineTransformMakeTranslation(self.size.width, self.size.height);
                 transform = CGAffineTransformRotate(transform, M_PI);
-            }
-                break;
+            } break;
                 
-            case UIImageOrientationDownMirrored:
-            {
+            case UIImageOrientationDownMirrored: {
                 transform = CGAffineTransformMakeTranslation (0., self.size.height);
                 transform = CGAffineTransformScale(transform, 1.0f, -1.0f);
-            }
-                break;
+            } break;
                 
-            case UIImageOrientationLeftMirrored:
-            {
+            case UIImageOrientationLeftMirrored: {
                 CGFloat boundHeight = bounds.size.height;
                 bounds.size.height = bounds.size.width;
                 bounds.size.width = boundHeight;
                 transform = CGAffineTransformMakeTranslation (self.size.height, self.size.width);
                 transform = CGAffineTransformScale(transform, -1.0f, 1.0f);
                 transform = CGAffineTransformRotate(transform, 3.0f * M_PI/ 2.0f);
-            }
-                break;
+            } break;
                 
-            case UIImageOrientationLeft:
-            {
+            case UIImageOrientationLeft: {
                 CGFloat boundHeight = bounds.size.height;
                 bounds.size.height = bounds.size.width;
                 bounds.size.width = boundHeight;
                 transform = CGAffineTransformMakeTranslation (0.0f, self.size.width);
                 transform = CGAffineTransformRotate(transform, 3.0f * M_PI / 2.0f);
-            }
-                break;
+            } break;
                 
-            case UIImageOrientationRightMirrored:
-            {
+            case UIImageOrientationRightMirrored: {
                 CGFloat boundHeight = bounds.size.height;
                 bounds.size.height = bounds.size.width;
                 bounds.size.width = boundHeight;
                 transform = CGAffineTransformMakeScale(-1.0f, 1.0f);
                 transform = CGAffineTransformRotate(transform, M_PI / 2.0f);
-            }
-                break;
+            } break;
                 
-            case UIImageOrientationRight:
-            {
+            case UIImageOrientationRight: {
                 CGFloat boundHeight = bounds.size.height;
                 bounds.size.height = bounds.size.width;
                 bounds.size.width = boundHeight;
                 transform = CGAffineTransformMakeTranslation(self.size.height, 0.0f);
                 transform = CGAffineTransformRotate(transform, M_PI  / 2.0f);
-            }
-                break;
-                
+            } break;
         }
 
         UIGraphicsBeginImageContext(self.size);

--- a/ResearchKit/Localized/en.lproj/ResearchKit.strings
+++ b/ResearchKit/Localized/en.lproj/ResearchKit.strings
@@ -236,13 +236,23 @@
 
 /* Tapping active task. */
 "TAPPING_TASK_TITLE" = "Tapping Speed";
+"TAPPING_TASK_TITLE_RIGHT" = "Right Hand";
+"TAPPING_TASK_TITLE_LEFT" = "Left Hand";
 "TAPPING_INTRO_TEXT" = "This activity measures your tapping speed.";
-"TAPPING_INTRO_TEXT_2_FORMAT" = "Rest your phone on a flat surface. Two buttons will appear on your screen for %@. Using two fingers on the same hand, take turns tapping the buttons as quickly as you can.";
+"TAPPING_INTRO_TEXT_2_REST_PHONE" = "Put your phone on a flat surface.";
+"TAPPING_INTRO_TEXT_2_MOST_AFFECTED" = "Use two fingers on the same hand to alternately tap the buttons on the screen.";
+"TAPPING_INTRO_TEXT_2_RIGHT_FIRST" = "Use two fingers on your right hand to alternately tap the buttons on the screen.";
+"TAPPING_INTRO_TEXT_2_LEFT_FIRST" = "Use two fingers on your left hand to alternately tap the buttons on the screen.";
+"TAPPING_INTRO_TEXT_2_RIGHT_SECOND" = "Now repeat the same test using your right hand.";
+"TAPPING_INTRO_TEXT_2_LEFT_SECOND" = "Now repeat the same test using your left hand.";
+"TAPPING_INTRO_TEXT_2_FORMAT" = "Tap one finger, then the other. Try to time your taps to be as even as possible. Keep tapping for %@.";
 "TAPPING_CALL_TO_ACTION" = "Tap Get Started to begin.";
+"TAPPING_CALL_TO_ACTION_NEXT" = "Tap Next to begin.";
 "TAP_BUTTON_TITLE" = "Tap";
 "TOTAL_TAPS_LABEL" = "Total Taps";
-"TAPPING_INSTRUCTION" = "Tap the buttons as quickly as you can using two fingers.";
-
+"TAPPING_INSTRUCTION" = "Tap the buttons as consistently as you can using two fingers.";
+"TAPPING_INSTRUCTION_RIGHT" = "Tap the buttons using your RIGHT hand.";
+"TAPPING_INSTRUCTION_LEFT" = "Tap the buttons using your LEFT hand.";
 
 /* Audio active task. */
 "AUDIO_TASK_TITLE" = "Voice";

--- a/ResearchKit/Localized/en.lproj/ResearchKit.strings
+++ b/ResearchKit/Localized/en.lproj/ResearchKit.strings
@@ -253,6 +253,7 @@
 "TAPPING_INSTRUCTION" = "Tap the buttons as consistently as you can using two fingers.";
 "TAPPING_INSTRUCTION_RIGHT" = "Tap the buttons using your RIGHT hand.";
 "TAPPING_INSTRUCTION_LEFT" = "Tap the buttons using your LEFT hand.";
+"TAPPING_SKIP_TITLE" = "Skip this hand";
 
 /* Audio active task. */
 "AUDIO_TASK_TITLE" = "Voice";

--- a/ResearchKitTests/ORKTaskTests.m
+++ b/ResearchKitTests/ORKTaskTests.m
@@ -1481,19 +1481,17 @@ static ORKStepResult *(^getStepResult)(NSString *, Class, ORKQuestionType, id) =
                                                                              duration:10
                                                                               options:0
                                                                           handOptions:0];
-    XCTAssertEqual(task.steps.count, 4);
+    NSArray *expectedStepIdentifiers = @[ORKInstruction0StepIdentifier,
+                                              ORKInstruction1StepIdentifier,
+                                              ORKTappingStepIdentifier,
+                                              ORKConclusionStepIdentifier];
+    NSArray *stepIdentifiers = [task.steps valueForKey:@"identifier"];
+    XCTAssertEqual(stepIdentifiers.count, expectedStepIdentifiers.count);
+    XCTAssertEqualObjects(stepIdentifiers, expectedStepIdentifiers);
     
-    for (ORKStep *step in task.steps) {
-        XCTAssertFalse([step.identifier.lowercaseString containsString:@"left"]);
-        XCTAssertFalse([step.identifier.lowercaseString containsString:@"right"]);
-        XCTAssertFalse([step.title.lowercaseString containsString:@"right"]);
-        XCTAssertFalse([step.title.lowercaseString containsString:@"left"]);
-        XCTAssertFalse([step.text.lowercaseString containsString:@"right"]);
-        XCTAssertFalse([step.text.lowercaseString containsString:@"left"]);
-        if ([step isKindOfClass:[ORKActiveStep class]]) {
-            XCTAssertFalse(step.optional);
-        }
-    }
+    ORKStep *tappingStep = [task stepWithIdentifier:ORKTappingStepIdentifier];
+    XCTAssertFalse(tappingStep.optional);
+
 }
 
 - (void)testTwoFingerTappingIntervalTaskWithIdentifier_TapHandOptionLeft {

--- a/ResearchKitTests/ORKTaskTests.m
+++ b/ResearchKitTests/ORKTaskTests.m
@@ -1578,7 +1578,7 @@ static ORKStepResult *(^getStepResult)(NSString *, Class, ORKQuestionType, id) =
     NSUInteger totalCount = 100;
     NSUInteger threshold = 30;
     
-    for (int ii=0; ii<totalCount; ii++) {
+    for (int ii = 0; ii < totalCount; ii++) {
         ORKOrderedTask *task = [ORKOrderedTask twoFingerTappingIntervalTaskWithIdentifier:@"test"
                                                                    intendedUseDescription:nil
                                                                                  duration:10

--- a/ResearchKitTests/ORKTaskTests.m
+++ b/ResearchKitTests/ORKTaskTests.m
@@ -1572,17 +1572,13 @@ static ORKStepResult *(^getStepResult)(NSString *, Class, ORKQuestionType, id) =
     
 }
 
-- (void)testTwoFingerTappingIntervalTaskWithIdentifier_TapHandOptionBoth
-{
+- (void)testTwoFingerTappingIntervalTaskWithIdentifier_TapHandOptionBoth {
     NSUInteger leftCount = 0;
     NSUInteger rightCount = 0;
     NSUInteger totalCount = 100;
     NSUInteger threshold = 30;
     
-    for (int ii=0; ii<totalCount; ii++)
-    {
-        
-        
+    for (int ii=0; ii<totalCount; ii++) {
         ORKOrderedTask *task = [ORKOrderedTask twoFingerTappingIntervalTaskWithIdentifier:@"test"
                                                                    intendedUseDescription:nil
                                                                                  duration:10
@@ -1605,8 +1601,7 @@ static ORKStepResult *(^getStepResult)(NSString *, Class, ORKQuestionType, id) =
         BOOL isRightFirst = [task.steps indexOfObject:rightInstructionStep] < [task.steps indexOfObject:leftInstructionStep];
         if (isRightFirst) {
             rightCount++;
-        }
-        else {
+        } else {
             leftCount++;
         }
         
@@ -1621,8 +1616,7 @@ static ORKStepResult *(^getStepResult)(NSString *, Class, ORKQuestionType, id) =
             if (isRightFirst) {
                 XCTAssertEqualObjects(rightInstructionStep.text, @"Put your phone on a flat surface. Use two fingers on your right hand to alternately tap the buttons on the screen. Tap one finger, then the other. Try to time your taps to be as even as possible. Keep tapping for 10 seconds.");
                 XCTAssertEqualObjects(leftInstructionStep.text, @"Put your phone on a flat surface. Now repeat the same test using your left hand. Tap one finger, then the other. Try to time your taps to be as even as possible. Keep tapping for 10 seconds.");
-            }
-            else {
+            } else {
                 XCTAssertEqualObjects(leftInstructionStep.text, @"Put your phone on a flat surface. Use two fingers on your left hand to alternately tap the buttons on the screen. Tap one finger, then the other. Try to time your taps to be as even as possible. Keep tapping for 10 seconds.");
                 XCTAssertEqualObjects(rightInstructionStep.text, @"Put your phone on a flat surface. Now repeat the same test using your right hand. Tap one finger, then the other. Try to time your taps to be as even as possible. Keep tapping for 10 seconds.");
             }

--- a/ResearchKitTests/ORKTaskTests.m
+++ b/ResearchKitTests/ORKTaskTests.m
@@ -1353,7 +1353,7 @@ static ORKStepResult *(^getStepResult)(NSString *, Class, ORKQuestionType, id) =
 
 - (void)testStepViewControllerWillDisappear {
     TestTaskViewControllerDelegate *delegate = [[TestTaskViewControllerDelegate alloc] init];
-    ORKOrderedTask *task = [ORKOrderedTask twoFingerTappingIntervalTaskWithIdentifier:@"test" intendedUseDescription:nil duration:30 options:0];
+    ORKOrderedTask *task = [ORKOrderedTask twoFingerTappingIntervalTaskWithIdentifier:@"test" intendedUseDescription:nil duration:30 options:0 handOptions:0];
     ORKTaskViewController *taskViewController = [[MockTaskViewController alloc] initWithTask:task taskRunUUID:nil];
     taskViewController.delegate = delegate;
     ORKInstructionStepViewController *stepViewController = [[ORKInstructionStepViewController alloc] initWithStep:task.steps.firstObject];
@@ -1370,7 +1370,7 @@ static ORKStepResult *(^getStepResult)(NSString *, Class, ORKQuestionType, id) =
 }
 
 - (void)testIndexOfStep {
-    ORKOrderedTask *task = [ORKOrderedTask twoFingerTappingIntervalTaskWithIdentifier:@"tapping" intendedUseDescription:nil duration:30 options:0];
+    ORKOrderedTask *task = [ORKOrderedTask twoFingerTappingIntervalTaskWithIdentifier:@"tapping" intendedUseDescription:nil duration:30 options:0 handOptions:0];
     
     // get the first step
     ORKStep *step0 = [task.steps firstObject];

--- a/ResearchKitTests/ORKTaskTests.m
+++ b/ResearchKitTests/ORKTaskTests.m
@@ -1472,6 +1472,181 @@ static ORKStepResult *(^getStepResult)(NSString *, Class, ORKQuestionType, id) =
     
 }
 
+#pragma mark - two-finger tapping with both hands
+
+- (void)testTwoFingerTappingIntervalTaskWithIdentifier_TapHandOptionUndefined {
+    
+    ORKOrderedTask *task = [ORKOrderedTask twoFingerTappingIntervalTaskWithIdentifier:@"test"
+                                                               intendedUseDescription:nil
+                                                                             duration:10
+                                                                              options:0
+                                                                          handOptions:0];
+    XCTAssertEqual(task.steps.count, 4);
+    
+    for (ORKStep *step in task.steps) {
+        XCTAssertFalse([step.identifier.lowercaseString containsString:@"left"]);
+        XCTAssertFalse([step.identifier.lowercaseString containsString:@"right"]);
+        XCTAssertFalse([step.title.lowercaseString containsString:@"right"]);
+        XCTAssertFalse([step.title.lowercaseString containsString:@"left"]);
+        XCTAssertFalse([step.text.lowercaseString containsString:@"right"]);
+        XCTAssertFalse([step.text.lowercaseString containsString:@"left"]);
+        if ([step isKindOfClass:[ORKActiveStep class]]) {
+            XCTAssertFalse(step.optional);
+        }
+    }
+}
+
+- (void)testTwoFingerTappingIntervalTaskWithIdentifier_TapHandOptionLeft {
+    
+    ORKOrderedTask *task = [ORKOrderedTask twoFingerTappingIntervalTaskWithIdentifier:@"test"
+                                                               intendedUseDescription:nil
+                                                                             duration:10
+                                                                              options:0
+                                                                          handOptions:ORKPredefinedTaskHandOptionLeft];
+    // Check assumption around how many steps
+    XCTAssertEqual(task.steps.count, 4);
+    
+    // Check that none of the language or identifiers contain the word "right"
+    for (ORKStep *step in task.steps) {
+        XCTAssertFalse([step.identifier.lowercaseString hasSuffix:@"right"]);
+        XCTAssertFalse([step.title.lowercaseString containsString:@"right"]);
+        XCTAssertFalse([step.text.lowercaseString containsString:@"right"]);
+    }
+    
+    NSArray * (^filteredSteps)(NSString*, NSString*) = ^(NSString *part1, NSString *part2) {
+        NSString *keyValue = [NSString stringWithFormat:@"%@.%@", part1, part2];
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K == %@", NSStringFromSelector(@selector(identifier)), keyValue];
+        return [task.steps filteredArrayUsingPredicate:predicate];
+    };
+    
+    // Look for instruction step
+    NSArray *instructions = filteredSteps(@"instruction1", @"left");
+    XCTAssertEqual(instructions.count, 1);
+    ORKStep *instructionStep = [instructions firstObject];
+    XCTAssertEqualObjects(instructionStep.title, @"Left Hand");
+    XCTAssertEqualObjects(instructionStep.text, @"Put your phone on a flat surface. Use two fingers on your left hand to alternately tap the buttons on the screen. Tap one finger, then the other. Try to time your taps to be as even as possible. Keep tapping for 10 seconds.");
+    
+    // Look for the activity step
+    NSArray *tappings = filteredSteps(@"tapping", @"left");
+    XCTAssertEqual(tappings.count, 1);
+    ORKStep *tappingStep = [tappings firstObject];
+    XCTAssertEqualObjects(tappingStep.title, @"Tap the buttons using your LEFT hand.");
+    XCTAssertFalse(tappingStep.optional);
+    
+}
+
+- (void)testTwoFingerTappingIntervalTaskWithIdentifier_TapHandOptionRight {
+    
+    ORKOrderedTask *task = [ORKOrderedTask twoFingerTappingIntervalTaskWithIdentifier:@"test"
+                                                               intendedUseDescription:nil
+                                                                             duration:10
+                                                                              options:0
+                                                                          handOptions:ORKPredefinedTaskHandOptionRight];
+    // Check assumption around how many steps
+    XCTAssertEqual(task.steps.count, 4);
+    
+    // Check that none of the language or identifiers contain the word "right"
+    for (ORKStep *step in task.steps) {
+        XCTAssertFalse([step.identifier.lowercaseString hasSuffix:@"left"]);
+        XCTAssertFalse([step.title.lowercaseString containsString:@"left"]);
+        XCTAssertFalse([step.text.lowercaseString containsString:@"left"]);
+    }
+    
+    NSArray * (^filteredSteps)(NSString*, NSString*) = ^(NSString *part1, NSString *part2) {
+        NSString *keyValue = [NSString stringWithFormat:@"%@.%@", part1, part2];
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K == %@", NSStringFromSelector(@selector(identifier)), keyValue];
+        return [task.steps filteredArrayUsingPredicate:predicate];
+    };
+    
+    // Look for instruction step
+    NSArray *instructions = filteredSteps(@"instruction1", @"right");
+    XCTAssertEqual(instructions.count, 1);
+    ORKStep *instructionStep = [instructions firstObject];
+    XCTAssertEqualObjects(instructionStep.title, @"Right Hand");
+    XCTAssertEqualObjects(instructionStep.text, @"Put your phone on a flat surface. Use two fingers on your right hand to alternately tap the buttons on the screen. Tap one finger, then the other. Try to time your taps to be as even as possible. Keep tapping for 10 seconds.");
+    
+    // Look for the activity step
+    NSArray *tappings = filteredSteps(@"tapping", @"right");
+    XCTAssertEqual(tappings.count, 1);
+    ORKStep *tappingStep = [tappings firstObject];
+    XCTAssertEqualObjects(tappingStep.title, @"Tap the buttons using your RIGHT hand.");
+    XCTAssertFalse(tappingStep.optional);
+    
+}
+
+- (void)testTwoFingerTappingIntervalTaskWithIdentifier_TapHandOptionBoth
+{
+    NSUInteger leftCount = 0;
+    NSUInteger rightCount = 0;
+    NSUInteger totalCount = 100;
+    NSUInteger threshold = 30;
+    
+    for (int ii=0; ii<totalCount; ii++)
+    {
+        
+        
+        ORKOrderedTask *task = [ORKOrderedTask twoFingerTappingIntervalTaskWithIdentifier:@"test"
+                                                                   intendedUseDescription:nil
+                                                                                 duration:10
+                                                                                  options:0
+                                                                              handOptions:ORKPredefinedTaskHandOptionBoth];
+        ORKStep * (^filteredSteps)(NSString*, NSString*) = ^(NSString *part1, NSString *part2) {
+            NSString *keyValue = [NSString stringWithFormat:@"%@.%@", part1, part2];
+            NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K == %@", NSStringFromSelector(@selector(identifier)), keyValue];
+            return [[task.steps filteredArrayUsingPredicate:predicate] firstObject];
+        };
+        
+        // Look for instruction steps
+        ORKStep *rightInstructionStep = filteredSteps(@"instruction1", @"right");
+        XCTAssertNotNil(rightInstructionStep);
+        ORKStep *leftInstructionStep = filteredSteps(@"instruction1", @"left");
+        XCTAssertNotNil(leftInstructionStep);
+        
+        // Depending upon the seed (clock time) this will be either the right or left hand
+        // Without using OCMock, cannot easily verify that both will display.
+        BOOL isRightFirst = [task.steps indexOfObject:rightInstructionStep] < [task.steps indexOfObject:leftInstructionStep];
+        if (isRightFirst) {
+            rightCount++;
+        }
+        else {
+            leftCount++;
+        }
+        
+        if ((isRightFirst && rightCount == 1) || (!isRightFirst && leftCount == 1)) {
+            
+            // Look for instruction steps
+            XCTAssertEqualObjects(rightInstructionStep.title, @"Right Hand");
+            XCTAssertEqualObjects(leftInstructionStep.title, @"Left Hand");
+            
+            // Depending upon the seed (clock time) this will be either the right or left hand
+            // Without using OCMock, cannot easily verify that both will display.
+            if (isRightFirst) {
+                XCTAssertEqualObjects(rightInstructionStep.text, @"Put your phone on a flat surface. Use two fingers on your right hand to alternately tap the buttons on the screen. Tap one finger, then the other. Try to time your taps to be as even as possible. Keep tapping for 10 seconds.");
+                XCTAssertEqualObjects(leftInstructionStep.text, @"Put your phone on a flat surface. Now repeat the same test using your left hand. Tap one finger, then the other. Try to time your taps to be as even as possible. Keep tapping for 10 seconds.");
+            }
+            else {
+                XCTAssertEqualObjects(leftInstructionStep.text, @"Put your phone on a flat surface. Use two fingers on your left hand to alternately tap the buttons on the screen. Tap one finger, then the other. Try to time your taps to be as even as possible. Keep tapping for 10 seconds.");
+                XCTAssertEqualObjects(rightInstructionStep.text, @"Put your phone on a flat surface. Now repeat the same test using your right hand. Tap one finger, then the other. Try to time your taps to be as even as possible. Keep tapping for 10 seconds.");
+            }
+            
+            // Look for tapping steps
+            ORKStep *rightTapStep = filteredSteps(@"tapping", @"right");
+            XCTAssertNotNil(rightTapStep);
+            XCTAssertEqualObjects(rightTapStep.title, @"Tap the buttons using your RIGHT hand.");
+            XCTAssertTrue(rightTapStep.optional);
+            
+            ORKStep *leftTapStep = filteredSteps(@"tapping", @"left");
+            XCTAssertNotNil(leftTapStep);
+            XCTAssertEqualObjects(leftTapStep.title, @"Tap the buttons using your LEFT hand.");
+            XCTAssertTrue(leftTapStep.optional);
+        }
+    }
+    
+    XCTAssertGreaterThan(leftCount, threshold);
+    XCTAssertGreaterThan(rightCount, threshold);
+}
+
+
 @end
 
 @implementation MethodObject

--- a/ResearchKitTests/ORKTaskTests.m
+++ b/ResearchKitTests/ORKTaskTests.m
@@ -1353,7 +1353,7 @@ static ORKStepResult *(^getStepResult)(NSString *, Class, ORKQuestionType, id) =
 
 - (void)testStepViewControllerWillDisappear {
     TestTaskViewControllerDelegate *delegate = [[TestTaskViewControllerDelegate alloc] init];
-    ORKOrderedTask *task = [ORKOrderedTask twoFingerTappingIntervalTaskWithIdentifier:@"test" intendedUseDescription:nil duration:30 options:0 handOptions:0];
+    ORKOrderedTask *task = [ORKOrderedTask twoFingerTappingIntervalTaskWithIdentifier:@"test" intendedUseDescription:nil duration:30 handOptions:0 options:0];
     ORKTaskViewController *taskViewController = [[MockTaskViewController alloc] initWithTask:task taskRunUUID:nil];
     taskViewController.delegate = delegate;
     ORKInstructionStepViewController *stepViewController = [[ORKInstructionStepViewController alloc] initWithStep:task.steps.firstObject];
@@ -1370,7 +1370,7 @@ static ORKStepResult *(^getStepResult)(NSString *, Class, ORKQuestionType, id) =
 }
 
 - (void)testIndexOfStep {
-    ORKOrderedTask *task = [ORKOrderedTask twoFingerTappingIntervalTaskWithIdentifier:@"tapping" intendedUseDescription:nil duration:30 options:0 handOptions:0];
+    ORKOrderedTask *task = [ORKOrderedTask twoFingerTappingIntervalTaskWithIdentifier:@"tapping" intendedUseDescription:nil duration:30 handOptions:0 options:0];
     
     // get the first step
     ORKStep *step0 = [task.steps firstObject];
@@ -1479,8 +1479,8 @@ static ORKStepResult *(^getStepResult)(NSString *, Class, ORKQuestionType, id) =
     ORKOrderedTask *task = [ORKOrderedTask twoFingerTappingIntervalTaskWithIdentifier:@"test"
                                                                intendedUseDescription:nil
                                                                              duration:10
-                                                                              options:0
-                                                                          handOptions:0];
+                                                                          handOptions:0
+                                                                              options:0];
     NSArray *expectedStepIdentifiers = @[ORKInstruction0StepIdentifier,
                                               ORKInstruction1StepIdentifier,
                                               ORKTappingStepIdentifier,
@@ -1499,8 +1499,8 @@ static ORKStepResult *(^getStepResult)(NSString *, Class, ORKQuestionType, id) =
     ORKOrderedTask *task = [ORKOrderedTask twoFingerTappingIntervalTaskWithIdentifier:@"test"
                                                                intendedUseDescription:nil
                                                                              duration:10
-                                                                              options:0
-                                                                          handOptions:ORKPredefinedTaskHandOptionLeft];
+                                                                          handOptions:ORKPredefinedTaskHandOptionLeft
+                                                                              options:0];
     // Check assumption around how many steps
     XCTAssertEqual(task.steps.count, 4);
     
@@ -1538,8 +1538,8 @@ static ORKStepResult *(^getStepResult)(NSString *, Class, ORKQuestionType, id) =
     ORKOrderedTask *task = [ORKOrderedTask twoFingerTappingIntervalTaskWithIdentifier:@"test"
                                                                intendedUseDescription:nil
                                                                              duration:10
-                                                                              options:0
-                                                                          handOptions:ORKPredefinedTaskHandOptionRight];
+                                                                          handOptions:ORKPredefinedTaskHandOptionRight
+                                                                              options:0];
     // Check assumption around how many steps
     XCTAssertEqual(task.steps.count, 4);
     
@@ -1586,8 +1586,8 @@ static ORKStepResult *(^getStepResult)(NSString *, Class, ORKQuestionType, id) =
         ORKOrderedTask *task = [ORKOrderedTask twoFingerTappingIntervalTaskWithIdentifier:@"test"
                                                                    intendedUseDescription:nil
                                                                                  duration:10
-                                                                                  options:0
-                                                                              handOptions:ORKPredefinedTaskHandOptionBoth];
+                                                                              handOptions:ORKPredefinedTaskHandOptionBoth
+                                                                                  options:0];
         ORKStep * (^filteredSteps)(NSString*, NSString*) = ^(NSString *part1, NSString *part2) {
             NSString *keyValue = [NSString stringWithFormat:@"%@.%@", part1, part2];
             NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K == %@", NSStringFromSelector(@selector(identifier)), keyValue];

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -522,6 +522,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         return [ORKOrderedTask twoFingerTappingIntervalTaskWithIdentifier:TwoFingerTapTaskIdentifier
                                                    intendedUseDescription:nil
                                                                  duration:20.0
+                                                              handOptions:ORKPredefinedTaskHandOptionBoth
                                                                   options:(ORKPredefinedTaskOption)0];
     } else if ([identifier isEqualToString:ReactionTimeTaskIdentifier]) {
         return [ORKOrderedTask reactionTimeTaskWithIdentifier:ReactionTimeTaskIdentifier

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -1181,7 +1181,7 @@ enum TaskListRow: Int, CustomStringConvertible {
     
     /// This task presents the Two Finger Tapping pre-defined active task.
     private var twoFingerTappingIntervalTask: ORKTask {
-        return ORKOrderedTask.twoFingerTappingIntervalTaskWithIdentifier(String(Identifier.TwoFingerTappingIntervalTask), intendedUseDescription: exampleDescription, duration: 20, options: [])
+        return ORKOrderedTask.twoFingerTappingIntervalTaskWithIdentifier(String(Identifier.TwoFingerTappingIntervalTask), intendedUseDescription: exampleDescription, duration: 10, options: [], handOptions: [.Both])
     }
     
     /// This task presents a walk back-and-forth task

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -1181,7 +1181,7 @@ enum TaskListRow: Int, CustomStringConvertible {
     
     /// This task presents the Two Finger Tapping pre-defined active task.
     private var twoFingerTappingIntervalTask: ORKTask {
-        return ORKOrderedTask.twoFingerTappingIntervalTaskWithIdentifier(String(Identifier.TwoFingerTappingIntervalTask), intendedUseDescription: exampleDescription, duration: 10, options: [], handOptions: [.Both])
+        return ORKOrderedTask.twoFingerTappingIntervalTaskWithIdentifier(String(Identifier.TwoFingerTappingIntervalTask), intendedUseDescription: exampleDescription, duration: 10, handOptions: [.Both], options: [])
     }
     
     /// This task presents a walk back-and-forth task


### PR DESCRIPTION
This pull request replaces https://github.com/ResearchKit/ResearchKit/pull/717

This includes the following required changes as well as the updated module:
1. `ORKTappingContentView` will show the skip button if applicable.
2. Added category method for flipping a set of images.

`ORKCatalog` has been modified to include this module as an example (in addition to the original tapping test that does not differentiate between left and right hand).

With the mPower app, one of the things our researchers wished to know was which hand the user was using to perform the tapping activity. This module is in addition to the existing modules that may be used in other apps and will allow the developer to specify either hand or both.