### PR TITLE
Expose passcode flow types

### DIFF
--- a/ResearchKit/Common/ORKPasscodeStep.h
+++ b/ResearchKit/Common/ORKPasscodeStep.h
@@ -36,6 +36,16 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
+ An enumeration of values used in `ORKPasscodeStepViewController` to indicate the type of flow used
+ by the view controller.
+ */
+typedef NS_ENUM(NSUInteger, ORKPasscodeFlow) {
+    ORKPasscodeFlowCreate,
+    ORKPasscodeFlowAuthenticate,
+    ORKPasscodeFlowEdit
+};
+
+/**
  An `ORKPasscodeStep` object provides the participant a passcode creation step.
  
  It is recommended to use a passcode step as part of the consent process to ensure
@@ -44,6 +54,22 @@ NS_ASSUME_NONNULL_BEGIN
  */
 ORK_CLASS_AVAILABLE
 @interface ORKPasscodeStep : ORKStep
+
+/**
+ Returns a new passcode step with the specified identifier and passcode flow.
+ 
+ @param identifier    The identifier of the step (a step identifier should be unique within the task).
+ @param passcodeFlow  The passcode flow to be used for the step.
+ */
++ (instancetype)passcodeStepWithIdentifier:(NSString *)identifier
+                              passcodeFlow:(ORKPasscodeFlow)passcodeFlow;
+
+/**
+ The passcode flow to be used for the step.
+ 
+ The default value of this property is `ORKPasscodeFlowCreate`.
+ */
+@property (nonatomic) ORKPasscodeFlow passcodeFlow;
 
 /**
  The passcode type to be used for the step.

--- a/ResearchKit/Common/ORKPasscodeStep.m
+++ b/ResearchKit/Common/ORKPasscodeStep.m
@@ -42,6 +42,14 @@
     return [ORKPasscodeStepViewController class];
 }
 
++ (instancetype)passcodeStepWithIdentifier:(NSString *)identifier
+                              passcodeFlow:(ORKPasscodeFlow)passcodeFlow {
+    
+    ORKPasscodeStep *step = [[ORKPasscodeStep alloc] initWithIdentifier:identifier];
+    step.passcodeFlow = passcodeFlow;
+    return step;
+}
+
 - (BOOL)showsProgress {
     return NO;
 }

--- a/ResearchKit/Common/ORKPasscodeStepViewController.h
+++ b/ResearchKit/Common/ORKPasscodeStepViewController.h
@@ -36,16 +36,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- An enumeration of values used in `ORKPasscodeStepViewController` to indicate the type of flow used
- by the view controller.
- */
-typedef NS_ENUM(NSUInteger, ORKPasscodeFlow) {
-    ORKPasscodeFlowCreate,
-    ORKPasscodeFlowAuthenticate,
-    ORKPasscodeFlowEdit
-};
-
-/**
  An `ORKPasscodeStepViewController` object is the view controller for an `ORKPasscodeStep` object.
  
  A passcode view controller can be instantiated indirectly by adding a passcode step to a consent task 
@@ -53,13 +43,6 @@ typedef NS_ENUM(NSUInteger, ORKPasscodeFlow) {
  view controller for the step.
  */
 @interface ORKPasscodeStepViewController : ORKStepViewController
-
-/**
- The passcode flow to be used for the step.
- 
- The default value of this property is `ORKPasscodeFlowCreate`.
- */
-@property (nonatomic) ORKPasscodeFlow passcodeFlow;
 
 @end
 

--- a/ResearchKit/Common/ORKPasscodeStepViewController.h
+++ b/ResearchKit/Common/ORKPasscodeStepViewController.h
@@ -36,6 +36,16 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
+ An enumeration of values used in `ORKPasscodeStepViewController` to indicate the type of flow used
+ by the view controller.
+ */
+typedef NS_ENUM(NSUInteger, ORKPasscodeFlow) {
+    ORKPasscodeFlowCreate,
+    ORKPasscodeFlowAuthenticate,
+    ORKPasscodeFlowEdit
+};
+
+/**
  An `ORKPasscodeStepViewController` object is the view controller for an `ORKPasscodeStep` object.
  
  A passcode view controller can be instanstiated indirectly by adding a passcode step to a consent task 
@@ -43,6 +53,13 @@ NS_ASSUME_NONNULL_BEGIN
  view controller for the step.
  */
 @interface ORKPasscodeStepViewController : ORKStepViewController
+
+/**
+ The passcode flow to be used for the step.
+ 
+ The default value of this property is `ORKPasscodeFlowCreate`.
+ */
+@property (nonatomic) ORKPasscodeFlow passcodeFlow;
 
 @end
 

--- a/ResearchKit/Common/ORKPasscodeStepViewController.h
+++ b/ResearchKit/Common/ORKPasscodeStepViewController.h
@@ -48,7 +48,7 @@ typedef NS_ENUM(NSUInteger, ORKPasscodeFlow) {
 /**
  An `ORKPasscodeStepViewController` object is the view controller for an `ORKPasscodeStep` object.
  
- A passcode view controller can be instanstiated indirectly by adding a passcode step to a consent task 
+ A passcode view controller can be instantiated indirectly by adding a passcode step to a consent task 
  and present the task using a task view controller. When appropriate, the task view controller instantiates the step
  view controller for the step.
  */

--- a/ResearchKit/Common/ORKPasscodeStepViewController.m
+++ b/ResearchKit/Common/ORKPasscodeStepViewController.m
@@ -400,7 +400,7 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
 
 - (void)finishTouchId {
     // Only save to keychain if it is not in authenticate flow.
-    if (!(self.passcodeFlow == ORKPasscodeFlowAuthenticate)) {
+    if (self.passcodeFlow != ORKPasscodeFlowAuthenticate) {
         [self savePasscodeToKeychain];
     }
     

--- a/ResearchKit/Common/ORKPasscodeStepViewController_Internal.h
+++ b/ResearchKit/Common/ORKPasscodeStepViewController_Internal.h
@@ -41,12 +41,6 @@ static NSString *const KeychainDictionaryTouchIdKey = @"touchIdEnabled";
 static NSString *const PasscodeStepIdentifier = @"passcode_step";
 static NSString *const PasscodeKey = @"ORKPasscode";
 
-typedef NS_ENUM(NSUInteger, ORKPasscodeFlow) {
-    ORKPasscodeFlowCreate,
-    ORKPasscodeFlowAuthenticate,
-    ORKPasscodeFlowEdit
-};
-
 typedef NS_ENUM(NSUInteger, ORKPasscodeState) {
     ORKPasscodeStateEntry,
     ORKPasscodeStateConfirm,
@@ -58,7 +52,6 @@ typedef NS_ENUM(NSUInteger, ORKPasscodeState) {
 
 @interface ORKPasscodeStepViewController() <UITextFieldDelegate, CAAnimationDelegate>
 
-@property (nonatomic) ORKPasscodeFlow passcodeFlow;
 @property (nonatomic, weak) id<ORKPasscodeDelegate> passcodeDelegate;
 
 /**

--- a/ResearchKit/Common/ORKPasscodeViewController.m
+++ b/ResearchKit/Common/ORKPasscodeViewController.m
@@ -87,11 +87,11 @@
                                   passcodeType:(ORKPasscodeType)passcodeType {
     
     ORKPasscodeStep *step = [[ORKPasscodeStep alloc] initWithIdentifier:PasscodeStepIdentifier];
+    step.passcodeFlow = passcodeFlow;
     step.passcodeType = passcodeType;
     step.text = text;
     
     ORKPasscodeStepViewController *passcodeStepViewController = [ORKPasscodeStepViewController new];
-    passcodeStepViewController.passcodeFlow = passcodeFlow;
     passcodeStepViewController.passcodeDelegate = delegate;
     passcodeStepViewController.step = step;
     


### PR DESCRIPTION
Unless I'm mistaken, currently the only way to ask the user for a passcode is to use the static `ORKPasscodeViewController.passcodeAuthenticationViewController()` method, which produces a view controller to be modally presented with little in the way of customization or integration with other steps.

One use case we have is the need to show passcode authentication as a step along with an `ORKLoginStep` so that the user can switch between the two as desired.

This PR publicly exposes the `passcodeFlow` property and associated enums at the ORKPasscodeStep level so that its value can be set to `.authenticate` when constructing the step. The constructor that takes only an identifier remains untouched so existing code is not affected.