### PR TITLE
Added Gesture Recognizer to MapView for ORKLocationAnswerFormat.

### DIFF
--- a/ResearchKit/Common/ORKLocationSelectionView.m
+++ b/ResearchKit/Common/ORKLocationSelectionView.m
@@ -141,6 +141,7 @@ static const NSString *FormattedAddressLines = @"FormattedAddressLines";
             [self addSubview:_seperator3];
         }
         
+        [self setUpGestureRecognizer];
         [self setUpConstraints];
 
         if (NO == formMode) {
@@ -151,6 +152,27 @@ static const NSString *FormattedAddressLines = @"FormattedAddressLines";
     }
     
     return self;
+}
+
+- (void)setUpGestureRecognizer {
+    UILongPressGestureRecognizer *lpgr = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(addPlacemarkToMap:)];
+    lpgr.minimumPressDuration = 1.0; // press for 1 second
+    [_mapView addGestureRecognizer:lpgr];
+}
+
+- (void)addPlacemarkToMap:(UIGestureRecognizer *)gestureRecognizer {
+    if (gestureRecognizer.state != UIGestureRecognizerStateBegan)
+        return;
+    
+    CGPoint touchPoint = [gestureRecognizer locationInView:_mapView];
+    CLLocationCoordinate2D touchMapCoordinate = [_mapView convertPoint:touchPoint toCoordinateFromView:_mapView];
+    
+    MKPointAnnotation *annotation = [[MKPointAnnotation alloc] init];
+    annotation.coordinate = touchMapCoordinate;
+    [_mapView addAnnotation:annotation];
+    
+    ORKLocation *pinLocation = [[ORKLocation alloc] initWithCoordinate:touchMapCoordinate region:nil userInput:nil addressDictionary:nil];
+    [self setAnswer:pinLocation];
 }
 
 - (void)setUpConstraints {


### PR DESCRIPTION
Press and hold on map for one second to place marker and input location into text field.

It currently jumps to the nearest address, which is reasonable for my purposes, but others may want a more refined placement.

At the moment there is no animation happening when the user places a marker, this I think would a good addition but not entirely sure where to start with that. 