### PR TITLE
Update README.md Swift example code to latest Swift syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,9 @@ taskViewController.delegate = self;
 *Swift*
 
 ```swift
-let taskViewController = ORKTaskViewController(task: task, taskRunUUID: nil)
+let taskViewController = ORKTaskViewController(task: task, taskRun: nil)
 taskViewController.delegate = self
-presentViewController(taskViewController, animated: true, completion: nil)
+present(taskViewController, animated: true, completion: nil)
 ```
 
 The above snippet assumes that your class implements the `ORKTaskViewControllerDelegate` protocol.
@@ -221,7 +221,7 @@ func taskViewController(_ taskViewController: ORKTaskViewController,
     // You could do something with the result here.
 
     // Then, dismiss the task view controller.
-    dismiss(true, completion: nil)
+    dismiss(animated: true, completion: nil)
 }
 ```
 


### PR DESCRIPTION
The `HelloResearchWorld` Swift code example from the README isn't up-to-date with latest Swift syntax and does not compile with Swift 3.x. 