### PR TITLE
ork_answer_format_property

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -1289,6 +1289,13 @@ ORK_CLASS_AVAILABLE
  */
 @property(nonatomic,getter=isSecureTextEntry) BOOL secureTextEntry;
 
+/**
+ Identifies whether the text object should be allowed to be blank strings, aka all whitespace, like "   ".
+ 
+ By default, the value of this property is NO.
+ */
+@property (nonatomic) BOOL disallowBlankString;
+
 @end
 
 

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -170,6 +170,7 @@ static NSString *const _FamilyNameIdentifier = @"family";
     nameAnswerFormat.autocapitalizationType = UITextAutocapitalizationTypeWords;
     nameAnswerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
     nameAnswerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+    nameAnswerFormat.disallowBlankString = YES;
     ORKFormItem *givenNameFormItem = [[ORKFormItem alloc] initWithIdentifier:_GivenNameIdentifier
                                                               text:ORKLocalizedString(@"CONSENT_NAME_GIVEN", nil)
                                                       answerFormat:nameAnswerFormat];


### PR DESCRIPTION
I am one of the primary developers for the Football Player's Health Study App.  We had a bug filed that user's could enter any blank string, like "    ", as their name in the consent review flow, and it would allow them to continue.  

To fix it, I added a new property to ORKAnswerFormat that allows the consent review step vc to make any "blank" string be considered invalid input.