### PR TITLE
Call becomeFirstResponder with dispatch to main queue after delay

### DIFF
--- a/ResearchKit/Common/ORKPasscodeStepViewController.m
+++ b/ResearchKit/Common/ORKPasscodeStepViewController.m
@@ -369,7 +369,17 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
                                                             }]];
                     [strongSelf presentViewController:alert animated:YES completion:nil];
                 } else if (error.code == LAErrorUserCancel) {
-                    [strongSelf makePasscodeViewBecomeFirstResponder];
+
+                    // call becomeFirstResponder here to show the keyboard. dispatch to main queue with
+                    // delay because without it, the transition from the touch ID context back to the app
+                    // inexplicably causes the keyboard to be invisble. It's not hidden, as user can still
+                    // tap keys, but cannot see them
+                    
+                    double delayInSeconds = 0.3;
+                    dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
+                    dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
+                        [strongSelf makePasscodeViewBecomeFirstResponder];
+                    });
                 }
                 
                 [strongSelf finishTouchId];


### PR DESCRIPTION
When user is prompted to use Touch ID and they tap 'cancel', the number pad keyboard is shown (via call to becomeFirstResponder). But, the keyboard is invisible. It is there and not hidden because the user can still tap the keys, but cannot see them. Something inexplicable is happening when switching from Touch ID context back to app context. Calling becomeFirstResponder with dispatch to main queue after delay fixes this.