### PR TITLE
Publicly expose the ORKInstructionStep and allow for custom view.

### DIFF
--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 		86C40D3E1A8D7C5C00081FAC /* ORKImageChoiceLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = 86C40B911A8D7C5C00081FAC /* ORKImageChoiceLabel.m */; };
 		86C40D401A8D7C5C00081FAC /* ORKInstructionStep.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40B921A8D7C5C00081FAC /* ORKInstructionStep.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		86C40D421A8D7C5C00081FAC /* ORKInstructionStep.m in Sources */ = {isa = PBXBuildFile; fileRef = 86C40B931A8D7C5C00081FAC /* ORKInstructionStep.m */; };
-		86C40D441A8D7C5C00081FAC /* ORKInstructionStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40B941A8D7C5C00081FAC /* ORKInstructionStepViewController.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		86C40D441A8D7C5C00081FAC /* ORKInstructionStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40B941A8D7C5C00081FAC /* ORKInstructionStepViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		86C40D461A8D7C5C00081FAC /* ORKInstructionStepViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 86C40B951A8D7C5C00081FAC /* ORKInstructionStepViewController.m */; };
 		86C40D481A8D7C5C00081FAC /* ORKInstructionStepViewController_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40B961A8D7C5C00081FAC /* ORKInstructionStepViewController_Internal.h */; };
 		86C40D4A1A8D7C5C00081FAC /* ORKLabel.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C40B971A8D7C5C00081FAC /* ORKLabel.h */; };

--- a/ResearchKit/Common/ORKCompletionStepViewController.m
+++ b/ResearchKit/Common/ORKCompletionStepViewController.m
@@ -145,11 +145,12 @@ static const CGFloat TickViewSize = 122;
 - (void)stepDidChange {
     [super stepDidChange];
     
-    _completionStepView = [ORKCompletionStepView new];
-    
-    self.stepView.stepView = _completionStepView;
-    
     self.stepView.continueSkipContainer.continueButtonItem = nil;
+}
+
+- (nullable UIView *)buildCustomView {
+    _completionStepView = [ORKCompletionStepView new];
+    return _completionStepView;
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/ResearchKit/Common/ORKInstructionStepViewController.h
+++ b/ResearchKit/Common/ORKInstructionStepViewController.h
@@ -47,6 +47,12 @@ NS_ASSUME_NONNULL_BEGIN
 ORK_CLASS_AVAILABLE
 @interface ORKInstructionStepViewController : ORKStepViewController
 
+/**
+ The Custom View is a view that can optionally replace the `UIImageView` used in the `ORKInstructionStepViewController` 
+ by default, if non-nil.
+ */
+- (nullable UIView *)buildCustomView;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKInstructionStepViewController.m
+++ b/ResearchKit/Common/ORKInstructionStepViewController.m
@@ -68,7 +68,17 @@
         self.stepView.continueSkipContainer.hidden = self.isBeingReviewed;
         
         self.stepView.instructionStep = [self instructionStep];
+        
+        // Replace the standard image view with a custom view if there is one
+        UIView *customView = [self buildCustomView];
+        if (customView != nil) {
+            self.stepView.stepView = customView;
+        }
     }
+}
+
+- (nullable UIView *)buildCustomView {
+    return nil;
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/ResearchKit/ResearchKit_Private.h
+++ b/ResearchKit/ResearchKit_Private.h
@@ -72,7 +72,6 @@
 #import "ORKHolePegTestPlaceStepViewController.h"
 #import "ORKHolePegTestRemoveStepViewController.h"
 #import "ORKImageCaptureStepViewController.h"
-#import "ORKInstructionStepViewController.h"
 #import "ORKPSATStepViewController.h"
 #import "ORKQuestionStepViewController.h"
 #import "ORKReviewStepViewController.h"

--- a/Testing/ORKTest/ORKTest.xcodeproj/project.pbxproj
+++ b/Testing/ORKTest/ORKTest.xcodeproj/project.pbxproj
@@ -29,10 +29,11 @@
 		BC9A271C1B81752800BDA84D /* Charts.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BC9A271B1B81752800BDA84D /* Charts.storyboard */; };
 		BCB0809E1B83E9B300A3F400 /* TaskFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB0809D1B83E9B300A3F400 /* TaskFactory.swift */; };
 		CAF31DCF1BC6AEA200041163 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CAF31DCE1BC6AEA200041163 /* MapKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		FF5CA60E1D272CF4001660A3 /* DragonPokerStep.m in Sources */ = {isa = PBXBuildFile; fileRef = FF5CA60D1D272CF4001660A3 /* DragonPokerStep.m */; };
+		FF5E56C11D6F759A008BA2A8 /* CustomViewStepViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FF5E56C01D6F759A008BA2A8 /* CustomViewStepViewController.m */; };
 		FFF010721D21F1EA0054B430 /* ContinueButtonExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FFF0106F1D21F1EA0054B430 /* ContinueButtonExampleViewController.m */; };
 		FFF010731D21F1EA0054B430 /* FooterView.m in Sources */ = {isa = PBXBuildFile; fileRef = FFF010711D21F1EA0054B430 /* FooterView.m */; };
 		FFF010751D21F2030054B430 /* ContinueButtonExample.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FFF010741D21F2030054B430 /* ContinueButtonExample.storyboard */; };
-		FF5CA60E1D272CF4001660A3 /* DragonPokerStep.m in Sources */ = {isa = PBXBuildFile; fileRef = FF5CA60D1D272CF4001660A3 /* DragonPokerStep.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -130,13 +131,15 @@
 		BC9A271B1B81752800BDA84D /* Charts.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Charts.storyboard; path = Charts/Charts.storyboard; sourceTree = "<group>"; };
 		BCB0809D1B83E9B300A3F400 /* TaskFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskFactory.swift; sourceTree = "<group>"; };
 		CAF31DCE1BC6AEA200041163 /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
+		FF5CA60C1D272CF4001660A3 /* DragonPokerStep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DragonPokerStep.h; sourceTree = "<group>"; };
+		FF5CA60D1D272CF4001660A3 /* DragonPokerStep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DragonPokerStep.m; sourceTree = "<group>"; };
+		FF5E56BF1D6F759A008BA2A8 /* CustomViewStepViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomViewStepViewController.h; sourceTree = "<group>"; };
+		FF5E56C01D6F759A008BA2A8 /* CustomViewStepViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CustomViewStepViewController.m; sourceTree = "<group>"; };
 		FFF0106E1D21F1EA0054B430 /* ContinueButtonExampleViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContinueButtonExampleViewController.h; sourceTree = "<group>"; };
 		FFF0106F1D21F1EA0054B430 /* ContinueButtonExampleViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ContinueButtonExampleViewController.m; sourceTree = "<group>"; };
 		FFF010701D21F1EA0054B430 /* FooterView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FooterView.h; sourceTree = "<group>"; };
 		FFF010711D21F1EA0054B430 /* FooterView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FooterView.m; sourceTree = "<group>"; };
 		FFF010741D21F2030054B430 /* ContinueButtonExample.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = ContinueButtonExample.storyboard; path = "ORKTest/Supporting Files/ContinueButtonExample.storyboard"; sourceTree = SOURCE_ROOT; };
-		FF5CA60C1D272CF4001660A3 /* DragonPokerStep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DragonPokerStep.h; sourceTree = "<group>"; };
-		FF5CA60D1D272CF4001660A3 /* DragonPokerStep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DragonPokerStep.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -231,6 +234,8 @@
 			children = (
 				FFF0106E1D21F1EA0054B430 /* ContinueButtonExampleViewController.h */,
 				FFF0106F1D21F1EA0054B430 /* ContinueButtonExampleViewController.m */,
+				FF5E56BF1D6F759A008BA2A8 /* CustomViewStepViewController.h */,
+				FF5E56C01D6F759A008BA2A8 /* CustomViewStepViewController.m */,
 				FFF010701D21F1EA0054B430 /* FooterView.h */,
 				FFF010711D21F1EA0054B430 /* FooterView.m */,
 				86717ADC1AC0C53800AC2A23 /* DynamicTask.h */,
@@ -438,6 +443,7 @@
 			files = (
 				86717AE81AC0C53800AC2A23 /* DynamicTask.m in Sources */,
 				BC9A27181B81743900BDA84D /* ChartDataSources.swift in Sources */,
+				FF5E56C11D6F759A008BA2A8 /* CustomViewStepViewController.m in Sources */,
 				BC9A27191B81743900BDA84D /* ChartListViewController.swift in Sources */,
 				FF5CA60E1D272CF4001660A3 /* DragonPokerStep.m in Sources */,
 				BC9A271A1B81743900BDA84D /* ChartTableViewCells.swift in Sources */,

--- a/Testing/ORKTest/ORKTest/CustomViewStepViewController.h
+++ b/Testing/ORKTest/ORKTest/CustomViewStepViewController.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015, Apple Inc. All rights reserved.
+ Copyright (c) 2016, Sage Bionetworks
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -28,63 +28,12 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <ResearchKit/ResearchKit.h>
 
-#import "ORKTypes.h"
+@interface CustomViewStep : ORKInstructionStep
 
-#import "ORKStep.h"
-#import "ORKActiveStep.h"
-#import "ORKConsentReviewStep.h"
-#import "ORKConsentSharingStep.h"
-#import "ORKFormStep.h"
-#import "ORKImageCaptureStep.h"
-#import "ORKInstructionStep.h"
-#import "ORKLoginStep.h"
-#import "ORKPasscodeStep.h"
-#import "ORKQuestionStep.h"
-#import "ORKRegistrationStep.h"
-#import "ORKReviewStep.h"
-#import "ORKSignatureStep.h"
-#import "ORKTableStep.h"
-#import "ORKVerificationStep.h"
-#import "ORKVisualConsentStep.h"
-#import "ORKWaitStep.h"
+@end
 
-#import "ORKTask.h"
-#import "ORKOrderedTask.h"
-#import "ORKNavigableOrderedTask.h"
-#import "ORKStepNavigationRule.h"
+@interface CustomViewStepViewController : ORKInstructionStepViewController
 
-#import "ORKAnswerFormat.h"
-#import "ORKHealthAnswerFormat.h"
-
-#import "ORKResult.h"
-#import "ORKResultPredicate.h"
-
-#import "ORKTextButton.h"
-#import "ORKBorderedButton.h"
-#import "ORKContinueButton.h"
-
-#import "ORKStepViewController.h"
-#import "ORKActiveStepViewController.h"
-#import "ORKFormStepViewController.h"
-#import "ORKInstructionStepViewController.h"
-#import "ORKLoginStepViewController.h"
-#import "ORKPasscodeViewController.h"
-#import "ORKTableStepViewController.h"
-#import "ORKTaskViewController.h"
-#import "ORKVerificationStepViewController.h"
-#import "ORKWaitStepViewController.h"
-
-#import "ORKRecorder.h"
-
-#import "ORKConsentDocument.h"
-#import "ORKConsentSection.h"
-#import "ORKConsentSignature.h"
-
-#import "ORKKeychainWrapper.h"
-
-#import "ORKChartTypes.h"
-#import "ORKBarGraphChartView.h"
-#import "ORKDiscreteGraphChartView.h"
-#import "ORKLineGraphChartView.h"
-#import "ORKPieChartView.h"
+@end

--- a/Testing/ORKTest/ORKTest/CustomViewStepViewController.m
+++ b/Testing/ORKTest/ORKTest/CustomViewStepViewController.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2015, Apple Inc. All rights reserved.
+ Copyright (c) 2016, Sage Bionetworks
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -28,63 +28,38 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import "CustomViewStepViewController.h"
 
-#import "ORKTypes.h"
+@implementation CustomViewStep
 
-#import "ORKStep.h"
-#import "ORKActiveStep.h"
-#import "ORKConsentReviewStep.h"
-#import "ORKConsentSharingStep.h"
-#import "ORKFormStep.h"
-#import "ORKImageCaptureStep.h"
-#import "ORKInstructionStep.h"
-#import "ORKLoginStep.h"
-#import "ORKPasscodeStep.h"
-#import "ORKQuestionStep.h"
-#import "ORKRegistrationStep.h"
-#import "ORKReviewStep.h"
-#import "ORKSignatureStep.h"
-#import "ORKTableStep.h"
-#import "ORKVerificationStep.h"
-#import "ORKVisualConsentStep.h"
-#import "ORKWaitStep.h"
+- (Class)stepViewControllerClass {
+    return [CustomViewStepViewController class];
+}
 
-#import "ORKTask.h"
-#import "ORKOrderedTask.h"
-#import "ORKNavigableOrderedTask.h"
-#import "ORKStepNavigationRule.h"
+@end
 
-#import "ORKAnswerFormat.h"
-#import "ORKHealthAnswerFormat.h"
+@interface CustomViewStepViewController ()
 
-#import "ORKResult.h"
-#import "ORKResultPredicate.h"
+@property (nonatomic) UIActivityIndicatorView *activityView;
 
-#import "ORKTextButton.h"
-#import "ORKBorderedButton.h"
-#import "ORKContinueButton.h"
+@end
 
-#import "ORKStepViewController.h"
-#import "ORKActiveStepViewController.h"
-#import "ORKFormStepViewController.h"
-#import "ORKInstructionStepViewController.h"
-#import "ORKLoginStepViewController.h"
-#import "ORKPasscodeViewController.h"
-#import "ORKTableStepViewController.h"
-#import "ORKTaskViewController.h"
-#import "ORKVerificationStepViewController.h"
-#import "ORKWaitStepViewController.h"
+@implementation CustomViewStepViewController
 
-#import "ORKRecorder.h"
+- (UIView *)buildCustomView {
+    _activityView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
+    _activityView.hidesWhenStopped = NO;
+    return _activityView;
+}
 
-#import "ORKConsentDocument.h"
-#import "ORKConsentSection.h"
-#import "ORKConsentSignature.h"
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self.activityView startAnimating];
+}
 
-#import "ORKKeychainWrapper.h"
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+    [self.activityView stopAnimating];
+}
 
-#import "ORKChartTypes.h"
-#import "ORKBarGraphChartView.h"
-#import "ORKDiscreteGraphChartView.h"
-#import "ORKLineGraphChartView.h"
-#import "ORKPieChartView.h"
+@end

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -38,6 +38,7 @@
 #import "DynamicTask.h"
 #import "ORKTest-Swift.h"
 #import "DragonPokerStep.h"
+#import "CustomViewStepViewController.h"
 
 @import ResearchKit;
 
@@ -68,6 +69,7 @@ DefineStringKey(SelectionSurveyTaskIdentifier);
 DefineStringKey(ActiveStepTaskIdentifier);
 DefineStringKey(AudioTaskIdentifier);
 DefineStringKey(AuxillaryImageTaskIdentifier);
+DefineStringKey(CustomViewTaskIdentifier);
 DefineStringKey(FitnessTaskIdentifier);
 DefineStringKey(GaitTaskIdentifier);
 DefineStringKey(HolePegTestTaskIdentifier);
@@ -394,6 +396,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                            @"Table Step",
                            @"Signature Step",
                            @"Auxillary Image",
+                           @"Custom View",
                            ],
                        ];
 }
@@ -635,6 +638,8 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                                                     options:ORKPredefinedTaskOptionNone];
     } else if ([identifier isEqualToString:AuxillaryImageTaskIdentifier]) {
         return [self makeAuxillaryImageTask];
+    } else if ([identifier isEqualToString:CustomViewTaskIdentifier]) {
+        return [self makeCustomViewTask];
     }
 
     return nil;
@@ -3608,7 +3613,6 @@ stepViewControllerWillAppear:(ORKStepViewController *)stepViewController {
         // Determinate step
         [self updateProgress:0.0 waitStepViewController:((ORKWaitStepViewController *)stepViewController)];
     }
-
 }
 
 /*
@@ -4070,7 +4074,23 @@ stepViewControllerWillAppear:(ORKStepViewController *)stepViewController {
     step.image = [UIImage imageNamed:@"tremortest3a" inBundle:[NSBundle bundleForClass:[ORKOrderedTask class]] compatibleWithTraitCollection:nil];
     step.auxiliaryImage = [UIImage imageNamed:@"tremortest3b" inBundle:[NSBundle bundleForClass:[ORKOrderedTask class]] compatibleWithTraitCollection:nil];
     
-    return [[ORKOrderedTask alloc] initWithIdentifier:SignatureStepTaskIdentifier steps:@[step]];
+    return [[ORKOrderedTask alloc] initWithIdentifier:AuxillaryImageTaskIdentifier steps:@[step]];
+}
+
+#pragma mark - Custom View
+
+- (IBAction)customViewButtonTapped:(id)sender {
+    [self beginTaskWithIdentifier:CustomViewTaskIdentifier];
+}
+
+- (ORKOrderedTask *)makeCustomViewTask {
+    
+    CustomViewStep *step = [[CustomViewStep alloc] initWithIdentifier:CustomViewTaskIdentifier];
+    step.title = @"Example Custom View";
+    step.text = @"This is description text.";
+    step.detailText = @"This is detail text.";
+    
+    return [[ORKOrderedTask alloc] initWithIdentifier:CustomViewTaskIdentifier steps:@[step]];
 }
 
 


### PR DESCRIPTION
This will allow a developer to have access to the layout of the parent instruction view controller (including detail, learnmore, next button) while using a custom view in place of the image view that the default implementation includes.