### PR TITLE
invert long and short investigator descriptions (logical)

### DIFF
--- a/ResearchKit/Consent/ORKConsentSharingStep.m
+++ b/ResearchKit/Consent/ORKConsentSharingStep.m
@@ -70,8 +70,8 @@
         }
         
         self.answerFormat = [ORKAnswerFormat choiceAnswerFormatWithStyle:ORKChoiceAnswerStyleSingleChoice textChoices:
-                             @[[ORKTextChoice choiceWithText:[NSString stringWithFormat:ORKLocalizedString(@"CONSENT_SHARE_WIDELY_%@",nil), investigatorShortDescription] value:@(YES)],
-                               [ORKTextChoice choiceWithText:[NSString stringWithFormat:ORKLocalizedString(@"CONSENT_SHARE_ONLY_%@",nil), investigatorLongDescription] value:@(NO)],
+                             @[[ORKTextChoice choiceWithText:[NSString stringWithFormat:ORKLocalizedString(@"CONSENT_SHARE_WIDELY_%@",nil), investigatorLongDescription] value:@(YES)],
+                               [ORKTextChoice choiceWithText:[NSString stringWithFormat:ORKLocalizedString(@"CONSENT_SHARE_ONLY_%@",nil), investigatorShortDescription] value:@(NO)],
                                ]];
         self.optional = NO;
         self.useSurveyMode = NO;


### PR DESCRIPTION
It seems more logical to have an investigatorShortDescription when we want to share only to one entity (share only), and an investigatorLongDescription when we want to share to multiple entities (share widely), right ?

Just a reminder of the strings for widely and only :
`"CONSENT_SHARE_WIDELY_%@" = "Share my data with %@ and qualified researchers worldwide";
"CONSENT_SHARE_ONLY_%@" = "Only share my data with %@";`