### PR TITLE
[ORKSignatureView] Increase height and distance of signing line to bottom

### DIFF
--- a/ResearchKit/Common/ORKSignatureView.m
+++ b/ResearchKit/Common/ORKSignatureView.m
@@ -56,6 +56,9 @@
 @end
 
 
+static const CGFloat TopToSigningLineRatio = 0.7;
+
+
 @implementation ORKSignatureGestureRecognizer
 
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
@@ -226,12 +229,8 @@ static const CGFloat LineWidthStepValue = 0.25f;
 
 - (CGPoint)placeholderPoint {
     CGFloat height = self.bounds.size.height;
-    
-    CGFloat bottom = 0.90;
-    
     CGFloat x1 = 0;
-        
-    CGFloat y1 = height*bottom;
+    CGFloat y1 = height * TopToSigningLineRatio;
     UIFont *font = [ORKSelectionTitleLabel defaultFont];
     return (CGPoint){x1, y1 - 5 - font.pointSize + font.descender};
 }
@@ -242,14 +241,12 @@ static const CGFloat LineWidthStepValue = 0.25f;
         CGFloat height = self.bounds.size.height;
         
         UIBezierPath *path = [UIBezierPath bezierPath];
-        
-        CGFloat bottom = 0.90;
         {
             CGFloat x1 = 0;
             CGFloat x2 = width;
             
-            CGFloat y1 = height*bottom;
-            CGFloat y2 = height*bottom;
+            CGFloat y1 = height * TopToSigningLineRatio;
+            CGFloat y2 = height * TopToSigningLineRatio;
             
             [path moveToPoint:CGPointMake(x1, y1)];
             [path addLineToPoint:CGPointMake(x2, y2)];

--- a/ResearchKit/Common/ORKSkin.m
+++ b/ResearchKit/Common/ORKSkin.m
@@ -213,7 +213,7 @@ CGFloat ORKGetMetricForScreenType(ORKScreenMetric metric, ORKScreenType screenTy
         {         10,        10,         0,         0,        10,        10},      // ORKScreenMetricHeadlineSideMargin
         {         44,        44,        44,        44,        44,        44},      // ORKScreenMetricToolbarHeight
         {        322,       274,       217,       217,       446,       446},      // ORKScreenMetricVerticalScaleHeight
-        {        156,       156,       156,       156,       256,       256},      // ORKScreenMetricSignatureViewHeight
+        {        194,       194,       194,       194,       256,       256},      // ORKScreenMetricSignatureViewHeight
         {        384,       324,       304,       304,       384,       384},      // ORKScreenMetricPSATKeyboardViewWidth
         {        197,       167,       157,       157,       197,       197},      // ORKScreenMetricPSATKeyboardViewHeight
         {        238,       238,       150,        90,       238,       238},      // ORKScreenMetricLocationQuestionMapHeight

--- a/ResearchKit/Common/ORKSkin.m
+++ b/ResearchKit/Common/ORKSkin.m
@@ -213,7 +213,7 @@ CGFloat ORKGetMetricForScreenType(ORKScreenMetric metric, ORKScreenType screenTy
         {         10,        10,         0,         0,        10,        10},      // ORKScreenMetricHeadlineSideMargin
         {         44,        44,        44,        44,        44,        44},      // ORKScreenMetricToolbarHeight
         {        322,       274,       217,       217,       446,       446},      // ORKScreenMetricVerticalScaleHeight
-        {        194,       194,       194,       194,       256,       256},      // ORKScreenMetricSignatureViewHeight
+        {        208,       208,       208,       208,       256,       256},      // ORKScreenMetricSignatureViewHeight
         {        384,       324,       304,       304,       384,       384},      // ORKScreenMetricPSATKeyboardViewWidth
         {        197,       167,       157,       157,       197,       197},      // ORKScreenMetricPSATKeyboardViewHeight
         {        238,       238,       150,        90,       238,       238},      // ORKScreenMetricLocationQuestionMapHeight


### PR DESCRIPTION
This PR Increases the height of `ORKSignatureView` for all phone sizes (the height on iPad remains the same), and the distance from its signing line to the bottom (on all devices). This addresses [Issue #623](https://github.com/ResearchKit/ResearchKit/issues/623). Even though the developer fixed the issue locally and the issue was closed, I feel it's a nice usability improvement.

---

Before (iPhone 4s)

![simulator screen shot jan 18 2017 7 53 19 pm](https://cloud.githubusercontent.com/assets/444313/22093168/6198eb78-ddb8-11e6-8d30-ecdece16217e.png)

---

After (iPhone 4s)

![simulator screen shot jan 18 2017 8 01 56 pm](https://cloud.githubusercontent.com/assets/444313/22093254/132e84ce-ddb9-11e6-9fe2-0e55ea8e0b73.png)

---

Before (iPhone 7)

![simulator screen shot jan 18 2017 7 52 10 pm](https://cloud.githubusercontent.com/assets/444313/22093175/69e6686e-ddb8-11e6-8451-d7de79dc72e5.png)

---

After (iPhone 7) 

![simulator screen shot jan 18 2017 8 02 37 pm](https://cloud.githubusercontent.com/assets/444313/22093257/178af610-ddb9-11e6-8e5d-c0228517c26c.png)
