### PR TITLE
[ORKPasscodeStepViewController] Make sure the view has been laid out before showing the keyboard

### DIFF
--- a/ResearchKit/Common/ORKPasscodeStepViewController.m
+++ b/ResearchKit/Common/ORKPasscodeStepViewController.m
@@ -182,6 +182,7 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
     }
     
     if (!_shouldResignFirstResponder) {
+        [self.view layoutIfNeeded]; // layout pass might be required before showing the keyboard
         [self makePasscodeViewBecomeFirstResponder];
     }
 }


### PR DESCRIPTION
This is a fix for issue #960, `-viewDidAppear:` is called but the view isn't on screen yet when the view controller is set in a `UIPageViewController`. Might be a bug from UIKit? https://forums.developer.apple.com/thread/15441