### PR TITLE
Fix class visibility for new types of Steps, fixes #649

### DIFF
--- a/ResearchKit/ActiveTasks/ORKShoulderRangeOfMotionStep.h
+++ b/ResearchKit/ActiveTasks/ORKShoulderRangeOfMotionStep.h
@@ -36,6 +36,7 @@
  The `ORKShoulderRangeOfMotionStep` class represents a step that takes a range of motion measurement
  for either a left or right shoulder.
  */
+ORK_CLASS_AVAILABLE
 @interface ORKShoulderRangeOfMotionStep : ORKRangeOfMotionStep
 
 @end

--- a/ResearchKit/Common/ORKVideoInstructionStep.h
+++ b/ResearchKit/Common/ORKVideoInstructionStep.h
@@ -41,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
  You can use video instruction steps to present video content during a task.
  
  */
+ORK_CLASS_AVAILABLE
 @interface ORKVideoInstructionStep : ORKInstructionStep
 
 /**


### PR DESCRIPTION
It seems like issue #649 has started to appear again. This fixes it by changing the class-visibility for two new steps that have been added since the last fix was merged.