### PR TITLE
Add custom yes and no strings option for ORKBooleanAnswerFormat

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -2,6 +2,7 @@
  Copyright (c) 2015, Apple Inc. All rights reserved.
  Copyright (c) 2015, Bruce Duncan.
  Copyright (c) 2016, Ricardo Sánchez-Sáez.
+ Copyright (c) 2017, Macro Yau.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -733,15 +733,21 @@ ORK_CLASS_AVAILABLE
 /**
  Returns an initialized Boolean answer format using the specified strings for Yes and No answers.
  
- @param yes         A string that designates the Yes answer.
- @param no          A string that designates the No answer.
+ @param yes         A string that describes the Yes answer.
+ @param no          A string that describes the No answer.
  
  @return An initialized Boolean answer format.
  */
 - (instancetype)initWithYesString:(NSString *)yes noString:(NSString *)no;
 
+/**
+ The string to describe the Yes answer. (read-only)
+ */
 @property (copy, readonly) NSString *yes;
 
+/**
+ The string to describe the No answer. (read-only)
+ */
 @property (copy, readonly) NSString *no;
 
 @end

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -114,6 +114,9 @@ ORK_CLASS_AVAILABLE
 
 + (ORKBooleanAnswerFormat *)booleanAnswerFormat;
 
++ (ORKBooleanAnswerFormat *)booleanAnswerFormatWithYesString:(NSString *)yes
+                                                    noString:(NSString *)no;
+
 + (ORKValuePickerAnswerFormat *)valuePickerAnswerFormatWithTextChoices:(NSArray<ORKTextChoice *> *)textChoices;
 
 + (ORKImageChoiceAnswerFormat *)choiceAnswerFormatWithImageChoices:(NSArray<ORKImageChoice *> *)imageChoices;
@@ -725,6 +728,12 @@ ORK_CLASS_AVAILABLE
  */
 ORK_CLASS_AVAILABLE
 @interface ORKBooleanAnswerFormat : ORKAnswerFormat
+
+- (instancetype)initWithYesString:(NSString *)yes noString:(NSString *)no;
+
+@property (copy, readonly) NSString *yes;
+
+@property (copy, readonly) NSString *no;
 
 @end
 

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -730,6 +730,14 @@ ORK_CLASS_AVAILABLE
 ORK_CLASS_AVAILABLE
 @interface ORKBooleanAnswerFormat : ORKAnswerFormat
 
+/**
+ Returns an initialized Boolean answer format using the specified strings for Yes and No answers.
+ 
+ @param yes         A string that designates the Yes answer.
+ @param no          A string that designates the No answer.
+ 
+ @return An initialized Boolean answer format.
+ */
 - (instancetype)initWithYesString:(NSString *)yes noString:(NSString *)no;
 
 @property (copy, readonly) NSString *yes;

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -294,6 +294,10 @@ NSNumberFormatterStyle ORKNumberFormattingStyleConvert(ORKNumberFormattingStyle 
     return [ORKBooleanAnswerFormat new];
 }
 
++ (ORKBooleanAnswerFormat *)booleanAnswerFormatWithYesString:(NSString *)yes noString:(NSString *)no {
+    return [[ORKBooleanAnswerFormat alloc] initWithYesString:yes noString:no];
+}
+
 + (ORKValuePickerAnswerFormat *)valuePickerAnswerFormatWithTextChoices:(NSArray<ORKTextChoice *> *)textChoices {
     return [[ORKValuePickerAnswerFormat alloc] initWithTextChoices:textChoices];
 }

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -999,8 +999,9 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 }
 
 - (instancetype)copyWithZone:(NSZone *)zone {
-    ORKBooleanAnswerFormat *answerFormat = [[[self class] allocWithZone:zone] initWithYesString:[_yes copy]
-                                                                                       noString:[_no copy]];
+    ORKBooleanAnswerFormat *answerFormat = [super copyWithZone:zone];
+    answerFormat->_yes = [_yes copy];
+    answerFormat->_no = [_no copy];
     return answerFormat;
 }
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -994,6 +994,16 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     return [self.impliedAnswerFormat stringForAnswer: @[answer]];
 }
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+    ORKBooleanAnswerFormat *answerFormat = [[[self class] allocWithZone:zone] initWithYesString:[_yes copy]
+                                                                                       noString:[_no copy]];
+    return answerFormat;
+}
+
 - (BOOL)isEqual:(id)object {
     BOOL isParentSame = [super isEqual:object];
     

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1005,6 +1005,10 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     return answerFormat;
 }
 
+- (NSUInteger)hash {
+    return super.hash ^ _yes.hash ^ _no.hash;
+}
+
 - (BOOL)isEqual:(id)object {
     BOOL isParentSame = [super isEqual:object];
     

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -958,16 +958,13 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 
 #pragma mark - ORKBooleanAnswerFormat
 
-@implementation ORKBooleanAnswerFormat {
-    NSString *_yes;
-    NSString *_no;
-}
+@implementation ORKBooleanAnswerFormat
 
 - (instancetype)initWithYesString:(NSString *)yes noString:(NSString *)no {
     self = [super init];
     if (self) {
-        _yes = yes;
-        _no = no;
+        _yes = [yes copy];
+        _no = [no copy];
     }
     return self;
 }
@@ -978,11 +975,12 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 
 - (ORKAnswerFormat *)impliedAnswerFormat {
     if (!_yes.length) {
-        _yes = ORKLocalizedString(@"BOOL_YES",nil);
+        _yes = ORKLocalizedString(@"BOOL_YES", nil);
     }
     if (!_no.length) {
-        _no = ORKLocalizedString(@"BOOL_NO",nil);
+        _no = ORKLocalizedString(@"BOOL_NO", nil);
     }
+    
     return [ORKAnswerFormat choiceAnswerFormatWithStyle:ORKChoiceAnswerStyleSingleChoice
                                             textChoices:@[[ORKTextChoice choiceWithText:_yes value:@(YES)],
                                                           [ORKTextChoice choiceWithText:_no value:@(NO)]]];
@@ -994,6 +992,30 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 
 - (NSString *)stringForAnswer:(id)answer {
     return [self.impliedAnswerFormat stringForAnswer: @[answer]];
+}
+
+- (BOOL)isEqual:(id)object {
+    BOOL isParentSame = [super isEqual:object];
+    
+    __typeof(self) castObject = object;
+    return (isParentSame &&
+            ORKEqualObjects(self.yes, castObject.yes) &&
+            ORKEqualObjects(self.no, castObject.no));
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    self = [super init];
+    if (self) {
+        ORK_DECODE_OBJ_CLASS(aDecoder, yes, NSString);
+        ORK_DECODE_OBJ_CLASS(aDecoder, no, NSString);
+    }
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [super encodeWithCoder:aCoder];
+    ORK_ENCODE_OBJ(aCoder, yes);
+    ORK_ENCODE_OBJ(aCoder, no);
 }
 
 @end

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -957,16 +957,34 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 
 #pragma mark - ORKBooleanAnswerFormat
 
-@implementation ORKBooleanAnswerFormat
+@implementation ORKBooleanAnswerFormat {
+    NSString *_yes;
+    NSString *_no;
+}
+
+- (instancetype)initWithYesString:(NSString *)yes noString:(NSString *)no {
+    self = [super init];
+    if (self) {
+        _yes = yes;
+        _no = no;
+    }
+    return self;
+}
 
 - (ORKQuestionType)questionType {
     return ORKQuestionTypeBoolean;
 }
 
 - (ORKAnswerFormat *)impliedAnswerFormat {
+    if (!_yes.length) {
+        _yes = ORKLocalizedString(@"BOOL_YES",nil);
+    }
+    if (!_no.length) {
+        _no = ORKLocalizedString(@"BOOL_NO",nil);
+    }
     return [ORKAnswerFormat choiceAnswerFormatWithStyle:ORKChoiceAnswerStyleSingleChoice
-                                            textChoices:@[[ORKTextChoice choiceWithText:ORKLocalizedString(@"BOOL_YES",nil) value:@(YES)],
-                                                          [ORKTextChoice choiceWithText:ORKLocalizedString(@"BOOL_NO",nil) value:@(NO)]]];
+                                            textChoices:@[[ORKTextChoice choiceWithText:_yes value:@(YES)],
+                                                          [ORKTextChoice choiceWithText:_no value:@(NO)]]];
 }
 
 - (Class)questionResultClass {

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -3,6 +3,7 @@
  Copyright (c) 2015, Scott Guelich.
  Copyright (c) 2016, Ricardo Sánchez-Sáez.
  Copyright (c) 2017, Medable Inc. All rights reserved.
+ Copyright (c) 2017, Macro Yau.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -2,7 +2,8 @@
  Copyright (c) 2015, Apple Inc. All rights reserved.
  Copyright (c) 2015, Bruce Duncan.
  Copyright (c) 2015-2016, Ricardo Sánchez-Sáez.
- Copyright (c) 2016, Sage Bionetworks
+ Copyright (c) 2016, Sage Bionetworks.
+ Copyright (c) 2017, Macro Yau.
 
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -888,6 +889,17 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
         ORKBooleanAnswerFormat *format = [ORKBooleanAnswerFormat new];
         ORKQuestionStep *step = [ORKQuestionStep questionStepWithIdentifier:@"qid_001b"
                                                                       title:@"Do you consent to a background check?"
+                                                                     answer:format];
+        [steps addObject:step];
+    }
+    
+    {
+        /*
+         A custom boolean question.
+         */
+        ORKBooleanAnswerFormat *format = [ORKAnswerFormat booleanAnswerFormatWithYesString:@"Agree" noString:@"Disagree"];
+        ORKQuestionStep *step = [ORKQuestionStep questionStepWithIdentifier:@"qid_001c"
+                                                                      title:@"Do you agree to proceed to the background check questions?"
                                                                      answer:format];
         [steps addObject:step];
     }

--- a/Testing/ORKTest/ORKTest/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTest/ORKESerialization.m
@@ -1034,9 +1034,11 @@ encondingTable =
           })),
   ENTRY(ORKBooleanAnswerFormat,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
-            return [[ORKBooleanAnswerFormat alloc] init];
+            return [[ORKBooleanAnswerFormat alloc] initWithYesString:((NSString *)GETPROP(dict, yes)) noString:((NSString *)GETPROP(dict, no))];
         },
         (@{
+           PROPERTY(yes, NSString, NSObject, NO, nil, nil),
+           PROPERTY(no, NSString, NSObject, NO, nil, nil)
           })),
    ENTRY(ORKHeightAnswerFormat,
          ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -1,6 +1,7 @@
 /*
  Copyright (c) 2015, Apple Inc. All rights reserved.
  Copyright (c) 2015-2016, Ricardo Sánchez-Sáez.
+ Copyright (c) 2017, Macro Yau.
 
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -62,6 +63,7 @@ enum TaskListRow: Int, CustomStringConvertible {
     case form = 0
     case survey
     case booleanQuestion
+    case customBooleanQuestion
     case dateQuestion
     case dateTimeQuestion
     case imageChoiceQuestion
@@ -122,6 +124,7 @@ enum TaskListRow: Int, CustomStringConvertible {
             TaskListRowSection(title: "Survey Questions", rows:
                 [
                     .booleanQuestion,
+                    .customBooleanQuestion,
                     .dateQuestion,
                     .dateTimeQuestion,
                     .heightQuestion,
@@ -184,6 +187,9 @@ enum TaskListRow: Int, CustomStringConvertible {
             
         case .booleanQuestion:
             return NSLocalizedString("Boolean Question", comment: "")
+            
+        case .customBooleanQuestion:
+            return NSLocalizedString("Custom Boolean Question", comment: "")
             
         case .dateQuestion:
             return NSLocalizedString("Date Question", comment: "")
@@ -477,6 +483,9 @@ enum TaskListRow: Int, CustomStringConvertible {
         case .booleanQuestion:
             return booleanQuestionTask
             
+        case .customBooleanQuestion:
+            return customBooleanQuestionTask
+            
         case .dateQuestion:
             return dateQuestionTask
             
@@ -654,6 +663,19 @@ enum TaskListRow: Int, CustomStringConvertible {
     /// This task presents just a single "Yes" / "No" question.
     private var booleanQuestionTask: ORKTask {
         let answerFormat = ORKBooleanAnswerFormat()
+        
+        // We attach an answer format to a question step to specify what controls the user sees.
+        let questionStep = ORKQuestionStep(identifier: String(describing:Identifier.booleanQuestionStep), title: exampleQuestionText, answer: answerFormat)
+        
+        // The detail text is shown in a small font below the title.
+        questionStep.text = exampleDetailText
+        
+        return ORKOrderedTask(identifier: String(describing:Identifier.booleanQuestionTask), steps: [questionStep])
+    }
+    
+    /// This task presents a customized "Yes" / "No" question.
+    private var customBooleanQuestionTask: ORKTask {
+        let answerFormat = ORKBooleanAnswerFormat(yesString: "Agree", noString: "Disagree")
         
         // We attach an answer format to a question step to specify what controls the user sees.
         let questionStep = ORKQuestionStep(identifier: String(describing:Identifier.booleanQuestionStep), title: exampleQuestionText, answer: answerFormat)


### PR DESCRIPTION
In some contexts, it makes more sense to present users with customized "Yes" and "No" options (e.g., "Agree" vs. "Disagree", "I have" vs. "I have not", etc.) in Boolean tasks.