### PR TITLE
Fix missing passcodeFlow serialization, copying, encoding and equality

### DIFF
--- a/ResearchKit/Common/ORKPasscodeStep.m
+++ b/ResearchKit/Common/ORKPasscodeStep.m
@@ -58,6 +58,7 @@
     self = [super initWithCoder:aDecoder];
     if (self) {
         ORK_DECODE_INTEGER(aDecoder, passcodeType);
+        ORK_DECODE_UINT32(aDecoder, passcodeFlow);
     }
     return self;
 }
@@ -65,6 +66,7 @@
 - (void)encodeWithCoder:(NSCoder *)aCoder {
     [super encodeWithCoder:aCoder];
     ORK_ENCODE_INTEGER(aCoder, passcodeType);
+    ORK_ENCODE_UINT32(aCoder, passcodeFlow);
 }
 
 + (BOOL)supportsSecureCoding {
@@ -74,6 +76,7 @@
 - (instancetype)copyWithZone:(NSZone *)zone {
     ORKPasscodeStep *step = [super copyWithZone:zone];
     step.passcodeType = self.passcodeType;
+    step.passcodeFlow = self.passcodeFlow;
     return step;
 }
 
@@ -82,6 +85,7 @@
     
     __typeof(self) castObject = object;
     return (isParentSame &&
+            self.passcodeFlow == castObject.passcodeFlow &&
             self.passcodeType == castObject.passcodeType);
 }
 

--- a/ResearchKit/Common/ORKPasscodeStep.m
+++ b/ResearchKit/Common/ORKPasscodeStep.m
@@ -58,7 +58,7 @@
     self = [super initWithCoder:aDecoder];
     if (self) {
         ORK_DECODE_INTEGER(aDecoder, passcodeType);
-        ORK_DECODE_UINT32(aDecoder, passcodeFlow);
+        ORK_DECODE_ENUM(aDecoder, passcodeFlow);
     }
     return self;
 }
@@ -66,7 +66,7 @@
 - (void)encodeWithCoder:(NSCoder *)aCoder {
     [super encodeWithCoder:aCoder];
     ORK_ENCODE_INTEGER(aCoder, passcodeType);
-    ORK_ENCODE_UINT32(aCoder, passcodeFlow);
+    ORK_ENCODE_ENUM(aCoder, passcodeFlow);
 }
 
 + (BOOL)supportsSecureCoding {

--- a/Testing/ORKTest/ORKTest/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTest/ORKESerialization.m
@@ -440,7 +440,8 @@ encondingTable =
              return [[ORKPasscodeStep alloc] initWithIdentifier:GETPROP(dict, identifier)];
          },
          (@{
-           PROPERTY(passcodeType, NSNumber, NSObject, YES, nil, nil)
+           PROPERTY(passcodeType, NSNumber, NSObject, YES, nil, nil),
+           PROPERTY(passcodeFlow, NSNumber, NSObject, YES, nil, nil)
            })),
    ENTRY(ORKWaitStep,
          ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {


### PR DESCRIPTION
When this was pushed to master, the `ORKTest` tests weren't run on our fork because we have added tests to check equality for primitive values. This fixes the tests.