### PR TITLE
Feature/touch ID report results of if touchID was chosen in Passcode Setup

### DIFF
--- a/ResearchKit/ActiveTasks/ORKFitnessContentView.m
+++ b/ResearchKit/ActiveTasks/ORKFitnessContentView.m
@@ -328,7 +328,7 @@
     static NSDateComponentsFormatter *formatter = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        *formatter = [NSDateComponentsFormatter new];
+        formatter = [NSDateComponentsFormatter new];
         formatter.unitsStyle = NSDateComponentsFormatterUnitsStylePositional;
         formatter.zeroFormattingBehavior = NSDateComponentsFormatterZeroFormattingBehaviorPad;
         formatter.allowedUnits = NSCalendarUnitMinute | NSCalendarUnitSecond;

--- a/ResearchKit/Common/ORKPasscodeStepViewController.m
+++ b/ResearchKit/Common/ORKPasscodeStepViewController.m
@@ -365,11 +365,6 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
                 }
                 
                 [strongSelf finishTouchId];
-                //Report back to the delegate the result of the passcode result
-                if (self.taskViewController.delegate && [self.taskViewController.delegate respondsToSelector:@selector(taskViewController:didChangeResult:)]) {
-                    [self.taskViewController.delegate taskViewController:self.taskViewController didChangeResult:[self result]];
-                }
-
             });
         }];
         

--- a/ResearchKit/Common/ORKPasscodeStepViewController.m
+++ b/ResearchKit/Common/ORKPasscodeStepViewController.m
@@ -262,6 +262,7 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
     
     ORKPasscodeResult *passcodeResult = [[ORKPasscodeResult alloc] initWithIdentifier:[self passcodeStep].identifier];
     passcodeResult.passcodeSaved = _isPasscodeSaved;
+    passcodeResult.touchIdEnabled = _isTouchIdAuthenticated;
     passcodeResult.startDate = stepResult.startDate;
     passcodeResult.endDate = now;
     
@@ -364,6 +365,11 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
                 }
                 
                 [strongSelf finishTouchId];
+                //Report back to the delegate the result of the passcode result
+                if (self.taskViewController.delegate && [self.taskViewController.delegate respondsToSelector:@selector(taskViewController:didChangeResult:)]) {
+                    [self.taskViewController.delegate taskViewController:self.taskViewController didChangeResult:[self result]];
+                }
+
             });
         }];
         

--- a/ResearchKit/Common/ORKResult.h
+++ b/ResearchKit/Common/ORKResult.h
@@ -250,6 +250,11 @@ ORK_CLASS_AVAILABLE
  */
 @property (nonatomic, assign, getter=isPasscodeSaved) BOOL passcodeSaved;
 
+/**
+ A boolean that indicates if the user has enabled/disabled TouchID
+ */
+@property (nonatomic, assign, getter=isTouchIdEnabled) BOOL touchIdEnabled;
+
 @end
 
 

--- a/ResearchKit/Common/ORKResult.m
+++ b/ResearchKit/Common/ORKResult.m
@@ -208,12 +208,14 @@ const NSUInteger NumberOfPaddingSpacesForIndentationLevel = 4;
 - (void)encodeWithCoder:(NSCoder *)aCoder {
     [super encodeWithCoder:aCoder];
     ORK_ENCODE_BOOL(aCoder, passcodeSaved);
+    ORK_ENCODE_BOOL(aCoder, touchIdEnabled);
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
         ORK_DECODE_BOOL(aDecoder, passcodeSaved);
+        ORK_DECODE_BOOL(aDecoder, touchIdEnabled);
     }
     return self;
 }
@@ -223,17 +225,19 @@ const NSUInteger NumberOfPaddingSpacesForIndentationLevel = 4;
 
     __typeof(self) castObject = object;
     return (isParentSame &&
-            self.isPasscodeSaved == castObject.isPasscodeSaved);
+            self.isPasscodeSaved == castObject.isPasscodeSaved &&
+            self.isTouchIdEnabled == castObject.isTouchIdEnabled);
 }
 
 - (instancetype)copyWithZone:(NSZone *)zone {
     ORKPasscodeResult *result = [super copyWithZone:zone];
     result.passcodeSaved = self.isPasscodeSaved;
+    result.touchIdEnabled = self.isTouchIdEnabled;
     return result;
 }
 
 - (NSString *)descriptionWithNumberOfPaddingSpaces:(NSUInteger)numberOfPaddingSpaces {
-    return [NSString stringWithFormat:@"%@; passcodeSaved: %d%@", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces], self.isPasscodeSaved, self.descriptionSuffix];
+    return [NSString stringWithFormat:@"%@; passcodeSaved: %d touchIDEnabled: %d%@", [self descriptionPrefixWithNumberOfPaddingSpaces:numberOfPaddingSpaces], self.isPasscodeSaved, self.isTouchIdEnabled, self.descriptionSuffix];
 }
 
 @end

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -3686,6 +3686,23 @@ stepViewControllerWillAppear:(ORKStepViewController *)stepViewController {
     }];
 }
 
+/**
+  When a task has completed it calls this method to post the result of the task to the delegate.
+*/
+- (void)taskViewController:(ORKTaskViewController *)taskViewController didChangeResult:(ORKTaskResult *)result {
+    /*
+     Upon creation of a Passcode by a user, the results of their creation
+     are returned by getting it from ORKPasscodeResult in this delegate call.
+     This is triggered upon completion/failure/or cancel
+     */
+    ORKStepResult *stepResult = (ORKStepResult *)[[result results] firstObject];
+    if ([[[stepResult results] firstObject] isKindOfClass:[ORKPasscodeResult class]]) {
+        ORKPasscodeResult *passcodeResult = (ORKPasscodeResult *)[[stepResult results] firstObject];
+        NSLog(@"passcode saved: %d , Touch ID Enabled: %d", passcodeResult.passcodeSaved, passcodeResult.touchIdEnabled);
+
+    }
+}
+
 - (void)taskViewController:(ORKTaskViewController *)taskViewController stepViewControllerWillDisappear:(ORKStepViewController *)stepViewController navigationDirection:(ORKStepViewControllerNavigationDirection)direction {
     if ([taskViewController.task.identifier isEqualToString:StepWillDisappearTaskIdentifier] &&
         [stepViewController.step.identifier isEqualToString:StepWillDisappearFirstStepIdentifier]) {

--- a/Testing/ORKTest/ORKTest/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTest/ORKESerialization.m
@@ -1153,6 +1153,7 @@ encondingTable =
          nil,
          (@{
             PROPERTY(passcodeSaved, NSNumber, NSObject, YES, nil, nil),
+            PROPERTY(touchIdEnabled, NSNumber, NSObject, YES, nil, nil)
             })),
     ENTRY(ORKQuestionResult,
          nil,


### PR DESCRIPTION
This PR is regarding the change in functionality outlined in issue  #791 ORKPasscodeStepViewController should report in its delegate if Touch ID was used or not 
This change allows the delegate of the taskViewController to be informed upon passcode creation if the user has decided to use TouchID or not.

It can be viewed by implementing the taskViewController delegate call
```
//WARNING THIS IS SWIFT
func taskViewController(taskViewController: ORKTaskViewController, didChangeResult result: ORKTaskResult) {
```

and then checking the result by iterating through the results of ORKTaskResult like so..
```
func taskViewController(taskViewController: ORKTaskViewController, didChangeResult result: ORKTaskResult) {
        if let stepResult = result.results?.first as? ORKStepResult, passcodeResult = stepResult.results?.first as? ORKPasscodeResult {
           print(passcodeResult.passcodeSaved)
           print(passcodeResult.touchIdEnabled)
        }
    }
```