### PR TITLE
Fixes #834. "Continuous Scale Step - UI value and result value mismatch when using fraction digits."

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -2,6 +2,7 @@
  Copyright (c) 2015, Apple Inc. All rights reserved.
  Copyright (c) 2015, Scott Guelich.
  Copyright (c) 2016, Ricardo Sánchez-Sáez.
+ Copyright (c) 2017, Medable Inc. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -453,6 +453,19 @@ NSNumberFormatterStyle ORKNumberFormattingStyleConvert(ORKNumberFormattingStyle 
 
 - (ORKQuestionResult *)resultWithIdentifier:(NSString *)identifier answer:(id)answer {
     ORKQuestionResult *questionResult = [[[self questionResultClass] alloc] initWithIdentifier:identifier];
+    
+// Medable ---
+/*
+    ContinuousScale navigation rules always evaluate to false because the result is different from what is displayed in the UI.
+    The fraction digits have to be taken into account in self.answer as well.
+*/
+    if ([self isKindOfClass:[ORKContinuousScaleAnswerFormat class]])
+    {
+        NSNumberFormatter* formatter = [(ORKContinuousScaleAnswerFormat*)self numberFormatter];
+        answer = [formatter numberFromString:[formatter stringFromNumber:answer]];
+    }
+// Medable ---
+    
     questionResult.answer = answer;
     questionResult.questionType = self.questionType;
     return questionResult;

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -454,17 +454,14 @@ NSNumberFormatterStyle ORKNumberFormattingStyleConvert(ORKNumberFormattingStyle 
 - (ORKQuestionResult *)resultWithIdentifier:(NSString *)identifier answer:(id)answer {
     ORKQuestionResult *questionResult = [[[self questionResultClass] alloc] initWithIdentifier:identifier];
     
-// Medable ---
 /*
     ContinuousScale navigation rules always evaluate to false because the result is different from what is displayed in the UI.
     The fraction digits have to be taken into account in self.answer as well.
 */
-    if ([self isKindOfClass:[ORKContinuousScaleAnswerFormat class]])
-    {
+    if ([self isKindOfClass:[ORKContinuousScaleAnswerFormat class]]) {
         NSNumberFormatter* formatter = [(ORKContinuousScaleAnswerFormat*)self numberFormatter];
         answer = [formatter numberFromString:[formatter stringFromNumber:answer]];
     }
-// Medable ---
     
     questionResult.answer = answer;
     questionResult.questionType = self.questionType;


### PR DESCRIPTION
When using fraction digits, the value displayed by the UI is not the same as the one from the results. For example if `maximumFractionDigits` is `2`, the user slides the slider to, let's say, `7`, the UI shows `7` but the result is something near `7` but not `7` (i.e. `6.9884...`).

This becomes important when using _navigation rules_, if we create a navigation rule and provide a `7` in our `NSPredicate` it **will always be false**.

Doing this fixes the issue:

`@ ORKAnserFormat`

``` Objective-C
- (ORKQuestionResult *)resultWithIdentifier:(NSString *)identifier answer:(id)answer {
    ORKQuestionResult *questionResult = [[[self questionResultClass] alloc] initWithIdentifier:identifier];

    // mirlhaq --- ContinuousScale navigation rules always evaluate to false because the result is different from what is displayed in the UI. The fraction digits have to be taken into account in self.answer as well.
    if ([self isKindOfClass:[ORKContinuousScaleAnswerFormat class]])
    {
        NSNumberFormatter* formatter = [(ORKContinuousScaleAnswerFormat*)self numberFormatter];
        answer = [formatter numberFromString:[formatter stringFromNumber:answer]];
    }
    // mirlhaq ---

    questionResult.answer = answer;
    questionResult.questionType = self.questionType;
    return questionResult;
}
```

**OR** perhaps, a more elegant way to do this would be to add an overriding method in `ORKContinuousScaleAnswerFormat` so the code is cleaner.
