### PR TITLE
[Charts] IBDesignable improvements

### DIFF
--- a/ResearchKit/Charts/ORKBarGraphChartView.m
+++ b/ResearchKit/Charts/ORKBarGraphChartView.m
@@ -37,6 +37,59 @@
 #import "ORKHelpers_Internal.h"
 
 
+#if TARGET_INTERFACE_BUILDER
+
+@interface ORKIBBarGraphChartViewDataSource : ORKIBGraphChartViewDataSource <ORKValueStackGraphChartViewDataSource>
+
++ (instancetype)sharedInstance;
+
+@end
+
+
+@implementation ORKIBBarGraphChartViewDataSource
+
++ (instancetype)sharedInstance {
+    static id sharedInstance;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[self class] new];
+    });
+    return sharedInstance;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.plotPoints = @[
+                            @[
+                                [[ORKValueStack alloc] initWithStackedValues:@[@4, @6]],
+                                [[ORKValueStack alloc] initWithStackedValues:@[@2, @4, @4]],
+                                [[ORKValueStack alloc] initWithStackedValues:@[@2, @6, @3, @6]],
+                                [[ORKValueStack alloc] initWithStackedValues:@[@3, @8, @10, @12]],
+                                [[ORKValueStack alloc] initWithStackedValues:@[@5, @10, @12, @8]],
+                                [[ORKValueStack alloc] initWithStackedValues:@[@8, @13, @18]],
+                                ],
+                            @[
+                                [[ORKValueStack alloc] initWithStackedValues:@[@14]],
+                                [[ORKValueStack alloc] initWithStackedValues:@[@6, @6]],
+                                [[ORKValueStack alloc] initWithStackedValues:@[@3, @10, @12]],
+                                [[ORKValueStack alloc] initWithStackedValues:@[@5, @11, @14]],
+                                [[ORKValueStack alloc] initWithStackedValues:@[@7, @13, @20]],
+                                [[ORKValueStack alloc] initWithStackedValues:@[@10, @13, @25]],
+                                ]
+                            ];
+    }
+    return self;
+}
+
+- (ORKValueStack *)graphChartView:(ORKGraphChartView *)graphChartView dataPointForPointIndex:(NSInteger)pointIndex plotIndex:(NSInteger)plotIndex {
+    return self.plotPoints[plotIndex][pointIndex];
+}
+
+@end
+
+#endif
+
 static const CGFloat BarWidth = 10.0;
 
 
@@ -223,5 +276,15 @@ static const CGFloat BarWidth = 10.0;
 - (BOOL)isXPositionSnapped:(CGFloat)xPosition plotIndex:(NSInteger)plotIndex {
     return [super isXPositionSnapped:xPosition - [self xOffsetForPlotIndex:plotIndex] plotIndex:plotIndex];
 }
+
+#pragma mark - Interface Builder designable
+
+- (void)prepareForInterfaceBuilder {
+    [super prepareForInterfaceBuilder];
+#if TARGET_INTERFACE_BUILDER
+    self.dataSource = [ORKIBBarGraphChartViewDataSource sharedInstance];
+#endif
+}
+
 
 @end

--- a/ResearchKit/Charts/ORKDiscreteGraphChartView.m
+++ b/ResearchKit/Charts/ORKDiscreteGraphChartView.m
@@ -41,29 +41,45 @@
 
 #if TARGET_INTERFACE_BUILDER
 
-@interface ORKIBDiscreteGraphChartViewDataSource : ORKIBGraphChartViewDataSource
+@interface ORKIBDiscreteGraphChartViewDataSource : ORKIBValueRangeGraphChartViewDataSource
+
++ (instancetype)sharedInstance;
 
 @end
 
 
 @implementation ORKIBDiscreteGraphChartViewDataSource
 
++ (instancetype)sharedInstance {
+    static id sharedInstance;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[self class] new];
+    });
+    return sharedInstance;
+}
+
 - (instancetype)init {
     self = [super init];
     if (self) {
-        self.plotPoints = @[@[[[ORKValueRange alloc] initWithMinimumValue: 0 maximumValue: 2],
-                              [[ORKValueRange alloc] initWithMinimumValue: 1 maximumValue: 4],
-                              [[ORKValueRange alloc] initWithMinimumValue: 2 maximumValue: 6],
-                              [[ORKValueRange alloc] initWithMinimumValue: 3 maximumValue: 8],
-                              [[ORKValueRange alloc] initWithMinimumValue: 5 maximumValue: 10],
-                              [[ORKValueRange alloc] initWithMinimumValue: 8 maximumValue: 13]],
-                            @[[[ORKValueRange alloc] initWithValue: 1],
-                              [[ORKValueRange alloc] initWithMinimumValue: 2 maximumValue: 6],
-                              [[ORKValueRange alloc] initWithMinimumValue: 3 maximumValue: 10],
-                              [[ORKValueRange alloc] initWithMinimumValue: 5 maximumValue: 11],
-                              [[ORKValueRange alloc] initWithMinimumValue: 7 maximumValue: 13],
-                              [[ORKValueRange alloc] initWithMinimumValue: 10 maximumValue: 13]
-                              ]];
+        self.plotPoints = @[
+                            @[
+                                [[ORKValueRange alloc] initWithMinimumValue:0 maximumValue: 2],
+                                [[ORKValueRange alloc] initWithMinimumValue:1 maximumValue: 4],
+                                [[ORKValueRange alloc] initWithMinimumValue:2 maximumValue: 6],
+                                [[ORKValueRange alloc] initWithMinimumValue:3 maximumValue: 8],
+                                [[ORKValueRange alloc] initWithMinimumValue:5 maximumValue:10],
+                                [[ORKValueRange alloc] initWithMinimumValue:8 maximumValue:13]
+                              ],
+                            @[
+                                [[ORKValueRange alloc] initWithValue:1],
+                                [[ORKValueRange alloc] initWithMinimumValue:2 maximumValue:6],
+                                [[ORKValueRange alloc] initWithMinimumValue:3 maximumValue:10],
+                                [[ORKValueRange alloc] initWithMinimumValue:5 maximumValue:11],
+                                [[ORKValueRange alloc] initWithMinimumValue:7 maximumValue:13],
+                                [[ORKValueRange alloc] initWithMinimumValue:10 maximumValue:13]
+                              ]
+                            ];
     }
     return self;
 }

--- a/ResearchKit/Charts/ORKDiscreteGraphChartView.m
+++ b/ResearchKit/Charts/ORKDiscreteGraphChartView.m
@@ -40,9 +40,36 @@
 
 
 #if TARGET_INTERFACE_BUILDER
-@interface ORKDiscreteGraphChartView ()
-@property (nonatomic, strong, nullable) ORKIBSampleDiscreteGraphDataSource *sampleDataSource;
+
+@interface ORKIBDiscreteGraphChartViewDataSource : ORKIBGraphChartViewDataSource
+
 @end
+
+
+@implementation ORKIBDiscreteGraphChartViewDataSource
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.plotPoints = @[@[[[ORKValueRange alloc] initWithMinimumValue: 0 maximumValue: 2],
+                              [[ORKValueRange alloc] initWithMinimumValue: 1 maximumValue: 4],
+                              [[ORKValueRange alloc] initWithMinimumValue: 2 maximumValue: 6],
+                              [[ORKValueRange alloc] initWithMinimumValue: 3 maximumValue: 8],
+                              [[ORKValueRange alloc] initWithMinimumValue: 5 maximumValue: 10],
+                              [[ORKValueRange alloc] initWithMinimumValue: 8 maximumValue: 13]],
+                            @[[[ORKValueRange alloc] initWithValue: 1],
+                              [[ORKValueRange alloc] initWithMinimumValue: 2 maximumValue: 6],
+                              [[ORKValueRange alloc] initWithMinimumValue: 3 maximumValue: 10],
+                              [[ORKValueRange alloc] initWithMinimumValue: 5 maximumValue: 11],
+                              [[ORKValueRange alloc] initWithMinimumValue: 7 maximumValue: 13],
+                              [[ORKValueRange alloc] initWithMinimumValue: 10 maximumValue: 13]
+                              ]];
+    }
+    return self;
+}
+
+@end
+
 #endif
 
 
@@ -130,9 +157,9 @@
 #pragma mark - Interface Builder designable
 
 - (void)prepareForInterfaceBuilder {
+    [super prepareForInterfaceBuilder];
 #if TARGET_INTERFACE_BUILDER
-    self.sampleDataSource = [ORKIBSampleDiscreteGraphDataSource new];
-    self.dataSource = self.sampleDataSource;
+    self.dataSource = [ORKIBDiscreteGraphChartViewDataSource sharedInstance];
 #endif
 }
 

--- a/ResearchKit/Charts/ORKGraphChartView.m
+++ b/ResearchKit/Charts/ORKGraphChartView.m
@@ -47,15 +47,6 @@
 
 @implementation ORKIBGraphChartViewDataSource
 
-+ (instancetype)sharedInstance {
-    static ORKIBGraphChartViewDataSource *sharedInstance;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        sharedInstance = [[self class] new];
-    });
-    return sharedInstance;
-}
-
 - (NSInteger)numberOfPlotsInGraphChartView:(ORKGraphChartView *)graphChartView {
     return self.plotPoints.count;
 }
@@ -64,12 +55,16 @@
     return self.plotPoints[plotIndex].count;
 }
 
-- (ORKValueRange *)graphChartView:(ORKGraphChartView *)graphChartView dataPointForPointIndex:(NSInteger)pointIndex plotIndex:(NSInteger)plotIndex {
-    return self.plotPoints[plotIndex][pointIndex];
-}
-
 - (NSString *)graphChartView:(ORKGraphChartView *)graphChartView titleForXAxisAtPointIndex:(NSInteger)pointIndex {
     return [@(pointIndex + 1) stringValue];
+}
+
+@end
+
+@implementation ORKIBValueRangeGraphChartViewDataSource
+
+- (ORKValueRange *)graphChartView:(ORKGraphChartView *)graphChartView dataPointForPointIndex:(NSInteger)pointIndex plotIndex:(NSInteger)plotIndex {
+    return self.plotPoints[plotIndex][pointIndex];
 }
 
 @end

--- a/ResearchKit/Charts/ORKGraphChartView.m
+++ b/ResearchKit/Charts/ORKGraphChartView.m
@@ -43,6 +43,40 @@
 #import "ORKSkin.h"
 
 
+#if TARGET_INTERFACE_BUILDER
+
+@implementation ORKIBGraphChartViewDataSource
+
++ (instancetype)sharedInstance {
+    static ORKIBGraphChartViewDataSource *sharedInstance;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[self class] new];
+    });
+    return sharedInstance;
+}
+
+- (NSInteger)numberOfPlotsInGraphChartView:(ORKGraphChartView *)graphChartView {
+    return self.plotPoints.count;
+}
+
+- (NSInteger)graphChartView:(ORKGraphChartView *)graphChartView numberOfDataPointsForPlotIndex:(NSInteger)plotIndex {
+    return self.plotPoints[plotIndex].count;
+}
+
+- (ORKValueRange *)graphChartView:(ORKGraphChartView *)graphChartView dataPointForPointIndex:(NSInteger)pointIndex plotIndex:(NSInteger)plotIndex {
+    return self.plotPoints[plotIndex][pointIndex];
+}
+
+- (NSString *)graphChartView:(ORKGraphChartView *)graphChartView titleForXAxisAtPointIndex:(NSInteger)pointIndex {
+    return [@(pointIndex + 1) stringValue];
+}
+
+@end
+
+#endif
+
+
 const CGFloat ORKGraphChartViewLeftPadding = 10.0;
 const CGFloat ORKGraphChartViewPointAndLineWidth = 8.0;
 const CGFloat ORKGraphChartViewScrubberMoveAnimationDuration = 0.1;
@@ -1239,103 +1273,4 @@ ORK_INLINE CALayer *graphPointLayerWithColor(UIColor *color, BOOL drawPointIndic
     }
 }
 
-#pragma mark - Interface Builder designable
-
-- (void)prepareForInterfaceBuilder {
-    [self reloadData];
-}
-
 @end
-
-
-#if TARGET_INTERFACE_BUILDER
-
-@implementation ORKIBSampleDiscreteGraphDataSource
-
-- (instancetype)init {
-    self = [super init];
-    if (self) {
-        self.plotPoints = @[@[[[ORKRangedPoint alloc] initWithMinimumValue: 0 maximumValue: 2],
-                              [[ORKRangedPoint alloc] initWithMinimumValue: 1 maximumValue: 4],
-                              [[ORKRangedPoint alloc] initWithMinimumValue: 2 maximumValue: 6],
-                              [[ORKRangedPoint alloc] initWithMinimumValue: 3 maximumValue: 8],
-                              [[ORKRangedPoint alloc] initWithMinimumValue: 5 maximumValue: 10],
-                              [[ORKRangedPoint alloc] initWithMinimumValue: 8 maximumValue: 13]],
-                            @[[[ORKRangedPoint alloc] initWithValue: 1],
-                              [[ORKRangedPoint alloc] initWithMinimumValue: 2 maximumValue: 6],
-                              [[ORKRangedPoint alloc] initWithMinimumValue: 3 maximumValue: 10],
-                              [[ORKRangedPoint alloc] initWithMinimumValue: 5 maximumValue: 11],
-                              [[ORKRangedPoint alloc] initWithMinimumValue: 7 maximumValue: 13],
-                              [[ORKRangedPoint alloc] initWithMinimumValue: 10 maximumValue: 13]
-                              ]];
-    }
-    return self;
-}
-
-- (NSInteger)numberOfPlotsInGraphChartView:(ORKGraphChartView *)graphChartView {
-    return self.plotPoints.count;
-}
-
-- (NSInteger)graphChartView:(ORKGraphChartView *)graphChartView numberOfDataPointsForPlotIndex:(NSInteger)plotIndex {
-    return self.plotPoints[plotIndex].count;
-}
-
-- (ORKRangedPoint *)graphChartView:(ORKGraphChartView *)graphChartView dataPointForPointIndex:(NSInteger)pointIndex plotIndex:(NSInteger)plotIndex {
-    return self.plotPoints[plotIndex][pointIndex];
-    }
-
-- (NSString *)graphChartView:(ORKGraphChartView *)graphChartView titleForXAxisAtPointIndex:(NSInteger)pointIndex {
-    return [@(pointIndex + 1) stringValue];
-}
-
-@end
-
-
-@implementation ORKIBSampleLineGraphDataSource
-    
-- (instancetype)init {
-    self = [super init];
-    if (self) {
-        self.plotPoints = @[@[[[ORKRangedPoint alloc] initWithValue: 10],
-                              [[ORKRangedPoint alloc] initWithValue: 20],
-                              [[ORKRangedPoint alloc] initWithValue: 25],
-                              [[ORKRangedPoint alloc] init],
-                              [[ORKRangedPoint alloc] initWithValue: 30],
-                              [[ORKRangedPoint alloc] initWithValue: 40]],
-                            @[[[ORKRangedPoint alloc] initWithValue: 2],
-                              [[ORKRangedPoint alloc] initWithValue: 4],
-                              [[ORKRangedPoint alloc] initWithValue: 8],
-                              [[ORKRangedPoint alloc] initWithValue: 16],
-                              [[ORKRangedPoint alloc] initWithValue: 32],
-                              [[ORKRangedPoint alloc] initWithValue: 64]
-                              ]];
-    }
-    return self;
-}
-        
-- (NSInteger)numberOfPlotsInGraphChartView:(ORKGraphChartView *)graphChartView {
-    return self.plotPoints.count;
-}
-            
-- (NSInteger)graphChartView:(ORKGraphChartView *)graphChartView numberOfDataPointsForPlotIndex:(NSInteger)plotIndex {
-    return self.plotPoints[plotIndex].count;
-            }
-
-- (ORKRangedPoint *)graphChartView:(ORKGraphChartView *)graphChartView dataPointForPointIndex:(NSInteger)pointIndex plotIndex:(NSInteger)plotIndex {
-    return self.plotPoints[plotIndex][pointIndex];
-        }
-        
-- (NSString *)graphChartView:(ORKGraphChartView *)graphChartView titleForXAxisAtPointIndex:(NSInteger)pointIndex {
-    return [@(pointIndex + 1) stringValue];
-        }
-
-- (CGFloat)minimumValueForGraphChartView:(ORKGraphChartView *)graphChartView {
-    return 0;
-    }
-    
-- (CGFloat)maximumValueForGraphChartView:(ORKGraphChartView *)graphChartView {
-    return 70;
-}
-
-@end
-#endif

--- a/ResearchKit/Charts/ORKGraphChartView_Internal.h
+++ b/ResearchKit/Charts/ORKGraphChartView_Internal.h
@@ -41,9 +41,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ORKIBGraphChartViewDataSource : NSObject <ORKGraphChartViewDataSource>
 
-+ (nullable instancetype)sharedInstance;
-
 @property (nonatomic, strong, nullable) NSArray <NSArray *> *plotPoints;
+
+@end
+
+
+@interface ORKIBValueRangeGraphChartViewDataSource : ORKIBGraphChartViewDataSource <ORKValueRangeGraphChartViewDataSource>
 
 @end
 

--- a/ResearchKit/Charts/ORKGraphChartView_Internal.h
+++ b/ResearchKit/Charts/ORKGraphChartView_Internal.h
@@ -37,6 +37,19 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#if TARGET_INTERFACE_BUILDER
+
+@interface ORKIBGraphChartViewDataSource : NSObject <ORKGraphChartViewDataSource>
+
++ (nullable instancetype)sharedInstance;
+
+@property (nonatomic, strong, nullable) NSArray <NSArray *> *plotPoints;
+
+@end
+
+#endif
+
+
 @class ORKXAxisView;
 
 typedef NS_ENUM(NSUInteger, ORKGraphAnimationType) {
@@ -81,15 +94,6 @@ ORK_INLINE CGFloat xOffsetForPlotIndex(NSInteger plotIndex, NSInteger numberOfPl
     return offset;
 }
 
-#if TARGET_INTERFACE_BUILDER
-@interface ORKIBSampleDiscreteGraphDataSource : NSObject <ORKGraphChartViewDataSource>
-@property (nonatomic, strong, nullable) NSArray <NSArray *> *plotPoints;
-@end
-
-@interface ORKIBSampleLineGraphDataSource : NSObject <ORKGraphChartViewDataSource>
-@property (nonatomic, strong, nullable) NSArray <NSArray *> *plotPoints;
-@end
-#endif
 
 @interface ORKGraphChartView ()
 

--- a/ResearchKit/Charts/ORKLineGraphChartView.m
+++ b/ResearchKit/Charts/ORKLineGraphChartView.m
@@ -40,10 +40,46 @@
 
 
 #if TARGET_INTERFACE_BUILDER
-@interface ORKLineGraphChartView ()
-@property (nonatomic, strong, nullable) ORKIBSampleLineGraphDataSource *sampleDataSource;
+
+@interface ORKIBLineGraphChartViewDataSource : ORKIBGraphChartViewDataSource
+
 @end
+
+
+@implementation ORKIBLineGraphChartViewDataSource
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.plotPoints = @[@[[[ORKValueRange alloc] initWithValue: 10],
+                              [[ORKValueRange alloc] initWithValue: 20],
+                              [[ORKValueRange alloc] initWithValue: 25],
+                              [[ORKValueRange alloc] init],
+                              [[ORKValueRange alloc] initWithValue: 30],
+                              [[ORKValueRange alloc] initWithValue: 40]],
+                            @[[[ORKValueRange alloc] initWithValue: 2],
+                              [[ORKValueRange alloc] initWithValue: 4],
+                              [[ORKValueRange alloc] initWithValue: 8],
+                              [[ORKValueRange alloc] initWithValue: 16],
+                              [[ORKValueRange alloc] initWithValue: 32],
+                              [[ORKValueRange alloc] initWithValue: 64]
+                              ]];
+    }
+    return self;
+}
+
+- (CGFloat)minimumValueForGraphChartView:(ORKGraphChartView *)graphChartView {
+    return 0;
+}
+
+- (CGFloat)maximumValueForGraphChartView:(ORKGraphChartView *)graphChartView {
+    return 70;
+}
+
+@end
+
 #endif
+
 
 const CGFloat FillColorAlpha = 0.4;
 
@@ -306,9 +342,9 @@ const CGFloat FillColorAlpha = 0.4;
 #pragma mark - Interface Builder designable
 
 - (void)prepareForInterfaceBuilder {
+    [super prepareForInterfaceBuilder];
 #if TARGET_INTERFACE_BUILDER
-    self.sampleDataSource = [ORKIBSampleLineGraphDataSource new];
-    self.dataSource = self.sampleDataSource;
+    self.dataSource = [ORKIBLineGraphChartViewDataSource sharedInstance];
 #endif
 }
 

--- a/ResearchKit/Charts/ORKLineGraphChartView.m
+++ b/ResearchKit/Charts/ORKLineGraphChartView.m
@@ -41,29 +41,45 @@
 
 #if TARGET_INTERFACE_BUILDER
 
-@interface ORKIBLineGraphChartViewDataSource : ORKIBGraphChartViewDataSource
+@interface ORKIBLineGraphChartViewDataSource : ORKIBValueRangeGraphChartViewDataSource
+
++ (instancetype)sharedInstance;
 
 @end
 
 
 @implementation ORKIBLineGraphChartViewDataSource
 
++ (instancetype)sharedInstance {
+    static id sharedInstance;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[self class] new];
+    });
+    return sharedInstance;
+}
+
 - (instancetype)init {
     self = [super init];
     if (self) {
-        self.plotPoints = @[@[[[ORKValueRange alloc] initWithValue: 10],
-                              [[ORKValueRange alloc] initWithValue: 20],
-                              [[ORKValueRange alloc] initWithValue: 25],
-                              [[ORKValueRange alloc] init],
-                              [[ORKValueRange alloc] initWithValue: 30],
-                              [[ORKValueRange alloc] initWithValue: 40]],
-                            @[[[ORKValueRange alloc] initWithValue: 2],
-                              [[ORKValueRange alloc] initWithValue: 4],
-                              [[ORKValueRange alloc] initWithValue: 8],
-                              [[ORKValueRange alloc] initWithValue: 16],
-                              [[ORKValueRange alloc] initWithValue: 32],
-                              [[ORKValueRange alloc] initWithValue: 64]
-                              ]];
+        self.plotPoints = @[
+                            @[
+                                [[ORKValueRange alloc] initWithValue:10],
+                                [[ORKValueRange alloc] initWithValue:20],
+                                [[ORKValueRange alloc] initWithValue:25],
+                                [[ORKValueRange alloc] init],
+                                [[ORKValueRange alloc] initWithValue:30],
+                                [[ORKValueRange alloc] initWithValue:40]
+                              ],
+                            @[
+                                [[ORKValueRange alloc] initWithValue:2],
+                                [[ORKValueRange alloc] initWithValue:4],
+                                [[ORKValueRange alloc] initWithValue:8],
+                                [[ORKValueRange alloc] initWithValue:16],
+                                [[ORKValueRange alloc] initWithValue:32],
+                                [[ORKValueRange alloc] initWithValue:64]
+                                ]
+                            ];
     }
     return self;
 }

--- a/ResearchKit/Charts/ORKPieChartView.m
+++ b/ResearchKit/Charts/ORKPieChartView.m
@@ -42,6 +42,86 @@
 #import "ORKSkin.h"
 
 
+#if TARGET_INTERFACE_BUILDER
+
+@interface ORKIBPieChartViewDataSourceSegment : NSObject
+
+@property (nonatomic, assign) CGFloat value;
+
+@property (nonatomic, copy, nullable) NSString *title;
+
+@property (nonatomic, strong, nullable) UIColor *color;
+
+@end
+
+
+@interface ORKIBPieChartViewDataSource : NSObject <ORKPieChartViewDataSource>
+
++ (instancetype)sharedInstance;
+
+@property (nonatomic, strong, nullable) NSArray <ORKIBPieChartViewDataSourceSegment *> *segments;
+
+@end
+
+
+@implementation ORKIBPieChartViewDataSourceSegment
+
+@end
+
+
+@implementation ORKIBPieChartViewDataSource
+
++ (instancetype)sharedInstance {
+    static ORKIBPieChartViewDataSource *sharedInstance;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[self class] new];
+    });
+    return sharedInstance;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        ORKIBPieChartViewDataSourceSegment *segment1 = [ORKIBPieChartViewDataSourceSegment new];
+        segment1.value = 10.0;
+        segment1.title = @"Title 1";
+        segment1.color = [UIColor colorWithRed:217.0/225 green:217.0/255 blue:217.0/225 alpha:1];
+        
+        ORKIBPieChartViewDataSourceSegment *segment2 = [ORKIBPieChartViewDataSourceSegment new];
+        segment2.value = 25.0;
+        segment2.title = @"Title 2";
+        segment2.color = [UIColor colorWithRed:142.0/255 green:142.0/255 blue:147.0/255 alpha:1];
+        
+        ORKIBPieChartViewDataSourceSegment *segment3 = [ORKIBPieChartViewDataSourceSegment new];
+        segment3.value = 45.0;
+        segment3.title = @"Title 3";
+        segment3.color = [UIColor colorWithRed:244.0/225 green:190.0/255 blue:74.0/225 alpha:1];
+        
+        _segments = @[segment1, segment2, segment3];
+    }
+    return self;
+}
+- (NSInteger)numberOfSegmentsInPieChartView:(ORKPieChartView *)pieChartView {
+    return self.segments.count;
+}
+- (CGFloat)pieChartView:(ORKPieChartView *)pieChartView valueForSegmentAtIndex:(NSInteger)index {
+    return self.segments[index].value;
+}
+
+- (UIColor *)pieChartView:(ORKPieChartView *)pieChartView colorForSegmentAtIndex:(NSInteger)index {
+    return self.segments[index].color;
+}
+
+- (NSString *)pieChartView:(ORKPieChartView *)pieChartView titleForSegmentAtIndex:(NSInteger)index {
+    return self.segments[index].title;
+}
+
+@end
+
+#endif
+
+
 static const CGFloat TitleToPiePadding = 8.0;
 static const CGFloat PieToLegendPadding = 8.0;
 
@@ -388,60 +468,10 @@ static const CGFloat PieToLegendPadding = 8.0;
 #pragma mark - Interface Builder designable
 
 - (void)prepareForInterfaceBuilder {
+    [super prepareForInterfaceBuilder];
 #if TARGET_INTERFACE_BUILDER
-    self.sampleDataSource = [ORKIBSamplePieChartDataSource new];
-    self.dataSource = self.sampleDataSource;
+    self.dataSource = [ORKIBPieChartViewDataSource sharedInstance];
 #endif
 }
 
 @end
-
-
-#if TARGET_INTERFACE_BUILDER
-
-@implementation ORKIBSamplePieChartDataSourceSegment
-@end
-
-@implementation ORKIBSamplePieChartDataSource
-
-- (instancetype)init {
-    self = [super init];
-    if (self) {
-        ORKIBSamplePieChartDataSourceSegment *segment1 = [ORKIBSamplePieChartDataSourceSegment new];
-        segment1.title = @"Title 1";
-        segment1.value = 10.0;
-        segment1.color = [UIColor colorWithRed:217.0/225 green:217.0/255 blue:217.0/225 alpha:1];
-
-        ORKIBSamplePieChartDataSourceSegment *segment2 = [ORKIBSamplePieChartDataSourceSegment new];
-        segment2.title = @"Title 2";
-        segment2.value = 25.0;
-        segment2.color = [UIColor colorWithRed:142.0/255 green:142.0/255 blue:147.0/255 alpha:1];
-
-        ORKIBSamplePieChartDataSourceSegment *segment3 = [ORKIBSamplePieChartDataSourceSegment new];
-        segment3.title = @"Title 3";
-        segment3.value = 45.0;
-        segment3.color = [UIColor colorWithRed:244.0/225 green:190.0/255 blue:74.0/225 alpha:1];
-
-        _segments = @[segment1, segment2, segment3];
-}
-    return self;
-}
-- (NSInteger)numberOfSegmentsInPieChartView:(ORKPieChartView *)pieChartView {
-    return self.segments.count;
-}
-- (CGFloat)pieChartView:(ORKPieChartView *)pieChartView valueForSegmentAtIndex:(NSInteger)index {
-
-    return self.segments[index].value;
-}
-
-- (UIColor *)pieChartView:(ORKPieChartView *)pieChartView colorForSegmentAtIndex:(NSInteger)index {
-    return self.segments[index].color;
-}
-
-- (NSString *)pieChartView:(ORKPieChartView *)pieChartView titleForSegmentAtIndex:(NSInteger)index {
-    return self.segments[index].title;
-}
-
-@end
-
-#endif

--- a/ResearchKit/Charts/ORKPieChartView_Internal.h
+++ b/ResearchKit/Charts/ORKPieChartView_Internal.h
@@ -44,26 +44,9 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 
-#if TARGET_INTERFACE_BUILDER
-@interface ORKIBSamplePieChartDataSourceSegment : NSObject
-@property (nonatomic, strong, nullable) NSString *title;
-@property (nonatomic, assign) CGFloat value;
-@property (nonatomic, strong, nullable) UIColor *color;
-@end
-
-@interface ORKIBSamplePieChartDataSource : NSObject <ORKPieChartViewDataSource>
-@property (nonatomic, strong, nullable) NSArray <ORKIBSamplePieChartDataSourceSegment *> *segments;
-@end
-#endif
-
-
 @interface ORKPieChartView ()
 
 - (UIColor *)colorForSegmentAtIndex:(NSInteger)index;
-
-#if TARGET_INTERFACE_BUILDER
-@property (nonatomic, strong, nullable) ORKIBSamplePieChartDataSource *sampleDataSource;
-#endif
 
 @end
 


### PR DESCRIPTION
This PR provides some improvements to the *sample data sources* used by *Xcode* when composing chart views on *Interface Builder*.
- Fix [Issue #886](https://github.com/ResearchKit/ResearchKit/issues/886).
- Add sample `ORKIBBarGraphChartViewDataSource` for `ORKBarGraphChartView`.
- Improve sample data source encapsulation and code reuse (and rename sample data source classes so they have the same name stem as the corresponding views) .
- Improve whitespace to conform to coding guidelines.