### PR TITLE
Allow optional check of default result source before using previous.

### DIFF
--- a/ResearchKit/Common/ORKResult.h
+++ b/ResearchKit/Common/ORKResult.h
@@ -1172,6 +1172,19 @@ ORK_CLASS_AVAILABLE
  */
 - (nullable ORKStepResult *)stepResultForStepIdentifier:(NSString *)stepIdentifier;
 
+/**
+ Should the default result store be used even if there is a previous result? (due to 
+ reverse navigation or looping)
+ 
+ By default, the `[ORKTaskViewController defaultResultSource]` is only queried for a 
+ result if the previous result is nil. This allows the result source to override that
+ default behavior.
+ 
+ @return `YES` if the default result should be given priority over the previous result.
+ */
+@optional
+- (BOOL)alwaysCheckForDefaultResult;
+
 @end
 
 

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1074,13 +1074,9 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
                 result = [self.defaultResultSource stepResultForStepIdentifier:step.identifier];
             }
             
-            // If nil, assign to the previous result
+            // If nil, assign to the previous result (if available) otherwise create new instance
             if (!result) {
-                result = previousResult;
-            }
-            
-            if (!result) {
-                result = [[ORKStepResult alloc] initWithIdentifier:step.identifier];
+                result = previousResult ? : [[ORKStepResult alloc] initWithIdentifier:step.identifier];
             }
             
             // Allow the step to instantiate the view controller. This will allow either the default

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1065,9 +1065,18 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
             
             // Get the step result associated with this step
             ORKStepResult *result = nil;
-            result = _managedResults[step.identifier];
-            if (!result ) {
-                result = [_defaultResultSource stepResultForStepIdentifier:step.identifier];
+            ORKStepResult *previousResult = _managedResults[step.identifier];
+            
+            // Check the default source first
+            BOOL alwaysCheckForDefaultResult = ([self.defaultResultSource respondsToSelector:@selector(alwaysCheckForDefaultResult)] &&
+                                                [self.defaultResultSource alwaysCheckForDefaultResult]);
+            if ((previousResult == nil) || alwaysCheckForDefaultResult) {
+                result = [self.defaultResultSource stepResultForStepIdentifier:step.identifier];
+            }
+            
+            // If nil, assign to the previous result
+            if (!result) {
+                result = previousResult;
             }
             
             if (!result) {


### PR DESCRIPTION
By request from another dev, this allows the developer to force checking the default source _before_ using the previous result. If an empty `ORKStepResult` is returned, then the previous result will be ignored.
