### PR TITLE
Erased asterisk/pointer from my last pull request

### DIFF
--- a/ResearchKit/ActiveTasks/ORKFitnessContentView.m
+++ b/ResearchKit/ActiveTasks/ORKFitnessContentView.m
@@ -328,7 +328,7 @@
     static NSDateComponentsFormatter *formatter = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        *formatter = [NSDateComponentsFormatter new];
+        formatter = [NSDateComponentsFormatter new];
         formatter.unitsStyle = NSDateComponentsFormatterUnitsStylePositional;
         formatter.zeroFormattingBehavior = NSDateComponentsFormatterZeroFormattingBehaviorPad;
         formatter.allowedUnits = NSCalendarUnitMinute | NSCalendarUnitSecond;


### PR DESCRIPTION
In my last pull request (#788) that was merged, I forgot to delete the "*" symbol. This actually caused the build to fail. The build should work now. 

(I'm really sorry about this, should've checked it more carefully.)