### PR TITLE
[Charts] Fix crashes

### DIFF
--- a/ResearchKit/Charts/ORKGraphChartView.h
+++ b/ResearchKit/Charts/ORKGraphChartView.h
@@ -109,10 +109,8 @@ ORK_AVAILABLE_DECL
 - (NSInteger)graphChartView:(ORKGraphChartView *)graphChartView numberOfDataPointsForPlotIndex:(NSInteger)plotIndex;
 
 
-@optional
 /**
- Asks the data source for the number of plots to be plotted by the graph chart view. If this method
- is not implemented, the graph chart view assumes that it has a single plot.
+ Asks the data source for the number of plots to be plotted by the graph chart view.
 
  @param graphChartView      The graph chart view asking for the number of plots.
 
@@ -120,6 +118,7 @@ ORK_AVAILABLE_DECL
 */
 - (NSInteger)numberOfPlotsInGraphChartView:(ORKGraphChartView *)graphChartView;
 
+@optional
 /**
  Asks the data source for the color of the specified plot.
  

--- a/ResearchKit/Charts/ORKGraphChartView.m
+++ b/ResearchKit/Charts/ORKGraphChartView.m
@@ -579,7 +579,7 @@ ORK_INLINE CALayer *graphPointLayerWithColor(UIColor *color) {
 #pragma mark - Plotting Points
 
 - (NSInteger)numberOfPlots {
-    NSInteger numberOfPlots = 1;
+    NSInteger numberOfPlots = 0;
     
     if ([_dataSource respondsToSelector:@selector(numberOfPlotsInGraphChartView:)]) {
         numberOfPlots = [_dataSource numberOfPlotsInGraphChartView:self];

--- a/ResearchKit/Charts/ORKPieChartPieView.m
+++ b/ResearchKit/Charts/ORKPieChartPieView.m
@@ -160,18 +160,11 @@ static const CGFloat InterAnimationDelay = 0.05;
         segmentLayer.strokeColor = [_parentPieChartView colorForSegmentAtIndex:idx].CGColor;
         CGFloat value = _normalizedValues[idx].floatValue;
         
-        if (value != 0) {
-            if (idx == 0) {
-                segmentLayer.strokeStart = 0.0;
-            } else {
-                segmentLayer.strokeStart = cumulativeValue;
-            }
-            
-            segmentLayer.strokeEnd = cumulativeValue;
-            [_circleLayer addSublayer:segmentLayer];
-            [_segmentLayers addObject:segmentLayer];
-            segmentLayer.strokeEnd = cumulativeValue + value;
-        }
+        segmentLayer.strokeStart = cumulativeValue;
+        [_circleLayer addSublayer:segmentLayer];
+        [_segmentLayers addObject:segmentLayer];
+        segmentLayer.strokeEnd = cumulativeValue + value;
+
         cumulativeValue += value;
     }
 }
@@ -188,31 +181,28 @@ static const CGFloat InterAnimationDelay = 0.05;
         for (NSInteger idx = 0; idx < numberOfSegments; idx++) {
             CGFloat value = _normalizedValues[idx].floatValue;
             
-            if (value != 0) {
-                
-                // Create a label
-                UILabel *label = [UILabel new];
-                label.text = [NSString stringWithFormat:@"%0.0f%%", (value < .01) ? 1 :value * 100];
-                label.font = _percentageLabelFont;
-                label.textColor = [_parentPieChartView colorForSegmentAtIndex:idx];
-                [label sizeToFit];
-                
-                // Only if there are no legends
-                label.isAccessibilityElement = ![_parentPieChartView.dataSource respondsToSelector:@selector(pieChartView:titleForSegmentAtIndex:)];
-                
-                // Calculate the angle to the centre of this segment in radians
-                CGFloat angle = 0;
-                if (_parentPieChartView.drawsClockwise) {
-                    angle = (value / 2 + cumulativeValue) * M_PI * 2;
-                } else {
-                    angle = (value / 2 + cumulativeValue) * - M_PI * 2;
-                }
-                
-                cumulativeValue += value;
-                ORKPieChartSection *pieSection = [[ORKPieChartSection alloc] initWithLabel:label angle:angle];
-                [_pieSections addObject:pieSection];
-                [self addSubview:label];
+            // Create a label
+            UILabel *label = [UILabel new];
+            label.text = [NSString stringWithFormat:@"%0.0f%%", value * 100];
+            label.font = _percentageLabelFont;
+            label.textColor = [_parentPieChartView colorForSegmentAtIndex:idx];
+            [label sizeToFit];
+            
+            // Only if there are no legends
+            label.isAccessibilityElement = ![_parentPieChartView.dataSource respondsToSelector:@selector(pieChartView:titleForSegmentAtIndex:)];
+            
+            // Calculate the angle to the centre of this segment in radians
+            CGFloat angle = 0;
+            if (_parentPieChartView.drawsClockwise) {
+                angle = (value / 2 + cumulativeValue) * M_PI * 2;
+            } else {
+                angle = (value / 2 + cumulativeValue) * - M_PI * 2;
             }
+            
+            cumulativeValue += value;
+            ORKPieChartSection *pieSection = [[ORKPieChartSection alloc] initWithLabel:label angle:angle];
+            [_pieSections addObject:pieSection];
+            [self addSubview:label];
         }
     }
 }
@@ -247,20 +237,19 @@ static const CGFloat InterAnimationDelay = 0.05;
     NSInteger numberOfSegments = [_parentPieChartView.dataSource numberOfSegmentsInPieChartView:_parentPieChartView];
     for (NSInteger idx = 0; idx < numberOfSegments; idx++) {
         CGFloat value = _normalizedValues[idx].floatValue;
-        if (value != 0) {
-            // Create a label
-            ORKPieChartSection *pieSection = _pieSections[idx];
-            UILabel *label = pieSection.label;
-            
-            // Calculate the angle to the centre of this segment in radians
-            CGFloat angle = (value / 2 + cumulativeValue) * M_PI * 2;
-            if (!_parentPieChartView.drawsClockwise) {
-                angle = (value / 2 + cumulativeValue) * - M_PI * 2;
-            }
-            
-            label.center = [self percentageLabel:label calculateCenterForAngle:angle pieRadius:pieRadius];
-            cumulativeValue += value;
+
+        // Get a label
+        ORKPieChartSection *pieSection = _pieSections[idx];
+        UILabel *label = pieSection.label;
+        
+        // Calculate the angle to the centre of this segment in radians
+        CGFloat angle = (value / 2 + cumulativeValue) * M_PI * 2;
+        if (!_parentPieChartView.drawsClockwise) {
+            angle = (value / 2 + cumulativeValue) * - M_PI * 2;
         }
+        
+        label.center = [self percentageLabel:label calculateCenterForAngle:angle pieRadius:pieRadius];
+        cumulativeValue += value;
     }
     [self adjustIntersectionsOfPercentageLabels:_pieSections pieRadius:pieRadius];
 }


### PR DESCRIPTION
This fixes crashes https://github.com/ResearchKit/ResearchKit/issues/691 and https://github.com/ResearchKit/ResearchKit/issues/766:
- `ORKGraphChartView` was crashing if laid out before the `dataSource` was set. The fix makes `-numberOfPlotsInGraphChartView` non-optional, and makes it to return 0 plots by default.
- `ORKPieChartView` was crashing if its `dataSource` returned a `0` value for any segment. Now segments with a `0` value are supported. The corresponding item will be added to the *legend*, and the percentage label will read `0 %`.

Big thanks to @p2 for discovering and/or investigating both issues.