### PR TITLE
Always set a date for non-nil ORKResult startDate

### DIFF
--- a/ResearchKit/Common/ORKStepViewController.m
+++ b/ResearchKit/Common/ORKStepViewController.m
@@ -271,7 +271,7 @@
 - (ORKStepResult *)result {
     
     ORKStepResult *stepResult = [[ORKStepResult alloc] initWithStepIdentifier:self.step.identifier results:@[]];
-    stepResult.startDate = self.presentedDate;
+    stepResult.startDate = self.presentedDate ? : [NSDate date];
     stepResult.endDate = self.dismissedDate ? : [NSDate date];
     
     return stepResult;


### PR DESCRIPTION
This is a non nil property and should not be set to a possibly nil value. Doing so can cause a crash in Swift 3.0 override of `-(ORKStepResult)result` because of a violated assumption.
