### PR TITLE
Issue #973

### DIFF
--- a/ResearchKit/Common/ORKPasscodeStepViewController.m
+++ b/ResearchKit/Common/ORKPasscodeStepViewController.m
@@ -297,7 +297,7 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
 }
 
 + (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-    return UIInterfaceOrientationMaskPortrait;
+    return UIInterfaceOrientationMaskAll;
 }
 
 #pragma mark - Helpers


### PR DESCRIPTION
in ORKPasscodeStepViewController, supported interface orientation is
set to UIInterfaceOrientationMaskPortrait. To support any orientation
this was changed to UIInterfaceOrientationMaskAll.