### PR TITLE
Now HR can be obtained trough the device's back camera. Feature #376

### DIFF
--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -557,6 +557,15 @@
 		D442397E1AF17F7600559D96 /* ORKImageCaptureStepViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D442397C1AF17F7600559D96 /* ORKImageCaptureStepViewController.m */; };
 		D458520A1AF6CCFA00A2DE13 /* ORKImageCaptureCameraPreviewView.h in Headers */ = {isa = PBXBuildFile; fileRef = D45852081AF6CCFA00A2DE13 /* ORKImageCaptureCameraPreviewView.h */; };
 		D458520B1AF6CCFA00A2DE13 /* ORKImageCaptureCameraPreviewView.m in Sources */ = {isa = PBXBuildFile; fileRef = D45852091AF6CCFA00A2DE13 /* ORKImageCaptureCameraPreviewView.m */; };
+		DBBF16A41ECBC72700602B86 /* ORKHrCaptureStepViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DBE4AF0D1ECBBC3100C9EE78 /* ORKHrCaptureStepViewController.m */; };
+		DBE4AEB41ECBB62300C9EE78 /* ORKHealthAnswerFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5424521DF1513B00A86918 /* ORKHealthAnswerFormat.swift */; };
+		DBE4AF081ECBBB7200C9EE78 /* ORKHrCaptureStep.h in Headers */ = {isa = PBXBuildFile; fileRef = DBE4AF071ECBBB7200C9EE78 /* ORKHrCaptureStep.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DBE4AF0A1ECBBBCD00C9EE78 /* ORKHrCaptureStep.m in Sources */ = {isa = PBXBuildFile; fileRef = DBE4AF091ECBBBCD00C9EE78 /* ORKHrCaptureStep.m */; };
+		DBE4AF0C1ECBBC1F00C9EE78 /* ORKHrCaptureStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = DBE4AF0B1ECBBC1F00C9EE78 /* ORKHrCaptureStepViewController.h */; };
+		DBE4AF121ECBBCBD00C9EE78 /* ORKHrCaptureView.h in Headers */ = {isa = PBXBuildFile; fileRef = DBE4AF111ECBBCBD00C9EE78 /* ORKHrCaptureView.h */; };
+		DBE4AF141ECBBCCD00C9EE78 /* ORKHrCaptureView.m in Sources */ = {isa = PBXBuildFile; fileRef = DBE4AF131ECBBCCD00C9EE78 /* ORKHrCaptureView.m */; };
+		DBE4AF181ECBBF8600C9EE78 /* ORKFFTUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = DBE4AF171ECBBF8600C9EE78 /* ORKFFTUtils.h */; };
+		DBE4AF1A1ECBBF9B00C9EE78 /* ORKFFTUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = DBE4AF191ECBBF9B00C9EE78 /* ORKFFTUtils.m */; };
 		FA7A9D2B1B082688005A2BEA /* ORKConsentDocumentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7A9D2A1B082688005A2BEA /* ORKConsentDocumentTests.m */; };
 		FA7A9D2F1B083DD3005A2BEA /* ORKConsentSectionFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = FA7A9D2D1B083DD3005A2BEA /* ORKConsentSectionFormatter.h */; };
 		FA7A9D301B083DD3005A2BEA /* ORKConsentSectionFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = FA7A9D2E1B083DD3005A2BEA /* ORKConsentSectionFormatter.m */; };
@@ -572,7 +581,6 @@
 		FF5051ED1D668FF80065E677 /* ORKPageStep_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = FF5051EC1D668FF80065E677 /* ORKPageStep_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF5051F01D66908C0065E677 /* ORKNavigablePageStep.h in Headers */ = {isa = PBXBuildFile; fileRef = FF5051EE1D66908C0065E677 /* ORKNavigablePageStep.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FF5051F11D66908C0065E677 /* ORKNavigablePageStep.m in Sources */ = {isa = PBXBuildFile; fileRef = FF5051EF1D66908C0065E677 /* ORKNavigablePageStep.m */; };
-		FF5424531DF1513B00A86918 /* ORKHealthAnswerFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5424521DF1513B00A86918 /* ORKHealthAnswerFormat.swift */; };
 		FF5CA6121D2C2670001660A3 /* ORKTableStep.h in Headers */ = {isa = PBXBuildFile; fileRef = FF5CA6101D2C2670001660A3 /* ORKTableStep.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FF5CA6131D2C2670001660A3 /* ORKTableStep.m in Sources */ = {isa = PBXBuildFile; fileRef = FF5CA6111D2C2670001660A3 /* ORKTableStep.m */; };
 		FF5CA61B1D2C6453001660A3 /* ORKSignatureStep.h in Headers */ = {isa = PBXBuildFile; fileRef = FF5CA6191D2C6453001660A3 /* ORKSignatureStep.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1185,6 +1193,14 @@
 		D442397C1AF17F7600559D96 /* ORKImageCaptureStepViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKImageCaptureStepViewController.m; sourceTree = "<group>"; };
 		D45852081AF6CCFA00A2DE13 /* ORKImageCaptureCameraPreviewView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKImageCaptureCameraPreviewView.h; sourceTree = "<group>"; };
 		D45852091AF6CCFA00A2DE13 /* ORKImageCaptureCameraPreviewView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKImageCaptureCameraPreviewView.m; sourceTree = "<group>"; };
+		DBE4AF071ECBBB7200C9EE78 /* ORKHrCaptureStep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKHrCaptureStep.h; sourceTree = "<group>"; };
+		DBE4AF091ECBBBCD00C9EE78 /* ORKHrCaptureStep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKHrCaptureStep.m; sourceTree = "<group>"; };
+		DBE4AF0B1ECBBC1F00C9EE78 /* ORKHrCaptureStepViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKHrCaptureStepViewController.h; sourceTree = "<group>"; };
+		DBE4AF0D1ECBBC3100C9EE78 /* ORKHrCaptureStepViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKHrCaptureStepViewController.m; sourceTree = "<group>"; };
+		DBE4AF111ECBBCBD00C9EE78 /* ORKHrCaptureView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKHrCaptureView.h; sourceTree = "<group>"; };
+		DBE4AF131ECBBCCD00C9EE78 /* ORKHrCaptureView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKHrCaptureView.m; sourceTree = "<group>"; };
+		DBE4AF171ECBBF8600C9EE78 /* ORKFFTUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKFFTUtils.h; sourceTree = "<group>"; };
+		DBE4AF191ECBBF9B00C9EE78 /* ORKFFTUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKFFTUtils.m; sourceTree = "<group>"; };
 		FA7A9D2A1B082688005A2BEA /* ORKConsentDocumentTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKConsentDocumentTests.m; sourceTree = "<group>"; };
 		FA7A9D2D1B083DD3005A2BEA /* ORKConsentSectionFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ORKConsentSectionFormatter.h; sourceTree = "<group>"; };
 		FA7A9D2E1B083DD3005A2BEA /* ORKConsentSectionFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ORKConsentSectionFormatter.m; sourceTree = "<group>"; };
@@ -1824,6 +1840,7 @@
 		B12EFF341AB2111200A80147 /* Step */ = {
 			isa = PBXGroup;
 			children = (
+				DBE4AF061ECBBA4800C9EE78 /* HR capture Step */,
 				86C40BB91A8D7C5C00081FAC /* ORKStep.h */,
 				86C40BBA1A8D7C5C00081FAC /* ORKStep.m */,
 				86C40BBB1A8D7C5C00081FAC /* ORKStep_Private.h */,
@@ -2492,6 +2509,21 @@
 			name = "Image Capture Step";
 			sourceTree = "<group>";
 		};
+		DBE4AF061ECBBA4800C9EE78 /* HR capture Step */ = {
+			isa = PBXGroup;
+			children = (
+				DBE4AF071ECBBB7200C9EE78 /* ORKHrCaptureStep.h */,
+				DBE4AF091ECBBBCD00C9EE78 /* ORKHrCaptureStep.m */,
+				DBE4AF0B1ECBBC1F00C9EE78 /* ORKHrCaptureStepViewController.h */,
+				DBE4AF0D1ECBBC3100C9EE78 /* ORKHrCaptureStepViewController.m */,
+				DBE4AF111ECBBCBD00C9EE78 /* ORKHrCaptureView.h */,
+				DBE4AF131ECBBCCD00C9EE78 /* ORKHrCaptureView.m */,
+				DBE4AF171ECBBF8600C9EE78 /* ORKFFTUtils.h */,
+				DBE4AF191ECBBF9B00C9EE78 /* ORKFFTUtils.m */,
+			);
+			name = "HR capture Step";
+			sourceTree = "<group>";
+		};
 		FA7A9D2C1B083D90005A2BEA /* Formatters */ = {
 			isa = PBXGroup;
 			children = (
@@ -2564,9 +2596,11 @@
 				86C40CE41A8D7C5C00081FAC /* ORKAnswerFormat.h in Headers */,
 				25ECC0951AFBD68300F3D63B /* ORKReactionTimeStep.h in Headers */,
 				86C40D0A1A8D7C5C00081FAC /* ORKCustomStepView.h in Headers */,
+				DBE4AF121ECBBCBD00C9EE78 /* ORKHrCaptureView.h in Headers */,
 				BCD192EE1B81255F00FCC08A /* ORKPieChartView_Internal.h in Headers */,
 				86C40DCE1A8D7C5C00081FAC /* ORKTaskViewController_Internal.h in Headers */,
 				25ECC09F1AFBD92D00F3D63B /* ORKReactionTimeContentView.h in Headers */,
+				DBE4AF181ECBBF8600C9EE78 /* ORKFFTUtils.h in Headers */,
 				10FF9AC31B79EF2800ECB5B4 /* ORKHolePegTestRemoveStep.h in Headers */,
 				86C40C361A8D7C5C00081FAC /* ORKSpatialSpanGame.h in Headers */,
 				86C40CAC1A8D7C5C00081FAC /* ORKRecorder.h in Headers */,
@@ -2673,6 +2707,7 @@
 				86C40D621A8D7C5C00081FAC /* ORKQuestionStep_Internal.h in Headers */,
 				86C40D641A8D7C5C00081FAC /* ORKQuestionStepViewController.h in Headers */,
 				10BAA2CA1B5FCB4F004FE478 /* ORKProgressView.h in Headers */,
+				DBE4AF081ECBBB7200C9EE78 /* ORKHrCaptureStep.h in Headers */,
 				BCB6E6601B7D534C000D5B34 /* ORKLineGraphChartView.h in Headers */,
 				86C40E241A8D7C5C00081FAC /* ORKEAGLMoviePlayerView.h in Headers */,
 				B183A4DD1A8535D100C76870 /* ResearchKit.h in Headers */,
@@ -2726,6 +2761,7 @@
 				BC8FC6781CA9B17C00D12768 /* ORKVoiceEngine_Internal.h in Headers */,
 				86C40C1E1A8D7C5C00081FAC /* ORKAudioStepViewController.h in Headers */,
 				FFDDD8491D3555EA00446806 /* ORKPageStep.h in Headers */,
+				DBE4AF0C1ECBBC1F00C9EE78 /* ORKHrCaptureStepViewController.h in Headers */,
 				147503AF1AEE8071004B17F3 /* ORKAudioGenerator.h in Headers */,
 				86AD91141AB7B97E00361FEB /* ORKQuestionStepView.h in Headers */,
 				86C40C621A8D7C5C00081FAC /* CLLocation+ORKJSONDictionary.h in Headers */,
@@ -3068,6 +3104,7 @@
 				959A2C011D68B9DA00841B04 /* ORKRangeOfMotionStepViewController.m in Sources */,
 				861D2AF11B8409D9008C4CD0 /* ORKTimedWalkContentView.m in Sources */,
 				86C40DC41A8D7C5C00081FAC /* ORKTapCountLabel.m in Sources */,
+				DBE4AF0A1ECBBBCD00C9EE78 /* ORKHrCaptureStep.m in Sources */,
 				25ECC0A01AFBD92D00F3D63B /* ORKReactionTimeContentView.m in Sources */,
 				86C40D4C1A8D7C5C00081FAC /* ORKLabel.m in Sources */,
 				86C40C9E1A8D7C5C00081FAC /* ORKDeviceMotionRecorder.m in Sources */,
@@ -3077,6 +3114,7 @@
 				86C40DF81A8D7C5C00081FAC /* ORKSignatureStepViewController.m in Sources */,
 				959A2BFD1D68B98700841B04 /* ORKRangeOfMotionStep.m in Sources */,
 				BCB6E6531B7D533B000D5B34 /* ORKPieChartLegendCell.m in Sources */,
+				DBE4AF141ECBBCCD00C9EE78 /* ORKHrCaptureView.m in Sources */,
 				866DA52A1D63D04700C9AF3F /* ORKOperation.m in Sources */,
 				86C40D8C1A8D7C5C00081FAC /* ORKSkin.m in Sources */,
 				86C40D221A8D7C5C00081FAC /* ORKFormStep.m in Sources */,
@@ -3170,6 +3208,7 @@
 				86C40DC01A8D7C5C00081FAC /* ORKTableViewCell.m in Sources */,
 				24A4DA111B8D0F21009C797A /* ORKPasscodeStepView.m in Sources */,
 				BC41942A1AE8453A00073D6B /* ORKObserver.m in Sources */,
+				DBE4AEB41ECBB62300C9EE78 /* ORKHealthAnswerFormat.swift in Sources */,
 				86C40C681A8D7C5C00081FAC /* CMAccelerometerData+ORKJSONDictionary.m in Sources */,
 				86C40C701A8D7C5C00081FAC /* CMMotionActivity+ORKJSONDictionary.m in Sources */,
 				147503B01AEE8071004B17F3 /* ORKAudioGenerator.m in Sources */,
@@ -3222,6 +3261,7 @@
 				86C40DEC1A8D7C5C00081FAC /* UIBarButtonItem+ORKBarButtonItem.m in Sources */,
 				106FF2AF1B6FACA8004EACF2 /* ORKDirectionView.m in Sources */,
 				BF1D438A1D4905FC007EE90B /* ORKVideoInstructionStepViewController.m in Sources */,
+				DBBF16A41ECBC72700602B86 /* ORKHrCaptureStepViewController.m in Sources */,
 				86C40CAA1A8D7C5C00081FAC /* ORKPedometerRecorder.m in Sources */,
 				BCA5C0361AEC05F20092AC8D /* ORKStepNavigationRule.m in Sources */,
 				106FF2A71B665CF5004EACF2 /* ORKHolePegTestPlaceContentView.m in Sources */,
@@ -3250,13 +3290,13 @@
 				86C40C441A8D7C5C00081FAC /* ORKSpatialSpanMemoryStep.m in Sources */,
 				BCB080A11B83EFB900A3F400 /* ORKStepNavigationRule.swift in Sources */,
 				24898B0E1B7186C000B0E7E7 /* ORKScaleRangeImageView.m in Sources */,
+				DBE4AF1A1ECBBF9B00C9EE78 /* ORKFFTUtils.m in Sources */,
 				86C40DD81A8D7C5C00081FAC /* ORKUnitLabel.m in Sources */,
 				86C40D361A8D7C5C00081FAC /* ORKHelpers.m in Sources */,
 				86C40C181A8D7C5C00081FAC /* ORKAudioContentView.m in Sources */,
 				86C40C8E1A8D7C5C00081FAC /* ORKActiveStepViewController.m in Sources */,
 				10864CA51B27146B000F4158 /* ORKPSATKeyboardView.m in Sources */,
 				86C40CE61A8D7C5C00081FAC /* ORKAnswerFormat.m in Sources */,
-				FF5424531DF1513B00A86918 /* ORKHealthAnswerFormat.swift in Sources */,
 				25ECC0961AFBD68300F3D63B /* ORKReactionTimeStep.m in Sources */,
 				BC13CE3A1B0660220044153C /* ORKNavigableOrderedTask.m in Sources */,
 				B11C54A11A9EF4A700265E61 /* ORKConsentSharingStepViewController.m in Sources */,

--- a/ResearchKit.xcodeproj/xcshareddata/xcschemes/ResearchKit.xcscheme
+++ b/ResearchKit.xcodeproj/xcshareddata/xcschemes/ResearchKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ResearchKit.xcodeproj/xcshareddata/xcschemes/docs.xcscheme
+++ b/ResearchKit.xcodeproj/xcshareddata/xcschemes/docs.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ResearchKit/Common/ORKFFTUtils.h
+++ b/ResearchKit/Common/ORKFFTUtils.h
@@ -1,0 +1,88 @@
+/*
+ Copyright (c) 2017, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#import <Foundation/Foundation.h>
+#include <Accelerate/Accelerate.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+static const int FftMinSamplesN = 64; //The minimum number of samples required for the first fft calculation. Around 2 seconds if Fs=30
+static const int FftInnerStepSamplesN = 128; // Start using this number rather than fftMinSamplesN as soon as we have enough data
+static const int FftMaxSamplesN = 256; // The maximum number of samples to be used for fft calculations. Around 8 seconds if Fs=30
+static const int SamplingRate = 30; //How many samples per second are we getting. Fs
+static const float FftMinHzForHR = 0.8; //Spectrum lower limit on FFT to be considered (according to a possible HR of 48  bpm)
+static const float FftMaxHzForHR = 4.0; //Spectrum upper limit on FFT to be considered (according to a possible HR of 204 bpm)
+static const float FftCalculationFrequency = 1; //Seconds between each HR estimation using fft for timer
+
+
+@interface ORKFFTUtils : NSObject {
+    
+}
+
+/**
+ Get RGB bits from a 32 bit string
+ */
+- (UInt32)Mask8:(UInt32)x;
+
+/**
+ Gets the blue channel bits
+ */
+- (UInt32)getBlue:(UInt32)x;
+
+/**
+ Gets the green channel bits
+ */
+- (UInt32)getGreen:(UInt32)x;
+
+/**
+ Gets the red channel bits
+ */
+- (UInt32)getRed:(UInt32)x;
+
+/**
+ Returns absolute value of a complex number
+ */
+- (float *)absOfComplex:(COMPLEX_SPLIT)complex withSize:(int)size;
+
+/**
+ Gets the desired amount of samples needed to perform FFT
+ */
+- (NSMutableArray *)getProperSamples:(NSMutableArray *)ppgSignal;
+
+/**
+ Calculates FFT of the ppgSignal then estimates HR from it
+ */
+- (float)getHrFromPpg:(NSMutableArray *)ppgSignal;
+
+@end
+
+
+NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKFFTUtils.m
+++ b/ResearchKit/Common/ORKFFTUtils.m
@@ -1,0 +1,157 @@
+/*
+ Copyright (c) 2017, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#import "ORKFFTUtils.h"
+
+
+@implementation ORKFFTUtils
+
+- (UInt32)Mask8:(UInt32)x {
+    return (x) & 0xFF;
+}
+
+- (UInt32)getBlue:(UInt32)x {
+    return [self Mask8:x];
+}
+
+- (UInt32)getGreen:(UInt32)x {
+    return [self Mask8:(x >> 8)];
+}
+
+- (UInt32)getRed:(UInt32)x {
+    return [self Mask8:(x >> 16)];
+}
+
+- (float *)absOfComplex:(COMPLEX_SPLIT)complex withSize:(int)size {
+    
+    float *absArray = malloc(size * sizeof(float));
+    
+    for (int i = 0; i < size; i++){
+        absArray[i] = sqrt(pow(complex.realp[i], 2) + pow(complex.imagp[i], 2));
+    }
+    
+    return absArray;
+}
+
+- (NSArray *)getProperSamples:(NSMutableArray *)ppgSignal{
+    
+    NSArray *ppgData = [[NSMutableArray alloc]init];
+    int ppgSamplesNum = (int)[ppgSignal count];
+    
+    if (ppgSamplesNum >= FftMinSamplesN && ppgSamplesNum < FftInnerStepSamplesN){
+        ppgData = [ppgSignal subarrayWithRange:NSMakeRange(ppgSamplesNum - FftMinSamplesN, FftMinSamplesN)];
+    } else if(ppgSamplesNum >= FftInnerStepSamplesN && ppgSamplesNum < FftMaxSamplesN){
+        ppgData = [ppgSignal subarrayWithRange:NSMakeRange(ppgSamplesNum - FftInnerStepSamplesN, FftInnerStepSamplesN)];
+    } else {
+        ppgData = [ppgSignal subarrayWithRange:NSMakeRange(ppgSamplesNum - FftMaxSamplesN, FftMaxSamplesN)];
+    }
+    
+    return ppgData;
+}
+
+- (float) getHrFromPpg:(NSMutableArray *)ppgSignal {
+    
+    // Holds the samples which we want to work on.
+    NSArray *ppgData = [[NSMutableArray alloc]init];
+    
+    // From the total number of samples we get the biggest amount of them that is a power of 2 so we dont have to padd
+    // with zeroes and loose accuracy. We are getting the last 2^k samples.
+    ppgData = [self getProperSamples:ppgSignal];
+    
+    // From the available samples how many are we really using
+    int samplesNum = (int) [ppgData count];
+    int fftRadix = log2(samplesNum);
+    int halfSamples = (int) (samplesNum / 2);
+    
+    // Setup the FFT
+    FFTSetup setup = vDSP_create_fftsetup(fftRadix, FFT_RADIX2);
+    
+    // Getting a simple float array of PPG data
+    float *ppgSamples = malloc(samplesNum * sizeof(float));
+    
+    for (int i=0;i<samplesNum;i++){
+        ppgSamples[i] = [ppgData[i] floatValue];
+    }
+    
+    // Hamming window function
+    float *window = (float *) malloc(sizeof(float) * samplesNum);
+    vDSP_hamm_window(window, samplesNum, 0);
+    
+    // Window the samples
+    vDSP_vmul(ppgSamples, 1, window, 1, ppgSamples, 1, samplesNum);
+    
+    // Define complex buffer
+    COMPLEX_SPLIT complex;
+    complex.realp = (float *) malloc(halfSamples * sizeof(float));
+    complex.imagp = (float *) malloc(halfSamples * sizeof(float));
+    
+    // Pack samples
+    vDSP_ctoz((COMPLEX *) ppgSamples, 2, &complex, 1, halfSamples);
+    
+    // Perform a forward FFT using fftSetup and A, results returned in A
+    vDSP_fft_zrip(setup, &complex, 1, fftRadix, FFT_FORWARD);
+    
+    // Get the absolute value of the FFT
+    float *absFFT = [self absOfComplex:complex withSize:halfSamples];
+    
+    // Calculate the frequencies for FFT
+    double freq[halfSamples];
+    float start = 0.0;
+    float stop = 1.0;
+    
+    for (int i = 1;i <= halfSamples; i++){
+        freq[i-1] = (SamplingRate / 2) * (start + (i - 1) * (stop - start) / (halfSamples - 1));
+    }
+    
+    // Find max value for FFT in range of HR and take its frequency
+    int maxIndex = 0;
+    float maxAmp = 0.0;
+    
+    // Consider only the frequencies between min and max config variables
+    for(int i = 1; i < halfSamples - 1; i++){
+        if(freq[i] >= FftMinHzForHR && freq[i] <= FftMaxHzForHR){//Consider only valid frequencies for Heartbeats 60-120 BPM
+            if(absFFT[i] > maxAmp){// Validate is greater than the last one
+                maxAmp = absFFT[i];
+                maxIndex = i;
+            }
+        }
+    }
+    
+    // Since we have the frequency in Hz (cycles per second), we want it in BPM (beats per minute)
+    float estimatedBpm = freq[maxIndex] * 60;
+    
+    // Free the custom ppg array
+    free(ppgSamples);
+    
+    return estimatedBpm;
+}
+
+@end

--- a/ResearchKit/Common/ORKHrCaptureStep.h
+++ b/ResearchKit/Common/ORKHrCaptureStep.h
@@ -1,0 +1,67 @@
+/*
+ Copyright (c) 2016, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#import <ResearchKit/ResearchKit.h>
+#import <AVFoundation/AVFoundation.h>
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ The `ORKHrCaptureStep` class represents a step that captures user heart rate through the device
+ camera. The user puts any finger in the back camera covering the camera and the LED.
+ 
+ To use the heart rate capture step, optionally set the `templateImage` and `templateImageInsets`
+ properties, incorporate the step into a task, and present the task with a task view controller.
+ 
+ The recording length can be a max of 2 minutes. It defaults to 20 seconds.
+ */
+ORK_CLASS_AVAILABLE
+@interface ORKHrCaptureStep : ORKStep
+
+/**
+ The duration, in seconds, for the session.
+ 
+ The maximum that this can be set to is 120 seconds.
+ The minimum that this can be set to is 20 seconds.
+ 
+ The default value is 20 seconds.
+ */
+@property (nonatomic) NSNumber *duration;
+
+/**
+ An accessibility hint of the capture button.
+ */
+@property (nonatomic, copy) NSString *accessibilityHint;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKHrCaptureStep.m
+++ b/ResearchKit/Common/ORKHrCaptureStep.m
@@ -1,0 +1,57 @@
+/*
+ Copyright (c) 2016, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#import "ORKHrCaptureStep.h"
+#import "ORKHelpers_Internal.h"
+#import "ORKStep_Private.h"
+#import "ORKHrCaptureStepViewController.h"
+
+
+@implementation ORKHrCaptureStep
+
++ (Class)stepViewControllerClass {
+    return [ORKHrCaptureStepViewController class];
+}
+
+- (instancetype)initWithIdentifier:(NSString *)identifier {
+    self = [super initWithIdentifier:identifier];
+    if (self) {
+        self.optional = YES;
+        self.duration = @20;
+    }
+    return self;
+}
+
+- (void)setDuration:(NSNumber *)duration {
+    _duration = MIN(MAX(duration, @20), @120);
+}
+
+@end

--- a/ResearchKit/Common/ORKHrCaptureStepViewController.h
+++ b/ResearchKit/Common/ORKHrCaptureStepViewController.h
@@ -1,0 +1,46 @@
+/*
+ Copyright (c) 2016, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#import <ResearchKit/ResearchKit.h>
+
+
+/**
+ The `ORKHrCaptureStepViewController` class represents the step view controller that
+ corresponds to an `ORKHrCaptureStep` class.
+ 
+ It is not usually necessary to instantiate this view controller directly.
+ Instead, add a hr capture step to a task, and present the task in a task
+ view controller.
+ */
+ORK_CLASS_AVAILABLE
+@interface ORKHrCaptureStepViewController : ORKStepViewController
+
+@end

--- a/ResearchKit/Common/ORKHrCaptureStepViewController.m
+++ b/ResearchKit/Common/ORKHrCaptureStepViewController.m
@@ -1,0 +1,507 @@
+/*
+ Copyright (c) 2016, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#import "ORKStepViewController_Internal.h"
+#import "ORKHrCaptureStepViewController.h"
+#import "ORKHrCaptureView.h"
+#import "ORKHrCaptureStep.h"
+#import "ORKHelpers_Internal.h"
+#import "ORKFFTUtils.h"
+#import <AVFoundation/AVFoundation.h>
+
+
+@interface ORKHrCaptureStepViewController () <ORKHrCaptureViewDelegate, AVCaptureVideoDataOutputSampleBufferDelegate, UIApplicationDelegate>
+
+@end
+
+
+@implementation ORKHrCaptureStepViewController {
+    ORKHrCaptureView *_hrCaptureView;
+    ORKHrCaptureStep *_hrCaptureStep;
+    ORKFFTUtils *_fftUtils; // Calculates HR from a signal using FFT approach
+    dispatch_queue_t _sessionQueue; // Runs the capture session
+    AVCaptureSession *_captureSession; // The capture session itself
+    NSTimer *_hrTimer; // Definies the intervals on which the HR should be calculated
+    NSMutableArray *_ppgSamples; // Holds the green values (RGB) that represents the ppg signal
+    BOOL _recording; // Control variable to show/hide buttons
+    UILabel *_hrLbl;
+    NSMutableArray *_collectedHrValues;
+    AVCaptureDevice *_device;
+}
+
+- (instancetype)initWithStep:(ORKStep *)step {
+    self = [super initWithStep:step];
+    if (self) {
+        _fftUtils = [[ORKFFTUtils alloc]init];
+        _ppgSamples = [[NSMutableArray alloc] init];
+        _hrCaptureView = [[ORKHrCaptureView alloc] initWithFrame:CGRectZero];
+        _hrCaptureView.hrCaptureStep = (ORKHrCaptureStep *)step;
+        _hrCaptureView.delegate = self;
+        _collectedHrValues = [[NSMutableArray alloc] init];
+        _hrCaptureView.capturedHr = NO;
+        [self.view addSubview:_hrCaptureView]; // This is our step view. The step title and back buttons are from parent
+        
+        _hrCaptureStep = (ORKHrCaptureStep *)self.step;
+        
+        [self setUpConstraints];
+    }
+    
+    return self;
+}
+
+- (void)setUpConstraints {
+    NSMutableArray *constraints = [NSMutableArray new];
+    
+    NSDictionary *views = @{ @"hrCaptureView": _hrCaptureView };
+    _hrCaptureView.translatesAutoresizingMaskIntoConstraints = NO;
+    
+    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[hrCaptureView]|"
+                                                                             options:NSLayoutFormatDirectionLeadingToTrailing
+                                                                             metrics:nil
+                                                                               views:views]];
+    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[hrCaptureView]|"
+                                                                             options:NSLayoutFormatDirectionLeadingToTrailing
+                                                                             metrics:nil
+                                                                               views:views]];
+    [NSLayoutConstraint activateConstraints:constraints];
+}
+
+// My videCaptureView must have continue and skip buttons that follows parent's behavior
+- (void)setContinueButtonItem:(UIBarButtonItem *)continueButtonItem {
+    [super setContinueButtonItem:continueButtonItem];
+    _hrCaptureView.continueButtonItem = continueButtonItem;
+}
+
+- (void)setSkipButtonItem:(UIBarButtonItem *)skipButtonItem {
+    [super setSkipButtonItem:skipButtonItem];
+    _hrCaptureView.skipButtonItem = skipButtonItem;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    // Capture actions should be performed off the main queue to keep the UI responsive
+    _sessionQueue = dispatch_queue_create("session queue", DISPATCH_QUEUE_SERIAL);
+    
+    // Setup the capture session
+    dispatch_async(_sessionQueue, ^{
+        [self queue_SetupCaptureSession]; // Prepares the captureSession information to be run in this queue
+    });
+    
+    // Prepare notification for when the app enters to background and stop any timer
+    [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(applicationEnterBackground:) name:UIApplicationWillResignActiveNotification object:nil];
+    [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(applicationEnterFromBackground:) name:UIApplicationDidBecomeActiveNotification object:nil];
+}
+
+-(void)applicationEnterFromBackground:(NSNotification *)notification {
+    
+    // Restore session when entering from background
+    if (!_captureSession.isRunning) {
+        dispatch_async(_sessionQueue, ^{
+            [_captureSession startRunning];
+            [self setSamplingRate];
+        });
+    }
+}
+
+-(void)applicationEnterBackground:(NSNotification *)notification {
+    [self stopSession];
+}
+
+// Securely stops the session taking care of the timers
+-(void)stopSession {
+    // Stop every timer before going background
+    
+    // If the capture session is running, stop it
+    if (_captureSession.isRunning) {
+        dispatch_async(_sessionQueue, ^{
+            [_captureSession stopRunning];
+        });
+    }
+    
+    // Drop everything since the current HR will no longer be valid
+    [self triggerHRCalculationTimer:NO];
+    _hrCaptureView.capturedHr = NO;
+    [_collectedHrValues removeAllObjects];
+    [_ppgSamples removeAllObjects];
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    dispatch_async(_sessionQueue, ^{
+        [_captureSession startRunning]; // Start the capture session that has already been setted trough viewDidLoad
+        [self setSamplingRate];
+    });
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+    [self stopSession];
+}
+
+-(void)setSamplingRate {
+    // Make sure the sampling rate for the video recording is the one we want. Defaults to 30
+    [_device lockForConfiguration:nil];
+    _device.activeVideoMinFrameDuration = CMTimeMake(1, SamplingRate);
+    _device.activeVideoMaxFrameDuration = CMTimeMake(1, SamplingRate);
+    [_device unlockForConfiguration];
+}
+
+- (void)queue_SetupCaptureSession {
+    // Create the session
+    _captureSession = [AVCaptureSession new];
+    [_captureSession beginConfiguration];
+    
+    // Get the camera
+    AVCaptureDevice *device;
+    NSArray *devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
+    
+    for (AVCaptureDevice *d in devices) {
+        if (d.position == AVCaptureDevicePositionBack) { // Make sure we use the back camera
+            device = d;
+            break;
+        }
+    }
+    
+    if (device) {
+        
+        // Configure the input and output
+        AVCaptureDeviceInput *input = [AVCaptureDeviceInput deviceInputWithDevice:device error:nil];
+        AVCaptureVideoDataOutput *output = [AVCaptureVideoDataOutput new] ;
+        
+        if ([_captureSession canAddInput:input] && [_captureSession canAddOutput:output]) {
+            
+            [_captureSession addInput:input];
+            [_captureSession addOutput:output];
+            
+            [output setSampleBufferDelegate:self queue:_sessionQueue];
+            
+            // Specify the pixel format
+            output.videoSettings = [NSDictionary dictionaryWithObject:[NSNumber numberWithInt:kCVPixelFormatType_32BGRA]
+                                                               forKey:(id)kCVPixelBufferPixelFormatTypeKey];
+            
+        } else {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self handleError:[NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:@{NSLocalizedDescriptionKey:ORKLocalizedString(@"CAPTURE_ERROR_NO_PERMISSIONS", nil)}]];
+            });
+            _captureSession = nil;
+        }
+        
+        _device = device;
+    } else {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self handleError:[NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:@{NSLocalizedDescriptionKey:ORKLocalizedString(@"CAPTURE_ERROR_CAMERA_NOT_FOUND", nil)}]];
+        });
+        _captureSession = nil;
+    }
+    
+    [_captureSession commitConfiguration];
+    _hrCaptureView.session = _captureSession;
+}
+
+- (void)handleError:(NSError *)error {
+    
+    // Shut down the session, if running
+    if (_captureSession.isRunning) {
+        [self stopSession];
+    }
+    
+    // Reset the state to before the capture session was setup.  Order here is important
+    _captureSession = nil;
+    _hrCaptureView.session = nil;
+    
+    // Show the error in the image capture view
+    _hrCaptureView.error = error;
+}
+
+- (void)setRecording:(BOOL)recording {
+    _recording = recording;
+    _hrCaptureView.recording = recording;
+}
+
+- (ORKStepResult *)result {
+    ORKStepResult *stepResult = [super result];
+    ORKResult *result = [[ORKResult alloc] init];
+    
+    // Retrieve only the HR after the first 5 measurements (about 5 secs)
+    // The first seconds are usually very noisy and are not accurate
+    NSArray *hrValues = [_collectedHrValues copy];
+    NSInteger hrNum = [_collectedHrValues count];
+    
+    if (hrNum > 5) {
+        hrValues = [_collectedHrValues subarrayWithRange:NSMakeRange(5, hrNum - 5)];
+    }
+    
+    NSDate *now = stepResult.endDate;
+    NSMutableArray *results = [NSMutableArray arrayWithArray:stepResult.results];
+    result.startDate = stepResult.startDate;
+    result.endDate = now;
+    result.userInfo = @{@"collectedHrValues": hrValues};
+    result.identifier = @"hrResults";
+    [results addObject:result];
+    stepResult.results = [results copy];
+    return stepResult;
+}
+
+
+#pragma mark - ORKHrCaptureViewDelegate
+
+- (void)retakePressed:(void (^)())handler {
+    dispatch_async(_sessionQueue, ^{
+        
+        if (!_recording) {// Init and start timer that applies fft and shows result in view
+            
+            [self triggerHRCalculationTimer:YES];
+            
+            // Drop previous PPG and HR
+            [_collectedHrValues removeAllObjects];
+            [_ppgSamples removeAllObjects];
+            _hrCaptureView.capturedHr = NO;
+        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (handler) {
+                handler();
+            }
+        });
+    });
+}
+
+- (void)capturePressed:(void (^)())handler {
+    // Capture the video via the output
+    dispatch_async(_sessionQueue, ^{
+        
+        if (!_recording) {// Init and start timer that applies fft and shows result in view
+            [self triggerHRCalculationTimer:YES];
+        }
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (handler) {
+                handler();
+            }
+        });
+    });
+}
+
+- (void)setHrLbl:(UILabel *)hrLbl {
+    _hrLbl = hrLbl;
+}
+
+- (void)stopCapturePressed:(void (^)())handler {
+    
+    dispatch_async(_sessionQueue, ^{
+        [self stopHrEstimation];
+        _hrCaptureView.capturedHr = NO;
+        [_collectedHrValues removeAllObjects];
+        [_ppgSamples removeAllObjects];
+        
+        // Use the main queue, as UI components may need to be updated
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (handler) {
+                handler();
+            }
+        });
+    });
+}
+
+- (void)stopHrEstimation {
+    [self triggerHRCalculationTimer:NO];
+}
+
+- (void)getHR {
+    
+    int currentNumberSamples = (int) [_ppgSamples count];
+    float currentHr = 0.0;
+    
+    // Start calculating as soon as we have enough samples
+    if (currentNumberSamples >= FftMinSamplesN) {
+        // Only attempt to get FFT if we have enough samples
+        currentHr = [_fftUtils getHrFromPpg:_ppgSamples];
+        _hrLbl.text = [NSString stringWithFormat:@"%d", (int) roundf(currentHr)];
+        [_collectedHrValues addObject:@(roundf(currentHr))];
+    }
+    
+}
+
+-(void)triggerHRCalculationTimer:(BOOL) start {
+    
+    if (start) {// Init and start timer that gets HR every FftBpmEstimationFrequency seconds
+        
+        // Creating fft timer in the main thread
+        
+        // Turn LED on if present
+        [self turnLedOn:YES];
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            
+            _hrTimer = [NSTimer scheduledTimerWithTimeInterval:FftCalculationFrequency
+                                                        target:self
+                                                      selector:@selector(getHR)
+                                                      userInfo:nil
+                                                       repeats:YES];
+            
+            self.recording = YES;
+            _recording = YES;
+            _hrCaptureView.capturedHr = NO;
+            
+        });
+        
+    } else {// Stop timer
+        
+        if (_hrTimer != nil) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [_hrTimer invalidate];
+                _hrTimer = nil;
+                self.recording = NO;
+                _recording = NO;
+                if ([_collectedHrValues count] > 0) {
+                    _hrCaptureView.capturedHr = YES;
+                }
+                
+            });
+            
+        }
+        // Turn LED off if present
+        [self turnLedOn:NO];
+        
+    }
+    
+}
+
+- (void) turnLedOn: (BOOL) value {
+    
+    if (value) {
+        if ([_device isTorchModeSupported:AVCaptureTorchModeOn]) {
+            [_device lockForConfiguration:nil];
+            _device.torchMode = AVCaptureTorchModeOn;
+            [_device unlockForConfiguration];
+        }
+    } else {
+        if ([_device isTorchModeSupported:AVCaptureTorchModeOff]) {
+            [_device lockForConfiguration:nil];
+            _device.torchMode = AVCaptureTorchModeOff;
+            [_device unlockForConfiguration];
+        }
+    }
+    
+}
+
+// Gets the PPG value (green mean on the center) per frame
+- (float) getPpgSampleFromSampleBufferWith:(CMSampleBufferRef) sampleBuffer {
+    
+    // Get a CMSampleBuffer's Core Video image buffer for the media data
+    CVImageBufferRef imageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
+    // Lock the base address of the pixel buffer
+    CVPixelBufferLockBaseAddress(imageBuffer, 0);
+    
+    // Get the number of bytes per row for the pixel buffer
+    void *baseAddress = CVPixelBufferGetBaseAddress(imageBuffer);
+    
+    // Get the number of bytes per row for the pixel buffer
+    size_t bytesPerRow = CVPixelBufferGetBytesPerRow(imageBuffer);
+    // Get the pixel buffer width and height
+    size_t width = CVPixelBufferGetWidth(imageBuffer);
+    size_t height = CVPixelBufferGetHeight(imageBuffer);
+    
+    // Getting center values
+    int centerX, centerY, centerW, centerH;
+    
+    centerX = (int) (width / 3);
+    centerY = (int) (height / 3);
+    centerW = centerX;
+    centerH = centerY;
+    
+    // Create a device-dependent RGB color space
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+    
+    // Create a bitmap graphics context with the sample buffer data
+    CGContextRef context = CGBitmapContextCreate(baseAddress, width, height, 8,
+                                                 bytesPerRow, colorSpace, kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big);
+    
+    // Create a Quartz image from the pixel data in the bitmap graphics context
+    CGImageRef quartzImage = CGBitmapContextCreateImage(context);
+    // Unlock the pixel buffer
+    CVPixelBufferUnlockBaseAddress(imageBuffer, 0);
+    
+    // Free up the context and color space
+    CGContextRelease(context);
+    CGColorSpaceRelease(colorSpace);
+    
+    float centerGreenMean = 0.0; // Holds the mean in the specified frame for green color
+    float pixelsNum = 0.0;
+    
+    UInt32 * currentPixel = baseAddress;
+    currentPixel += centerY * width + centerX; // x from starting point, considering a box from the top left corner;
+    
+    // Getting the center pixels
+    for (NSUInteger j = centerY; j < centerY + centerH; j++) {// From left corner to the righ and then down
+        for (NSUInteger i = centerX; i < centerX + centerW; i++) {
+            UInt32 color = *currentPixel;
+            pixelsNum++;
+            centerGreenMean += [_fftUtils getGreen:color];
+            currentPixel++;
+        }
+        currentPixel = currentPixel + (width - (centerX + centerW)) + centerX - 1;
+    }
+    centerGreenMean /= pixelsNum; // Center mean
+    
+    // Release the Quartz image
+    CGImageRelease(quartzImage);
+    
+    float a = -1;// Apply inverse
+    float b = 256;
+    
+    return centerGreenMean * a + b; // To get a proper PPG signal
+}
+
+- (void)videoOrientationDidChange:(AVCaptureVideoOrientation)videoOrientation {
+    // No action required
+}
+
+- (void)captureOutput:(AVCaptureOutput *)captureOutput
+didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
+       fromConnection:(AVCaptureConnection *)connection {
+    
+    // Getting the mean green color in a centered frame
+    float ppgSample = [self getPpgSampleFromSampleBufferWith:sampleBuffer];
+    
+    dispatch_async(dispatch_get_main_queue(), ^{// Add the data on the main thread, so it follows an order
+        
+        if ((int) [_ppgSamples count] >= FftMaxSamplesN) {
+            
+            // Maintain the array small
+            [_ppgSamples removeObjectAtIndex:0];
+        }
+        
+        [_ppgSamples addObject:[NSNumber numberWithFloat:ppgSample]];
+    });
+    
+}
+
+@end

--- a/ResearchKit/Common/ORKHrCaptureView.h
+++ b/ResearchKit/Common/ORKHrCaptureView.h
@@ -1,0 +1,64 @@
+/*
+ Copyright (c) 2016, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#import <UIKit/UIKit.h>
+#import <AVFoundation/AVFoundation.h>
+#import "ORKHrCaptureStep.h"
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol ORKHrCaptureViewDelegate <NSObject>
+
+- (void)capturePressed:(void (^ _Nullable)())handler;
+- (void)stopCapturePressed:(void (^ _Nullable)())handler;
+- (void)setHrLbl:(UILabel *)hrLbl;
+- (void)stopHrEstimation;
+- (void)retakePressed:(void (^ _Nullable)())handler;
+- (void)videoOrientationDidChange:(AVCaptureVideoOrientation)videoOrientation;
+
+@end
+
+
+@interface ORKHrCaptureView : UIView
+
+@property (nonatomic, strong, nullable) ORKHrCaptureStep *hrCaptureStep;
+@property (nonatomic, weak, nullable) id<ORKHrCaptureViewDelegate> delegate;
+@property (nonatomic, weak, nullable) AVCaptureSession *session;
+@property (nonatomic, strong, nullable) UIBarButtonItem *continueButtonItem;
+@property (nonatomic, strong, nullable) UIBarButtonItem *skipButtonItem;
+@property (nonatomic, strong, nullable) NSError *error;
+@property (nonatomic) BOOL recording;
+@property (nonatomic) BOOL capturedHr;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKHrCaptureView.m
+++ b/ResearchKit/Common/ORKHrCaptureView.m
@@ -1,0 +1,384 @@
+/*
+ Copyright (c) 2016, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#import "ORKHrCaptureView.h"
+#import "ORKNavigationContainerView_Internal.h"
+#import "ORKHelpers_Private.h"
+#import "ORKHelpers_Internal.h"
+#import "ORKSkin.h"
+#import "ORKStepHeaderView_Internal.h"
+
+
+@implementation ORKHrCaptureView {
+    ORKStepHeaderView *_headerView;
+    ORKNavigationContainerView *_continueSkipContainer;
+    UIBarButtonItem *_captureButtonItem;
+    UIBarButtonItem *_stopButtonItem;
+    UIBarButtonItem *_recordingButtonItem;
+    UIBarButtonItem *_recaptureButtonItem;
+    UILabel *_hrLabel;
+    UILabel *_hrUnitLabel;
+    NSMutableArray *_variableConstraints;
+    NSTimer *_timer;
+    CGFloat _recordTime;
+    NSDateComponentsFormatter *_dateComponentsFormatter;
+    AVCaptureSession *_session;
+    BOOL _capturePressesIgnored;
+    BOOL _stopCapturePressesIgnored;
+    BOOL _retakePressesIgnored;
+    BOOL _showSkipButtonItem;
+    
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        
+        _hrLabel = [[UILabel alloc]initWithFrame:CGRectMake(0, 0, 0, 0)];
+        _hrLabel.text = @"0";
+        _hrLabel.textAlignment = NSTextAlignmentCenter;
+        _hrLabel.font=[_hrLabel.font fontWithSize:80];
+        
+        _hrUnitLabel = [[UILabel alloc]initWithFrame:CGRectMake(0, 0, 0, 0)];
+        _hrUnitLabel.text = ORKLocalizedString(@"HR_LBL_UNITS", nil);
+        _hrUnitLabel.textAlignment = NSTextAlignmentCenter;
+        _hrUnitLabel.font=[_hrUnitLabel.font fontWithSize:25];
+        
+        // Set labels for delegate
+        dispatch_async(dispatch_get_main_queue(), ^{
+            // Delegate will update our label
+            [self.delegate setHrLbl:_hrLabel];
+        });
+        
+        [self addSubview:_hrLabel];
+        [self addSubview:_hrUnitLabel];
+        
+        _headerView = [ORKStepHeaderView new];
+        _headerView.instructionLabel.text = @" ";
+        [self addSubview:_headerView];
+        
+        _captureButtonItem = [[UIBarButtonItem alloc] initWithTitle:ORKLocalizedString(@"CAPTURE_BUTTON_CAPTURE_HR", nil)
+                                                              style:UIBarButtonItemStylePlain
+                                                             target:self
+                                                             action:@selector(capturePressed)];
+        
+        _stopButtonItem = [[UIBarButtonItem alloc] initWithTitle:ORKLocalizedString(@"CAPTURE_BUTTON_STOP_CAPTURE_HR", nil)
+                                                           style:UIBarButtonItemStylePlain
+                                                          target:self
+                                                          action:@selector(stopCapturePressed)];
+        
+        _recordingButtonItem = [[UIBarButtonItem alloc] initWithTitle:nil
+                                                                style:UIBarButtonItemStylePlain
+                                                               target:self
+                                                               action:nil];
+        
+        _recaptureButtonItem = [[UIBarButtonItem alloc] initWithTitle:ORKLocalizedString(@"CAPTURE_BUTTON_RECAPTURE_HR", nil)
+                                                                style:UIBarButtonItemStylePlain
+                                                               target:self
+                                                               action:@selector(retakePressed)];
+        
+        _continueSkipContainer = [ORKNavigationContainerView new];
+        _continueSkipContainer.continueEnabled = YES;
+        _continueSkipContainer.topMargin = 5;
+        _continueSkipContainer.bottomMargin = 15;
+        _continueSkipContainer.optional = YES;
+        _continueSkipContainer.backgroundColor = ORKColor(ORKBackgroundColorKey);
+        [self addSubview:_continueSkipContainer];
+        
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationDidChange) name:UIApplicationDidChangeStatusBarOrientationNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sessionWasInterrupted:) name:AVCaptureSessionWasInterruptedNotification object:self.session];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sessionInterruptionEnded:) name:AVCaptureSessionInterruptionEndedNotification object:self.session];
+        
+        [self updateAppearance];
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)orientationDidChange {
+    AVCaptureVideoOrientation orientation;
+    switch ([[UIApplication sharedApplication] statusBarOrientation]) {
+        case UIInterfaceOrientationLandscapeRight:
+            orientation = AVCaptureVideoOrientationLandscapeRight;
+            break;
+        case UIInterfaceOrientationLandscapeLeft:
+            orientation = AVCaptureVideoOrientationLandscapeLeft;
+            break;
+        case UIInterfaceOrientationPortraitUpsideDown:
+            orientation = AVCaptureVideoOrientationPortraitUpsideDown;
+            break;
+        case UIInterfaceOrientationPortrait:
+            orientation = AVCaptureVideoOrientationPortrait;
+            break;
+        case UIInterfaceOrientationUnknown:
+            // Do nothing in these cases, since we don't need to change display orientation.
+            return;
+    }
+    
+    [self.delegate videoOrientationDidChange:orientation];
+    [self setNeedsUpdateConstraints];
+}
+
+- (void)setHrCaptureStep:(ORKHrCaptureStep *)hrCaptureStep {
+    
+    _hrCaptureStep = hrCaptureStep;
+    _captureButtonItem.accessibilityHint = _hrCaptureStep.accessibilityHint;
+    _showSkipButtonItem = _hrCaptureStep.optional;
+    
+    [self updateAppearance];
+}
+
+- (void)updateAppearance {
+    
+    _headerView.alpha = (self.error) ? 1 : 0;
+    
+    if (self.error) {
+        
+        // Display the error instruction.
+        _headerView.instructionLabel.text = [self.error.userInfo valueForKey:NSLocalizedDescriptionKey];
+        
+        // Show skip, if available, and continue/capture button
+        _continueSkipContainer.continueButtonItem = nil;
+        _continueSkipContainer.skipButtonItem = _skipButtonItem;
+        _continueSkipContainer.skipEnabled = YES;
+    } else if (self.recording) {
+        
+        // Change the continue button back to capture.
+        _continueSkipContainer.continueButtonItem = _stopButtonItem;
+        
+        // Start a timer to show recording progress.
+        _recordingButtonItem.title = [self formattedTimeFromSeconds:_hrCaptureStep.duration.floatValue];
+        _continueSkipContainer.skipButtonItem = _recordingButtonItem;
+        _continueSkipContainer.skipEnabled = NO;
+        _recordTime = 0.0;
+        _timer = [NSTimer scheduledTimerWithTimeInterval:0.1
+                                                  target:self
+                                                selector:@selector(updateRecordTime:)
+                                                userInfo:nil
+                                                 repeats:YES];
+    } else if (self.capturedHr) {
+        
+        // Set the continue button to the one we've saved and configure the skip button as a recapture button
+        // only if we have collected HR
+        _continueSkipContainer.continueButtonItem = _continueButtonItem;
+        _continueSkipContainer.skipButtonItem = _recaptureButtonItem;
+        _continueSkipContainer.skipEnabled = YES;
+        if (UIAccessibilityIsVoiceOverRunning()) {
+            UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, ORKLocalizedString(@"AX_HR_CAPTURE_COMPLETE", nil));
+        }
+    } else {
+        
+        // Change the continue button back to capture, and change the recapture button back to skip (if available)
+        _continueSkipContainer.continueButtonItem = _captureButtonItem;
+        _continueSkipContainer.skipButtonItem = _skipButtonItem;
+        _continueSkipContainer.skipEnabled = YES;
+    }
+}
+
+- (void)setRecording:(BOOL)recording {
+    _recording = recording;
+    [self updateAppearance];
+}
+
+- (void)setError:(NSError *)error {
+    _error = error;
+    [self updateAppearance];
+}
+
+- (void)updateConstraints {
+    
+    if (_variableConstraints) {
+        [NSLayoutConstraint deactivateConstraints:_variableConstraints];
+        [_variableConstraints removeAllObjects];
+    }
+    
+    if (!_variableConstraints) {
+        _variableConstraints = [NSMutableArray new];
+    }
+    
+    NSDictionary *views = NSDictionaryOfVariableBindings(self, _headerView, _hrLabel,_hrUnitLabel, _continueSkipContainer);
+    ORKEnableAutoLayoutForViews(views.allValues);
+    
+    [_variableConstraints addObjectsFromArray: [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_headerView]|"
+                                                                                       options:NSLayoutFormatDirectionLeadingToTrailing
+                                                                                       metrics:nil
+                                                                                         views:views]];
+    [_variableConstraints addObjectsFromArray: [NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_headerView]"
+                                                                                       options:NSLayoutFormatDirectionLeadingToTrailing
+                                                                                       metrics:nil
+                                                                                         views:views]];
+    
+    [_variableConstraints addObjectsFromArray: [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_hrLabel]|"
+                                                                                       options:NSLayoutFormatDirectionLeadingToTrailing
+                                                                                       metrics:nil
+                                                                                         views:views]];
+    
+    [_variableConstraints addObjectsFromArray: [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_hrUnitLabel]|"
+                                                                                       options:NSLayoutFormatDirectionLeadingToTrailing
+                                                                                       metrics:nil
+                                                                                         views:views]];
+    
+    [_variableConstraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_continueSkipContainer]|"
+                                                                                      options:NSLayoutFormatDirectionLeadingToTrailing
+                                                                                      metrics:nil
+                                                                                        views:views]];
+    
+    [_variableConstraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[_headerView]-[_hrLabel]-[_hrUnitLabel]"
+                                                                                      options:NSLayoutFormatDirectionLeadingToTrailing
+                                                                                      metrics:nil
+                                                                                        views:views]];
+    
+    [_variableConstraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[_hrLabel]-20-[_hrUnitLabel]"
+                                                                                      options:NSLayoutFormatDirectionLeadingToTrailing
+                                                                                      metrics:nil
+                                                                                        views:views]];
+    
+    [_variableConstraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[_continueSkipContainer]|"
+                                                                                      options:NSLayoutFormatDirectionLeadingToTrailing
+                                                                                      metrics:nil
+                                                                                        views:views]];
+    
+    [NSLayoutConstraint activateConstraints:_variableConstraints];
+    [super updateConstraints];
+}
+
+- (AVCaptureSession *)session {
+    return _session;
+}
+
+- (void)setSession:(AVCaptureSession *)session {
+    _session = session;
+    // Set up the proper videoOrientation from the start
+    [self orientationDidChange];
+}
+
+- (void)setSkipButtonItem:(UIBarButtonItem *)skipButtonItem {
+    if (_showSkipButtonItem) {
+        _skipButtonItem = skipButtonItem;
+        [self updateAppearance];
+    }
+}
+
+- (void)setContinueButtonItem:(UIBarButtonItem *)continueButtonItem {
+    _continueButtonItem = continueButtonItem;
+    [self updateAppearance];
+}
+
+- (void)capturePressed {
+    // If we are still waiting for the delegate to complete, ignore futher presses
+    if (_capturePressesIgnored)
+        return;
+    
+    // Ignore futher presses until the delegate completes
+    _capturePressesIgnored = YES;
+    
+    // Capture the video via the delegate
+    [self.delegate capturePressed:^ {
+        // Stop ignoring presses
+        _capturePressesIgnored = NO;
+    }];
+}
+
+- (void)stopCapturePressed {
+    // If we are still waiting for the delegate to complete, ignore futher presses
+    if (_stopCapturePressesIgnored)
+        return;
+    
+    // Ignore futher presses until the delegate completes
+    _stopCapturePressesIgnored = YES;
+    
+    // Invalidate timer.
+    [_timer invalidate];
+    
+    // Stop the video capture via the delegate
+    [self.delegate stopCapturePressed:^ {
+        // Stop ignoring presses
+        _stopCapturePressesIgnored = NO;
+    }];
+    
+}
+
+- (void)retakePressed {
+    // If we are still waiting for the delegate to complete, ignore futher presses
+    if (_retakePressesIgnored) {
+        return;
+    }
+    
+    // Ignore futher presses until the delegate completes
+    _retakePressesIgnored = YES;
+    
+    // Tell the delegate to start capturing again
+    [self.delegate retakePressed:^{
+        // Stop ignoring presses
+        _retakePressesIgnored = NO;
+    }];
+}
+
+- (void)updateRecordTime:(NSTimer *)timer {
+    _recordTime += timer.timeInterval;
+    
+    if (_recordTime >= _hrCaptureStep.duration.floatValue || !self.recording) {
+        [_timer invalidate];
+        [self.delegate stopHrEstimation];
+        [self updateAppearance];
+    } else {
+        CGFloat remainingTime = _hrCaptureStep.duration.floatValue - _recordTime;
+        _recordingButtonItem.title = [self formattedTimeFromSeconds:remainingTime];
+        _continueSkipContainer.skipButtonItem = _recordingButtonItem;
+    }
+}
+
+-(NSString *)formattedTimeFromSeconds:(CGFloat)seconds {
+    if (!_dateComponentsFormatter) {
+        _dateComponentsFormatter = [NSDateComponentsFormatter new];
+        _dateComponentsFormatter.zeroFormattingBehavior = NSDateComponentsFormatterZeroFormattingBehaviorPad;
+        _dateComponentsFormatter.allowedUnits =  NSCalendarUnitMinute | NSCalendarUnitSecond | NSCalendarUnitNanosecond;
+    }
+    return [_dateComponentsFormatter stringFromTimeInterval:seconds];
+}
+
+- (void)sessionWasInterrupted:(NSNotification *)notification {
+    AVCaptureSessionInterruptionReason reason = [notification.userInfo[AVCaptureSessionInterruptionReasonKey] integerValue];
+    if (reason == AVCaptureSessionInterruptionReasonVideoDeviceNotAvailableWithMultipleForegroundApps) {
+        [self setError:[[NSError alloc] initWithDomain:@"" code:0 userInfo:@{NSLocalizedDescriptionKey : ORKLocalizedString(@"CAMERA_UNAVAILABLE_MESSAGE", nil)}]];
+    }
+    [self.delegate stopHrEstimation];
+    [_session stopRunning];
+}
+
+- (void)sessionInterruptionEnded:(NSNotification *)notification {
+    [self setError:nil];
+}
+
+@end

--- a/ResearchKit/Localized/en.lproj/ResearchKit.strings
+++ b/ResearchKit/Localized/en.lproj/ResearchKit.strings
@@ -520,3 +520,12 @@
 "AX_GRAPH_POINT_%@" = "Point: %@";
 
 "AX_AUDIO_BAR_GRAPH" = "Audio Bar Graph";
+
+"AX_HR_CAPTURE_COMPLETE" = "Hear Rate capture complete";
+
+/* HR capture step. */
+"CAPTURE_BUTTON_CAPTURE_HR" = "Start Capturing HR";
+"CAPTURE_BUTTON_STOP_CAPTURE_HR" = "Stop Capturing HR";
+"CAPTURE_BUTTON_RECAPTURE_HR" = "Recapture HR";
+
+"HR_LBL_UNITS" = "BPM";

--- a/ResearchKit/ResearchKit.h
+++ b/ResearchKit/ResearchKit.h
@@ -53,6 +53,7 @@
 #import <ResearchKit/ORKVisualConsentStep.h>
 #import <ResearchKit/ORKWaitStep.h>
 #import <ResearchKit/ORKVideoInstructionStep.h>
+#import <ResearchKit/ORKHrCaptureStep.h>
 
 #import <ResearchKit/ORKTask.h>
 #import <ResearchKit/ORKOrderedTask.h>


### PR DESCRIPTION
I used the VideoCaptureStep as a guideline and created a new step that uses the device's back camera and measures user's hearth rate. The step uses an FFT based approach to estimates the HR of the user every second once the measurement is started and enough samples have been collected (64 samples just to start showing information, supposing we are sampling at 30FPS we are talking about 2 seconds). The step retrieves a list of estimated HR values during the given session that can last no more than 2 minutes and no less than 20 seconds.