### PR TITLE
[ORKSignatureStepViewController] Fix not being able to start traces on the top part of the signature view

### DIFF
--- a/ResearchKit/Common/ORKSignatureStepViewController.m
+++ b/ResearchKit/Common/ORKSignatureStepViewController.m
@@ -45,7 +45,7 @@
 #import "ORKSkin.h"
 
 
-@interface ORKConsentSignatureWrapperView : UIView
+@interface ORKSignatureWrapperView : UIView
 
 @property (nonatomic, strong) ORKSignatureView *signatureView;
 
@@ -56,7 +56,7 @@
 @end
 
 
-@implementation ORKConsentSignatureWrapperView {
+@implementation ORKSignatureWrapperView {
 }
 
 - (void)willMoveToWindow:(UIWindow *)newWindow {
@@ -177,7 +177,7 @@
 
 @interface ORKConsentSigningView : ORKVerticalContainerView
 
-@property (nonatomic, strong) ORKConsentSignatureWrapperView *wrapperView;
+@property (nonatomic, strong) ORKSignatureWrapperView *wrapperView;
 
 @end
 
@@ -188,7 +188,7 @@
     self = [super initWithFrame:frame];
     if (self) {
         
-        _wrapperView = [ORKConsentSignatureWrapperView new];
+        _wrapperView = [ORKSignatureWrapperView new];
         _wrapperView.translatesAutoresizingMaskIntoConstraints = NO;
         
         self.stepView = _wrapperView;

--- a/ResearchKit/Common/ORKSignatureStepViewController.m
+++ b/ResearchKit/Common/ORKSignatureStepViewController.m
@@ -61,7 +61,6 @@
 
 - (void)willMoveToWindow:(UIWindow *)newWindow {
     [super willMoveToWindow:newWindow];
-    _signatureView.layoutMargins = (UIEdgeInsets){.top = ORKGetMetricForWindow(ORKScreenMetricLearnMoreBaselineToStepViewTopWithNoLearnMore, newWindow) - ABS([ORKTextButton defaultFont].descender) - 1};
     [self setNeedsLayout];
 }
 
@@ -81,10 +80,6 @@
         {
             _signatureView = [ORKSignatureView new];
             [_signatureView setClipsToBounds:YES];
-            
-            // This allows us to layout the signature view sticking up a bit past the top of the superview,
-            // so drawing can extend higher
-            _signatureView.layoutMargins = (UIEdgeInsets){.top=36};
             
             _signatureView.translatesAutoresizingMaskIntoConstraints = NO;
             [self addSubview:_signatureView];
@@ -150,13 +145,8 @@
                                                                              metrics:nil
                                                                                views:views]];
     
-    /*
-     Using top margin here is a hack to get the drawable area of the signature view to poke up
-     a bit past the top of this view. Doing anything else would be a layering violation, so...
-     we do this.
-     */
     [constraints addObject:[NSLayoutConstraint constraintWithItem:_signatureView
-                                                        attribute:NSLayoutAttributeTopMargin
+                                                        attribute:NSLayoutAttributeTop
                                                         relatedBy:NSLayoutRelationEqual
                                                            toItem:self
                                                         attribute:NSLayoutAttributeTop

--- a/ResearchKit/Common/ORKSignatureView.m
+++ b/ResearchKit/Common/ORKSignatureView.m
@@ -259,7 +259,7 @@ static const CGFloat LineWidthStepValue = 0.25f;
 
 #pragma mark Touch Event Handlers
 
-- (BOOL)_isForceTouchAvailable {
+- (BOOL)isForceTouchAvailable {
     static BOOL isAvailable;
     static dispatch_once_t onceToken;
     
@@ -275,7 +275,7 @@ static const CGFloat LineWidthStepValue = 0.25f;
     return isAvailable;
 }
 
-- (BOOL)_isTouchTypeStylus:(UITouch*)touch {
+- (BOOL)isTouchTypeStylus:(UITouch*)touch {
     BOOL isStylus = NO;
     
     if ([touch respondsToSelector:@selector(type)] && touch.type == UITouchTypeStylus) {
@@ -297,7 +297,7 @@ static const CGFloat LineWidthStepValue = 0.25f;
     previousPoint2 = [touch previousLocationInView:self];
     currentPoint = [touch locationInView:self];
     
-    if ([self _isForceTouchAvailable] || [self _isTouchTypeStylus:touch]) {
+    if ([self isForceTouchAvailable] || [self isTouchTypeStylus:touch]) {
         // This is a scale based on true force on the screen.
         minPressure = 0.f;
         maxPressure = [touch maximumPossibleForce] / 2.f;
@@ -338,7 +338,7 @@ static CGPoint mmid_Point(CGPoint p1, CGPoint p2) {
     // value on all devices.
     CGFloat pressure = minPressure;
     
-    if ([self _isForceTouchAvailable] || [self _isTouchTypeStylus:touch]) {
+    if ([self isForceTouchAvailable] || [self isTouchTypeStylus:touch]) {
         // If the device supports Force Touch, or is using a stylus, use it.
         pressure = [touch force];
     }

--- a/ResearchKit/Common/ORKSkin.m
+++ b/ResearchKit/Common/ORKSkin.m
@@ -213,7 +213,7 @@ CGFloat ORKGetMetricForScreenType(ORKScreenMetric metric, ORKScreenType screenTy
         {         10,        10,         0,         0,        10,        10},      // ORKScreenMetricHeadlineSideMargin
         {         44,        44,        44,        44,        44,        44},      // ORKScreenMetricToolbarHeight
         {        322,       274,       217,       217,       446,       446},      // ORKScreenMetricVerticalScaleHeight
-        {        208,       208,       208,       208,       256,       256},      // ORKScreenMetricSignatureViewHeight
+        {        208,       208,       208,       198,       256,       256},      // ORKScreenMetricSignatureViewHeight
         {        384,       324,       304,       304,       384,       384},      // ORKScreenMetricPSATKeyboardViewWidth
         {        197,       167,       157,       157,       197,       197},      // ORKScreenMetricPSATKeyboardViewHeight
         {        238,       238,       150,        90,       238,       238},      // ORKScreenMetricLocationQuestionMapHeight


### PR DESCRIPTION
Fixes not being able to start traces on the top part of the signature view ([Issue #674](https://github.com/ResearchKit/ResearchKit/issues/674)).

The problem was that the height of the `ORKSignatureView` was larger than the one of the containing `ORKSignatureWrapperView` (it was peeking out from the top), so the signing gesture recognizer was not being triggered if the initial touch began within the overextended part.

I removed the overextending part. As a result the layout is slightly different (and I also had to reduce the *iPhone 4* height by 10 pixels to avoid vertical scrolling), but I think this is more coherent from the functionality point of view. See screenshots below.

---

Another option would have been overriding `- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event` to take into account the overextended layout, but I feel the proposed solution is simpler and less hackish.


---
Before (*iPhone 4s*)
![simulator screen shot jan 24 2017 8 41 16 pm](https://cloud.githubusercontent.com/assets/444313/22278404/2effaf48-e278-11e6-84e9-204483800313.png)

---
After (*iPhone 4s*)
![simulator screen shot jan 24 2017 8 42 05 pm](https://cloud.githubusercontent.com/assets/444313/22278403/2c694320-e278-11e6-869f-8d23e13b1c34.png)

---
Before (*iPhone 7*)
![simulator screen shot jan 24 2017 8 43 49 pm](https://cloud.githubusercontent.com/assets/444313/22278395/1cb3d3aa-e278-11e6-97d3-59110315e962.png)

---
After (*iPhone 7*)
![simulator screen shot jan 24 2017 8 42 50 pm](https://cloud.githubusercontent.com/assets/444313/22278399/279c20b0-e278-11e6-9d9f-4821235e6606.png)


