### PR TITLE
Fixing bug where timerLabel did not display in ORKFitnessStep

### DIFF
--- a/ResearchKit/ActiveTasks/ORKFitnessContentView.m
+++ b/ResearchKit/ActiveTasks/ORKFitnessContentView.m
@@ -328,7 +328,7 @@
     static NSDateComponentsFormatter *formatter = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        NSDateComponentsFormatter *formatter = [NSDateComponentsFormatter new];
+        *formatter = [NSDateComponentsFormatter new];
         formatter.unitsStyle = NSDateComponentsFormatterUnitsStylePositional;
         formatter.zeroFormattingBehavior = NSDateComponentsFormatterZeroFormattingBehaviorPad;
         formatter.allowedUnits = NSCalendarUnitMinute | NSCalendarUnitSecond;


### PR DESCRIPTION
in the "updateTimerLabel" function, the timerLabel was always hidden because the labelString was null. The labelString was null every time because the "formatter" object (an NSDateComponentsFormatter object) was null the whole time. This object was null because inside the "dispatch_once", we did not reference/edit the existing static "formatter" object outside of the dispatch_once, but rather, we instantiated a new NSDateComponentsFormatter object.

This seems to work for me. I tested on iOS 6 simulator. I am on iOS 9/Xcode 7.

Edit: This pull request is related to the issue I made a day ago: #785 