### PR TITLE
Added decimal scale limit to `ORKNumericAnswerFormat`

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -1006,6 +1006,14 @@ Returns an initialized numeric answer format using the specified style, unit des
  */
 @property (copy, nullable) NSNumber *maximum;
 
+/**
+ The decimal scale (number of digits to the right of the decimal point) allowed value for the
+ numeric answer.
+ 
+ The default value of this property is `nil`, which means that no limit scale value is used.
+ */
+@property (copy, nullable) NSNumber *scale;
+
 @end
 
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1377,6 +1377,13 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     NSString *sanitizedText = text;
     if (_style == ORKNumericAnswerStyleDecimal) {
         sanitizedText = [self removeDecimalSeparatorsFromText:text numAllowed:1 separator:(NSString *)separator];
+        if (self.scale) {
+            NSArray *components = [sanitizedText componentsSeparatedByString:separator];
+            if([components count] >= 2 && [components[1] length] > [self.scale integerValue]) {
+                NSString *rightOfDecimal = [components[1] substringToIndex:[self.scale integerValue]];
+                sanitizedText = [NSString stringWithFormat:@"%@%@%@", components[0], separator, rightOfDecimal];
+            }
+        }
     } else if (_style == ORKNumericAnswerStyleInteger) {
         sanitizedText = [self removeDecimalSeparatorsFromText:text numAllowed:0 separator:(NSString *)separator];
     }


### PR DESCRIPTION
Our application requires a business rule where user input can be restricted to a specific decimal scale (number of digits right of the decimal point) for the `ORKNumericAnswerFormat`. The code change adds a `scale` property to `ORKNumericAnswerFormat` and when not `nil` will restrict entering of decimal values beyond the specified scale value.