### PR TITLE
Fix typo in podspec version quoting characters.

### DIFF
--- a/ResearchKit.podspec
+++ b/ResearchKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'ResearchKit'
-  s.version      = ‘1.4.1’
+  s.version      = '1.4.1'
   s.summary      = 'ResearchKit is an open source software framework that makes it easy to create apps for medical research or for other research projects.'
   s.homepage     = 'https://www.github.com/ResearchKit/ResearchKit'
   s.documentation_url = 'http://researchkit.github.io/docs/'


### PR DESCRIPTION
Looks like when the pod spec version was bumped backticks were used instead of single quotes.