### PR TITLE
[ORKESerialization] Fix ORKLocation unit tests

### DIFF
--- a/ResearchKit/Common/ORKHealthSampleQueryOperation.m
+++ b/ResearchKit/Common/ORKHealthSampleQueryOperation.m
@@ -229,7 +229,7 @@ static NSUInteger const QueryLimitSize = 1000;
         
         if (!handoutSuccess) {
             doContinue = NO;
-            self.error = [NSError errorWithDomain:ORKErrorDomain code:ORKErrorException userInfo:@{NSLocalizedFailureReasonErrorKey: @"Results are not devlivered to delegate properly."}];
+            self.error = [NSError errorWithDomain:ORKErrorDomain code:ORKErrorException userInfo:@{NSLocalizedFailureReasonErrorKey: @"Results were not properly delivered to the data collection manager delegate."}];
         }
     }
     

--- a/ResearchKit/Common/ORKMotionActivityQueryOperation.m
+++ b/ResearchKit/Common/ORKMotionActivityQueryOperation.m
@@ -177,7 +177,7 @@
         dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
         
         if (!handoutSuccess) {
-            self.error = [NSError errorWithDomain:ORKErrorDomain code:ORKErrorException userInfo:@{NSLocalizedFailureReasonErrorKey: @"Results are not devlivered properly."}];
+            self.error = [NSError errorWithDomain:ORKErrorDomain code:ORKErrorException userInfo:@{NSLocalizedFailureReasonErrorKey: @"Results were not properly delivered to the data collection manager delegate."}];
         }
         
         // If successfully reported to delegate, and we observed at

--- a/Testing/ORKTest/ORKTest/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTest/ORKESerialization.m
@@ -129,6 +129,20 @@ static NSString *ORKNumericAnswerStyleToString(ORKNumericAnswerStyle style) {
     return tableMapForward(style, ORKNumericAnswerStyleTable());
 }
 
+static NSDictionary *dictionaryFromCircularRegion(CLCircularRegion *region) {
+    return @{
+             @"coordinate": dictionaryFromCoordinate(region.center),
+             @"radius": @(region.radius),
+             @"identifier": region.identifier
+             };
+}
+
+static CLCircularRegion *CircularRegionFromDictionary(NSDictionary *dict) {
+    return [[CLCircularRegion alloc] initWithCenter:coordinateFromDictionary(dict[@"coordinate"])
+                                             radius:((NSNumber *)dict[@"radius"]).doubleValue
+                                         identifier:dict[@"identifier"]];
+}
+
 static NSMutableDictionary *ORKESerializationEncodingTable();
 static id propFromDict(NSDictionary *dict, NSString *propName);
 static NSArray *classEncodingsForClass(Class c) ;
@@ -1251,25 +1265,12 @@ encondingTable =
                      ^id(id dict) { return [NSValue valueWithMKCoordinate:coordinateFromDictionary(dict)]; }),
             PROPERTY(region, CLCircularRegion, NSObject, NO,
                      ^id(id value) {
-                         if ( nil == value ) {
-                             return nil;
-                         }
-                         CLCircularRegion *region = value;
-                         NSMutableDictionary *dict = [NSMutableDictionary dictionary];
-                         dict[@"coordinate"] = dictionaryFromCoordinate(region.center);
-                         dict[@"radius"] = @(region.radius);
-                         dict[@"identifier"] = region.identifier;
-                         return dict;
+                         return value ?
+                         dictionaryFromCircularRegion((CLCircularRegion *)value)
+                         : nil;
                      },
                      ^id(id dict) {
-                         NSDictionary *regionDict = dict;
-                         if (nil == regionDict) {
-                             return nil;
-                         }
-                         CLLocationCoordinate2D coordinate = coordinateFromDictionary(regionDict[@"coordinate"]);
-                         NSNumber *radius = regionDict[@"radius"];
-                         NSString *identifier = regionDict[@"identifier"];
-                         return [[CLCircularRegion alloc] initWithCenter:coordinate radius:radius.doubleValue identifier:identifier];
+                         return dict ? CircularRegionFromDictionary(dict) : nil;
                      }),
             })),
    ENTRY(ORKLocationQuestionResult,

--- a/Testing/ORKTest/ORKTestTests/ORKDataCollectionTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKDataCollectionTests.m
@@ -41,7 +41,7 @@
 @implementation ORKDataCollectionTests {
     XCTestExpectation *_completionExpectation;
     XCTestExpectation *_healthCollectionExpectation;
-    XCTestExpectation *_corrolationCollectionExpectation;
+    XCTestExpectation *_correlationCollectionExpectation;
     HKHealthStore *_healthStore;
     BOOL _acceptDelivery;
     NSInteger _errorCount;
@@ -86,11 +86,11 @@
     return storePath;
 }
 
-static ORKDataCollectionManager *createManagerWithCollecters (NSURL *url,
-                                                              ORKMotionActivityCollector **motionCollector,
-                                                              ORKHealthCollector **healthCollector,
-                                                              ORKHealthCorrelationCollector **healthCorrelationCollector,
-                                                              NSError **error) {
+static ORKDataCollectionManager *createManagerWithCollectors(NSURL *url,
+                                                             ORKMotionActivityCollector **motionCollector,
+                                                             ORKHealthCollector **healthCollector,
+                                                             ORKHealthCorrelationCollector **healthCorrelationCollector,
+                                                             NSError **error) {
     
     ORKDataCollectionManager *manager = [[ORKDataCollectionManager alloc] initWithPersistenceDirectoryURL:url];
     
@@ -168,7 +168,7 @@ static ORKDataCollectionManager *createManagerWithCollecters (NSURL *url,
     ORKHealthCorrelationCollector *healthCorrelationCollector;
     NSError *error;
     // Create
-    ORKDataCollectionManager *manager = createManagerWithCollecters([NSURL fileURLWithPath:[self cleanStorePath]],
+    ORKDataCollectionManager *manager = createManagerWithCollectors([NSURL fileURLWithPath:[self cleanStorePath]],
                                                                     &motionCollector,
                                                                     &healthCollector,
                                                                     &healthCorrelationCollector,
@@ -267,7 +267,7 @@ typedef NS_OPTIONS (NSInteger, SampleDataType) {
     ORKHealthCollector *healthCollector;
     ORKHealthCorrelationCollector *healthCorrelationCollector;
     __block NSError *error;
-    ORKDataCollectionManager *manager = createManagerWithCollecters([NSURL fileURLWithPath:[self cleanStorePath]],
+    ORKDataCollectionManager *manager = createManagerWithCollectors([NSURL fileURLWithPath:[self cleanStorePath]],
                                                                     &motionCollector,
                                                                     &healthCollector,
                                                                     &healthCorrelationCollector,
@@ -282,7 +282,7 @@ typedef NS_OPTIONS (NSInteger, SampleDataType) {
 #if TARGET_OS_SIMULATOR
     if ([self insertSampleDataWithType:SampleDataTypeALL]) {
         _healthCollectionExpectation = [self expectationWithDescription:@"Expectation for health sample collection completion"];
-        _corrolationCollectionExpectation = [self expectationWithDescription:@"Expectation for corrolation collection completion"];
+        _correlationCollectionExpectation = [self expectationWithDescription:@"Expectation for correlation collection completion"];
     }
 #endif
     
@@ -313,7 +313,7 @@ typedef NS_OPTIONS (NSInteger, SampleDataType) {
     if ([self insertSampleDataWithType:SampleDataTypeBP]) {
         // Health Collector was removed
         _healthCollectionExpectation = nil;
-        _corrolationCollectionExpectation = [self expectationWithDescription:@"Expectation for corrolation collection completion"];
+        _correlationCollectionExpectation = [self expectationWithDescription:@"Expectation for correlation collection completion"];
     }
 #endif
     
@@ -331,7 +331,7 @@ typedef NS_OPTIONS (NSInteger, SampleDataType) {
     ORKHealthCollector *healthCollector;
     ORKHealthCorrelationCollector *healthCorrelationCollector;
     __block NSError *error;
-    ORKDataCollectionManager *manager = createManagerWithCollecters([NSURL fileURLWithPath:[self cleanStorePath]],
+    ORKDataCollectionManager *manager = createManagerWithCollectors([NSURL fileURLWithPath:[self cleanStorePath]],
                                                                     &motionCollector,
                                                                     &healthCollector,
                                                                     &healthCorrelationCollector,
@@ -359,7 +359,7 @@ typedef NS_OPTIONS (NSInteger, SampleDataType) {
 #if TARGET_OS_SIMULATOR
     if ([self insertSampleDataWithType:SampleDataTypeALL]) {
         _healthCollectionExpectation = [self expectationWithDescription:@"Expectation for health sample collection completion"];
-        _corrolationCollectionExpectation = [self expectationWithDescription:@"Expectation for corrolation collection completion"];
+        _correlationCollectionExpectation = [self expectationWithDescription:@"Expectation for correlation collection completion"];
     }
 #endif
     
@@ -367,7 +367,7 @@ typedef NS_OPTIONS (NSInteger, SampleDataType) {
     ORKHealthCollector *healthCollector;
     ORKHealthCorrelationCollector *healthCorrelationCollector;
     __block NSError *error;
-    ORKDataCollectionManager *manager = createManagerWithCollecters([NSURL fileURLWithPath:[self cleanStorePath]],
+    ORKDataCollectionManager *manager = createManagerWithCollectors([NSURL fileURLWithPath:[self cleanStorePath]],
                                                                     &motionCollector,
                                                                     &healthCollector,
                                                                     &healthCorrelationCollector,
@@ -398,7 +398,7 @@ typedef NS_OPTIONS (NSInteger, SampleDataType) {
             didCollectCorrelations:(NSArray<HKCorrelation *> *)correlations {
     
     XCTAssertEqual(correlations.count, 1);
-    [_corrolationCollectionExpectation fulfill];
+    [_correlationCollectionExpectation fulfill];
     NSLog(@"Did collect correlation samples");
     return _acceptDelivery;
 }

--- a/Testing/ORKTest/ORKTestTests/ORKDataCollectionTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKDataCollectionTests.m
@@ -87,14 +87,13 @@
 }
 
 static ORKDataCollectionManager *createManagerWithCollectors(NSURL *url,
+                                                             NSDate *startDate,
                                                              ORKMotionActivityCollector **motionCollector,
                                                              ORKHealthCollector **healthCollector,
                                                              ORKHealthCorrelationCollector **healthCorrelationCollector,
                                                              NSError **error) {
     
     ORKDataCollectionManager *manager = [[ORKDataCollectionManager alloc] initWithPersistenceDirectoryURL:url];
-    
-    NSDate *startDate = [NSDate dateWithTimeIntervalSinceNow:-5];
     
     ORKMotionActivityCollector *mac = [manager addMotionActivityCollectorWithStartDate:startDate error:error];
     if (motionCollector) {
@@ -169,6 +168,7 @@ static ORKDataCollectionManager *createManagerWithCollectors(NSURL *url,
     NSError *error;
     // Create
     ORKDataCollectionManager *manager = createManagerWithCollectors([NSURL fileURLWithPath:[self cleanStorePath]],
+                                                                    [NSDate date],
                                                                     &motionCollector,
                                                                     &healthCollector,
                                                                     &healthCorrelationCollector,
@@ -204,7 +204,9 @@ typedef NS_OPTIONS (NSInteger, SampleDataType) {
 };
 
 
-- (BOOL)insertSampleDataWithType:(SampleDataType)sampleDataType {
+- (BOOL)insertSampleDataWithType:(SampleDataType)sampleDataType
+                       startDate:(NSDate *)startDate
+                         endDate:(NSDate *)endDate {
     _healthStore = [[HKHealthStore alloc] init];
     
     HKQuantityType *heartRateType = [HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierHeartRate];
@@ -223,23 +225,19 @@ typedef NS_OPTIONS (NSInteger, SampleDataType) {
         
 #if TARGET_OS_SIMULATOR
         
-        // Each time add new data samples to simulator
-        NSDate *d1 = [NSDate dateWithTimeIntervalSinceNow:-2];
-        NSDate *d2 = [NSDate dateWithTimeIntervalSinceNow:-1];
-        
         // Heart Rate
         HKUnit *hrUnit = [[HKUnit countUnit] unitDividedByUnit:[HKUnit minuteUnit]];
         HKQuantity* quantity = [HKQuantity quantityWithUnit:hrUnit doubleValue:(NSInteger)([NSDate date].timeIntervalSinceReferenceDate)%100];
-        HKQuantitySample *heartRateSample = [HKQuantitySample quantitySampleWithType:heartRateType quantity:quantity startDate:d1 endDate:d2];
+        HKQuantitySample *heartRateSample = [HKQuantitySample quantitySampleWithType:heartRateType quantity:quantity startDate:startDate endDate:endDate];
         
         NSString *identifier = HKCorrelationTypeIdentifierBloodPressure;
         HKUnit *bpUnit = [HKUnit unitFromString:@"mmHg"];
         
         // Blood Presure
-        HKQuantitySample *diastolicPressure = [HKQuantitySample quantitySampleWithType:diastolicType quantity:[HKQuantity quantityWithUnit:bpUnit doubleValue:70] startDate:d1 endDate:d2];
-        HKQuantitySample *systolicPressure = [HKQuantitySample quantitySampleWithType:systolicType quantity:[HKQuantity quantityWithUnit:bpUnit doubleValue:110] startDate:d1 endDate:d2];
+        HKQuantitySample *diastolicPressure = [HKQuantitySample quantitySampleWithType:diastolicType quantity:[HKQuantity quantityWithUnit:bpUnit doubleValue:70] startDate:startDate endDate:endDate];
+        HKQuantitySample *systolicPressure = [HKQuantitySample quantitySampleWithType:systolicType quantity:[HKQuantity quantityWithUnit:bpUnit doubleValue:110] startDate:startDate endDate:endDate];
         
-        HKCorrelation *bloodPressureCorrelation = [HKCorrelation correlationWithType:[HKCorrelationType correlationTypeForIdentifier:identifier] startDate:d1 endDate:d2 objects:[NSSet setWithObjects:diastolicPressure, systolicPressure, nil]];
+        HKCorrelation *bloodPressureCorrelation = [HKCorrelation correlationWithType:[HKCorrelationType correlationTypeForIdentifier:identifier] startDate:startDate endDate:endDate objects:[NSSet setWithObjects:diastolicPressure, systolicPressure, nil]];
         
         NSMutableArray *objects = [NSMutableArray new];
         if (sampleDataType & SampleDataTypeHR) {
@@ -255,7 +253,7 @@ typedef NS_OPTIONS (NSInteger, SampleDataType) {
 
 #endif
     } else {
-        NSLog(@"Not authorized!!!! ");
+        NSLog(@"HKHealthStore access has not been authorized.");
     }
 
     return authorized;
@@ -268,6 +266,7 @@ typedef NS_OPTIONS (NSInteger, SampleDataType) {
     ORKHealthCorrelationCollector *healthCorrelationCollector;
     __block NSError *error;
     ORKDataCollectionManager *manager = createManagerWithCollectors([NSURL fileURLWithPath:[self cleanStorePath]],
+                                                                    [NSDate dateWithTimeIntervalSinceNow:-10],
                                                                     &motionCollector,
                                                                     &healthCollector,
                                                                     &healthCorrelationCollector,
@@ -275,12 +274,13 @@ typedef NS_OPTIONS (NSInteger, SampleDataType) {
     
     manager.delegate = self;
     
-    
     // First round collection
     _completionExpectation = [self expectationWithDescription:@"Expectation for collection completion"];
     
 #if TARGET_OS_SIMULATOR
-    if ([self insertSampleDataWithType:SampleDataTypeALL]) {
+    if ([self insertSampleDataWithType:SampleDataTypeALL
+                             startDate:[NSDate dateWithTimeIntervalSinceNow:-9]
+                               endDate:[NSDate dateWithTimeIntervalSinceNow:-8]]) {
         _healthCollectionExpectation = [self expectationWithDescription:@"Expectation for health sample collection completion"];
         _correlationCollectionExpectation = [self expectationWithDescription:@"Expectation for correlation collection completion"];
     }
@@ -294,7 +294,6 @@ typedef NS_OPTIONS (NSInteger, SampleDataType) {
     XCTAssertNotNil(error);
     XCTAssertEqual(manager.collectors.count, 3);
 
-    
     [self waitForExpectationsWithTimeout:10.0 handler:^(NSError *error) {
         XCTAssertNil(error);
     }];
@@ -305,12 +304,13 @@ typedef NS_OPTIONS (NSInteger, SampleDataType) {
     XCTAssertNil(error);
     XCTAssertEqual(manager.collectors.count, 2);
     
-    
     // Second round collection
     _completionExpectation = [self expectationWithDescription:@"Expectation for collection completion"];
     
 #if TARGET_OS_SIMULATOR
-    if ([self insertSampleDataWithType:SampleDataTypeBP]) {
+    if ([self insertSampleDataWithType:SampleDataTypeBP
+                             startDate:[NSDate dateWithTimeIntervalSinceNow:-9]
+                               endDate:[NSDate dateWithTimeIntervalSinceNow:-8]]) {
         // Health Collector was removed
         _healthCollectionExpectation = nil;
         _correlationCollectionExpectation = [self expectationWithDescription:@"Expectation for correlation collection completion"];
@@ -325,20 +325,20 @@ typedef NS_OPTIONS (NSInteger, SampleDataType) {
 
 }
 
-- (void)testDataCollectionWithoutCollector {
+- (void)testDataCollectionWithoutCollectors {
     
     ORKMotionActivityCollector *motionCollector;
     ORKHealthCollector *healthCollector;
     ORKHealthCorrelationCollector *healthCorrelationCollector;
     __block NSError *error;
     ORKDataCollectionManager *manager = createManagerWithCollectors([NSURL fileURLWithPath:[self cleanStorePath]],
+                                                                    [NSDate date],
                                                                     &motionCollector,
                                                                     &healthCollector,
                                                                     &healthCorrelationCollector,
                                                                     &error);
     
     manager.delegate = self;
-    
     
     [manager removeCollector:motionCollector error:&error];
     [manager removeCollector:healthCollector error:&error];
@@ -353,29 +353,38 @@ typedef NS_OPTIONS (NSInteger, SampleDataType) {
     }];
 }
 
-- (void)testDelegateRejectDelivery {
+- (void)testDataCollectionDelegateDeliveryRejection {
     _acceptDelivery = NO;
     _errorCount = 0;
-#if TARGET_OS_SIMULATOR
-    if ([self insertSampleDataWithType:SampleDataTypeALL]) {
-        _healthCollectionExpectation = [self expectationWithDescription:@"Expectation for health sample collection completion"];
-        _correlationCollectionExpectation = [self expectationWithDescription:@"Expectation for correlation collection completion"];
-    }
-#endif
     
     ORKMotionActivityCollector *motionCollector;
     ORKHealthCollector *healthCollector;
     ORKHealthCorrelationCollector *healthCorrelationCollector;
     __block NSError *error;
+    
+    // Make sure the startDate isn't earlier that the dates
+    // of the samples added on '-testDataCollection'.
+    // Othersie, you'll get the samples from that test too.
     ORKDataCollectionManager *manager = createManagerWithCollectors([NSURL fileURLWithPath:[self cleanStorePath]],
+                                                                    [NSDate dateWithTimeIntervalSinceNow:-5],
                                                                     &motionCollector,
                                                                     &healthCollector,
                                                                     &healthCorrelationCollector,
                                                                     &error);
     
     manager.delegate = self;
+    
     _completionExpectation = [self expectationWithDescription:@"Expectation for collection completion"];
     
+#if TARGET_OS_SIMULATOR
+    if ([self insertSampleDataWithType:SampleDataTypeALL
+                             startDate:[NSDate dateWithTimeIntervalSinceNow:-4]
+                               endDate:[NSDate dateWithTimeIntervalSinceNow:-3]]) {
+        _healthCollectionExpectation = [self expectationWithDescription:@"Expectation for health sample collection completion"];
+        _correlationCollectionExpectation = [self expectationWithDescription:@"Expectation for correlation collection completion"];
+    }
+#endif
+
     [manager startCollection];
     [self waitForExpectationsWithTimeout:10.0 handler:^(NSError *error) {
         XCTAssertNil(error);
@@ -387,7 +396,6 @@ typedef NS_OPTIONS (NSInteger, SampleDataType) {
 
 - (BOOL)healthCollector:(ORKHealthCollector *)collector
       didCollectSamples:(NSArray<HKSample *> *)samples {
-    
     XCTAssertEqual(samples.count, 1);
     [_healthCollectionExpectation fulfill];
     NSLog(@"Did collect health samples");
@@ -396,7 +404,6 @@ typedef NS_OPTIONS (NSInteger, SampleDataType) {
 
 - (BOOL)healthCorrelationCollector:(ORKHealthCorrelationCollector *)collector
             didCollectCorrelations:(NSArray<HKCorrelation *> *)correlations {
-    
     XCTAssertEqual(correlations.count, 1);
     [_correlationCollectionExpectation fulfill];
     NSLog(@"Did collect correlation samples");
@@ -405,19 +412,18 @@ typedef NS_OPTIONS (NSInteger, SampleDataType) {
 
 - (BOOL)motionActivityCollector:(ORKMotionActivityCollector *)collector
      didCollectMotionActivities:(NSArray<CMMotionActivity *> *)motionActivities {
-    
     XCTAssertGreaterThan(motionActivities.count, 0);
     NSLog(@"Did collect CMMotionActivity samples");
     return _acceptDelivery;
 }
 
 - (void)dataCollectionManagerDidCompleteCollection:(ORKDataCollectionManager *)manager {
-     NSLog(@"dataCollectionManagerDidCompleteCollection %@", @(_acceptDelivery));
+    NSLog(@"dataCollectionManagerDidCompleteCollection %@", @(_acceptDelivery));
     [_completionExpectation fulfill];
 }
 
 - (void)collector:(ORKCollector *)collector didDetectError:(NSError *)error {
-     NSLog(@"didDetectError %@", error);
+    NSLog(@"didDetectError %@", error);
     if (_acceptDelivery) {
         XCTAssertNil(error);
     }

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -207,6 +207,9 @@ ORK_MAKE_TEST_INIT(HKObjectType, (^{
         return (HKObjectType *)[HKObjectType correlationTypeForIdentifier:HKCorrelationTypeIdentifierBloodPressure];
     }
 }))
+ORK_MAKE_TEST_INIT(CLCircularRegion, (^{
+    return [[CLCircularRegion alloc] initWithCenter:CLLocationCoordinate2DMake(2.0, 3.0) radius:100.0 identifier:@"identifier"];
+}));
 
                                                 
 @interface ORKJSONSerializationTests : XCTestCase <NSKeyedUnarchiverDelegate>
@@ -729,7 +732,8 @@ ORK_MAKE_TEST_INIT(HKObjectType, (^{
          ([c isSubclassOfClass:[ORKRecorderConfiguration class]]) ||
          (c == [ORKLocation class]) ||
          (c == [ORKResultSelector class]) ||
-         [c isSubclassOfClass:[HKObjectType class]])
+         [c isSubclassOfClass:[HKObjectType class]] ||
+        (c == [CLCircularRegion class]))
     {
         return [[c alloc] orktest_init];
     }


### PR DESCRIPTION
Fixes `ORKLocation` serialization unit test which was causing a *bad memory access* crash due  to `CLCircularRegion` being initialized using `init` instead of `initWithCenter:radius:identifier:` ([Issue #857](https://github.com/ResearchKit/ResearchKit/issues/857)). I've also submitted this to *bug report* as *Radar #29156129*, because I feel that trying to initialize `CLCircularRegion` through `init` should assert, rather than creating an invalid object.

Also, fix some `ORKDataCollectionTests` typos. The `testDelegateRejectDelivery` data collection test is still failing, I didn't have the time to familiarize with the new `ORKDataCollection` classes and fix the test.

---

Perhaps you guys should add a *GitHub* PR hook so the serialization tests are run for each PR, that way we'd find these kind of errors earlier. Also, I find `ORKESerialization` code quite tricky to debug. Maybe *ResearchKit* could benefit by rewriting this file without using *C preprocessor macros*: the code would be more verbose but easier to understand, debug, and maintain.