### PR TITLE
bad_access_fix

### DIFF
--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -946,6 +946,12 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     
     ORKWeakTypeOf(self) weakSelf = self;
     [self.pageViewController setViewControllers:@[viewController] direction:direction animated:animated completion:^(BOOL finished) {
+        
+        if (weakSelf == nil) {
+            ORK_Log_Debug(@"Task VC has been dismissed, skipping block code");
+            return;
+        }
+        
         ORKStrongTypeOf(weakSelf) strongSelf = weakSelf;
         
         ORK_Log_Debug(@"%@ %@", strongSelf, viewController);


### PR DESCRIPTION
Our QA team found an EXC_BAD_ACCESS crash on strongSelf of this block callback.  It is caused by quickly canceling a task while it is transitioning.

To fix it, I added a check if weakSelf is nil so that we can avoid the strong self bad access crash.