### PR TITLE
Use NSPredicate instead of Predicate

### DIFF
--- a/ResearchKit/Common/ORKStepNavigationRule.swift
+++ b/ResearchKit/Common/ORKStepNavigationRule.swift
@@ -32,20 +32,6 @@ import Foundation
 
 public extension ORKPredicateStepNavigationRule {
     
-    #if swift(>=3.0)
-    
-    convenience init(resultPredicatesAndDestinationStepIdentifiers tuples: [ (resultPredicate: Predicate, destinationStepIdentifier: String) ], defaultStepIdentifierOrNil: String? = nil ) {
-        var resultPredicates: [Predicate] = []
-        var destinationStepIdentifiers: [String] = []
-        for tuple in tuples {
-            resultPredicates.append(tuple.resultPredicate)
-            destinationStepIdentifiers.append(tuple.destinationStepIdentifier)
-        }
-        self.init(resultPredicates: resultPredicates, destinationStepIdentifiers: destinationStepIdentifiers, defaultStepIdentifier: defaultStepIdentifierOrNil, validateArrays: true);
-    }
-    
-    #else
-    
     convenience init(resultPredicatesAndDestinationStepIdentifiers tuples: [ (resultPredicate: NSPredicate, destinationStepIdentifier: String) ], defaultStepIdentifierOrNil: String? = nil ) {
         var resultPredicates: [NSPredicate] = []
         var destinationStepIdentifiers: [String] = []
@@ -56,5 +42,4 @@ public extension ORKPredicateStepNavigationRule {
         self.init(resultPredicates: resultPredicates, destinationStepIdentifiers: destinationStepIdentifiers, defaultStepIdentifier: defaultStepIdentifierOrNil, validateArrays: true);
     }
 
-    #endif
 }


### PR DESCRIPTION
NSPredicate was a thing. Then in Swift 3.0 beta something it became Predicate instead. Then in beta 6 it went back to NSPredicate. Predicate thus is no longer a thing.
