### PR TITLE
Fix ORKTimedWalkResult isEqual: and copyWithZone:

### DIFF
--- a/ResearchKit/Common/ORKResult.m
+++ b/ResearchKit/Common/ORKResult.m
@@ -858,8 +858,8 @@ const NSUInteger NumberOfPaddingSpacesForIndentationLevel = 4;
     
     __typeof(self) castObject = object;
     return (isParentSame &&
-            (self.duration == castObject.distanceInMeters) &&
-            (self.duration == castObject.timeLimit) &&
+            (self.distanceInMeters == castObject.distanceInMeters) &&
+            (self.timeLimit == castObject.timeLimit) &&
             (self.duration == castObject.duration));
 }
 
@@ -869,8 +869,8 @@ const NSUInteger NumberOfPaddingSpacesForIndentationLevel = 4;
 
 - (instancetype)copyWithZone:(NSZone *)zone {
     ORKTimedWalkResult *result = [super copyWithZone:zone];
-    result.duration = self.distanceInMeters;
-    result.duration = self.timeLimit;
+    result.distanceInMeters = self.distanceInMeters;
+    result.timeLimit = self.timeLimit;
     result.duration = self.duration;
     return result;
 }


### PR DESCRIPTION
It appears this was most likely the result of a copy and paste error. IMHO tests should be created for this class to catch small bugs like this one.