### PR TITLE
Fix navigation looping to return unique results for each step.

### DIFF
--- a/ResearchKit/Common/ORKResult.m
+++ b/ResearchKit/Common/ORKResult.m
@@ -1826,7 +1826,11 @@ const NSUInteger NumberOfPaddingSpacesForIndentationLevel = 4;
     
     __block ORKQuestionResult *result = nil;
     
-    [self.results enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+    // Look through the result set in reverse-order to account for the possibility of
+    // multiple results with the same identifier (due to a navigation loop)
+    NSEnumerator *enumerator = self.results.reverseObjectEnumerator;
+    id obj = enumerator.nextObject;
+    while ((result== nil) && (obj != nil)) {
         
         if (NO == [obj isKindOfClass:[ORKResult class]]) {
             @throw [NSException exceptionWithName:NSGenericException reason:[NSString stringWithFormat: @"Expected result object to be ORKResult type: %@", obj] userInfo:nil];
@@ -1835,10 +1839,9 @@ const NSUInteger NumberOfPaddingSpacesForIndentationLevel = 4;
         NSString *anIdentifier = [(ORKResult *)obj identifier];
         if ([anIdentifier isEqual:identifier]) {
             result = obj;
-            *stop = YES;
         }
-    
-    }];
+        obj = enumerator.nextObject;
+    }
     
     return result;
 }

--- a/ResearchKit/Common/ORKResultPredicate.m
+++ b/ResearchKit/Common/ORKResultPredicate.m
@@ -207,7 +207,7 @@ NSString *const ORKResultPredicateTaskIdentifierVariableName = @"ORK_TASK_IDENTI
     
     {
         // Match question result identifier
-        [format appendString:@" AND SUBQUERY($x.results, $y, $y.identifier == %@ AND SUBQUERY($y.results, $z, $z.identifier == %@"];
+        [format appendString:@" AND SUBQUERY($x.results, $y, $y.identifier == %@ AND $y.isPreviousResult == NO AND SUBQUERY($y.results, $z, $z.identifier == %@"];
         [formatArgumentArray addObject:stepIdentifier];
         [formatArgumentArray addObject:resultIdentifier];
         {

--- a/ResearchKit/Common/ORKResult_Private.h
+++ b/ResearchKit/Common/ORKResult_Private.h
@@ -110,6 +110,12 @@ ORK_CLASS_AVAILABLE
 
 @end
 
+@interface ORKStepResult ()
+
+@property (nonatomic) BOOL isPreviousResult;
+
+@end
+
 
 NS_ASSUME_NONNULL_END
 

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -695,30 +695,49 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
 - (NSArray *)managedResults {
     NSMutableArray *results = [NSMutableArray new];
     
-    [_managedStepIdentifiers enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-        NSString *identifier = obj;
-        ORKResult *result = _managedResults[identifier];
-        NSAssert(result, @"Result should not be nil for identifier %@", identifier);
+    [_managedStepIdentifiers enumerateObjectsUsingBlock:^(NSString *identifier, NSUInteger idx, BOOL *stop) {
+        id <NSCopying> key = [self uniqueManagedKey:identifier index:idx];
+        ORKResult *result = _managedResults[key];
+        NSAssert2(result, @"Result should not be nil for identifier %@ with key %@", identifier, key);
         [results addObject:result];
     }];
     
     return [results copy];
 }
 
-- (void)setManagedResult:(id)result forKey:(id <NSCopying>)aKey {
+- (void)setManagedResult:(ORKStepResult *)result forKey:(NSString *)aKey {
     if (aKey == nil) {
         return;
     }
     
-    if (result == nil || NO == [result isKindOfClass:[ORKResult class]]) {
+    if (result == nil || NO == [result isKindOfClass:[ORKStepResult class]]) {
         @throw [NSException exceptionWithName:NSGenericException reason:[NSString stringWithFormat: @"Expect result object to be ORKResult type and not nil: {%@ : %@}", aKey, result] userInfo:nil];
         return;
     }
+    
+    // Manage last result tracking (used in predicate navigation)
+    // If the previous result and the replacement result result are the same result then `isPreviousResult`
+    // will be set to `NO` otherwise it will be marked with `YES`.
+    ORKStepResult *previousResult = _managedResults[aKey];
+    previousResult.isPreviousResult = YES;
+    result.isPreviousResult = NO;
     
     if (_managedResults == nil) {
         _managedResults = [NSMutableDictionary new];
     }
     _managedResults[aKey] = result;
+    
+    // Also point to the object using a unique key
+    NSUInteger idx = _managedStepIdentifiers.count;
+    if ([_managedStepIdentifiers.lastObject isEqualToString:aKey]) {
+        idx--;
+    }
+    id <NSCopying> uniqueKey = [self uniqueManagedKey:aKey index:idx];
+    _managedResults[uniqueKey] = result;
+}
+
+- (id <NSCopying>)uniqueManagedKey:(NSString*)stepIdentifier index:(NSUInteger)index {
+    return [NSString stringWithFormat:@"%@:%@", stepIdentifier, @(index)];
 }
 
 - (NSUUID *)taskRunUUID {

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -711,12 +711,12 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     }
     
     if (result == nil || NO == [result isKindOfClass:[ORKStepResult class]]) {
-        @throw [NSException exceptionWithName:NSGenericException reason:[NSString stringWithFormat: @"Expect result object to be ORKResult type and not nil: {%@ : %@}", aKey, result] userInfo:nil];
+        @throw [NSException exceptionWithName:NSGenericException reason:[NSString stringWithFormat: @"Expect result object to be `ORKStepResult` type and not nil: {%@ : %@}", aKey, result] userInfo:nil];
         return;
     }
     
     // Manage last result tracking (used in predicate navigation)
-    // If the previous result and the replacement result result are the same result then `isPreviousResult`
+    // If the previous result and the replacement result are the same result then `isPreviousResult`
     // will be set to `NO` otherwise it will be marked with `YES`.
     ORKStepResult *previousResult = _managedResults[aKey];
     previousResult.isPreviousResult = YES;

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -3774,7 +3774,7 @@ stepViewControllerWillAppear:(ORKStepViewController *)stepViewController {
     if (results) {
         NSSet *uniqueResults = [NSSet setWithArray:results];
         BOOL allResultsUnique = (results.count == uniqueResults.count);
-        NSAssert(allResultsUnique, @"The returns results have duplicates of the same object.");
+        NSAssert(allResultsUnique, @"The returned results have duplicates of the same object.");
     }
     
     if (_currentDocument) {

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -3079,6 +3079,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
 
     step = [[ORKInstructionStep alloc] initWithIdentifier:@"skippableStep"];
     step.title = @"You'll optionally skip this step";
+    step.text = @"You should only see this step if you answered the previous question with 'No'";
     [steps addObject:step];
     
     // Loop target step
@@ -3767,6 +3768,14 @@ stepViewControllerWillAppear:(ORKStepViewController *)stepViewController {
 - (void)taskViewControllerDidComplete:(ORKTaskViewController *)taskViewController {
     
     NSLog(@"[ORKTest] task results: %@", taskViewController.result);
+    
+    // Validate the results
+    NSArray *results = taskViewController.result.results;
+    if (results) {
+        NSSet *uniqueResults = [NSSet setWithArray:results];
+        BOOL allResultsUnique = (results.count == uniqueResults.count);
+        NSAssert(allResultsUnique, @"The returns results have duplicates of the same object.");
+    }
     
     if (_currentDocument) {
         /*


### PR DESCRIPTION
Previous to this commit, `ORKTaskViewController` only tracked the _last_ result, inserting that result into the returned array of results for each instance of the step result with that identifier. This commit fixes that bug so that an `ORKNavigableOrderedTask` with a looping navigation will return the unique result for each loop.

Repro Steps:
1. Run the "Navigation Loop Task" in ORKTest
2. Loop through the answers 

Expected:
The results will show a different value for steps with the same identifier that are in the loop.

Actual:
All steps are replaced with the last result.
