### PR TITLE
Added vertical layout option and multiple choice to ORKImageChoiceAnswerFormat

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -125,6 +125,9 @@ ORK_CLASS_AVAILABLE
 + (ORKMultipleValuePickerAnswerFormat *)multipleValuePickerAnswerFormatWithValuePickers:(NSArray<ORKValuePickerAnswerFormat *> *)valuePickers;
 
 + (ORKImageChoiceAnswerFormat *)choiceAnswerFormatWithImageChoices:(NSArray<ORKImageChoice *> *)imageChoices;
++ (ORKImageChoiceAnswerFormat *)choiceAnswerFormatWithImageChoices:(NSArray<ORKImageChoice *> *)imageChoices
+                                                             style:(ORKChoiceAnswerStyle)style
+                                                          vertical:(BOOL)vertical;
 
 + (ORKTextChoiceAnswerFormat *)choiceAnswerFormatWithStyle:(ORKChoiceAnswerStyle)style
                                                textChoices:(NSArray<ORKTextChoice *> *)textChoices;
@@ -729,12 +732,36 @@ ORK_CLASS_AVAILABLE
 - (instancetype)initWithImageChoices:(NSArray<ORKImageChoice *> *)imageChoices NS_DESIGNATED_INITIALIZER;
 
 /**
+ Returns an initialized image choice answer format using the specified array of images.
+ 
+ @param imageChoices    Array of `ORKImageChoice` objects.
+ @param style           The style of question, such as single or multiple choice.
+ @param vertical        Pass `YES` to stack images vertically; for the default horizontal
+ layout, pass `NO`.
+ 
+ @return An initialized image choice answer format.
+ */
+- (instancetype)initWithImageChoices:(NSArray<ORKImageChoice *> *)imageChoices
+                               style:(ORKChoiceAnswerStyle)style
+                            vertical:(BOOL)vertical NS_DESIGNATED_INITIALIZER;
+
+/**
  An array of `ORKImageChoice` objects that represent the available choices. (read-only)
  
  The text of the currently selected choice is displayed on screen. The text for
  each choice is spoken by VoiceOver when an image is highlighted.
  */
 @property (copy, readonly) NSArray<ORKImageChoice *> *imageChoices;
+
+/**
+ The style of the question (that is, single or multiple choice).
+ */
+@property (readonly) ORKChoiceAnswerStyle style;
+
+/**
+ A Boolean value indicating whether the choices are stacked vertically. (read-only)
+ */
+@property (readonly, getter=isVertical) BOOL vertical;
 
 @end
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -331,6 +331,14 @@ NSNumberFormatterStyle ORKNumberFormattingStyleConvert(ORKNumberFormattingStyle 
     return [[ORKImageChoiceAnswerFormat alloc] initWithImageChoices:imageChoices];
 }
 
++ (ORKImageChoiceAnswerFormat *)choiceAnswerFormatWithImageChoices:(NSArray<ORKImageChoice *> *)imageChoices
+                                                             style:(ORKChoiceAnswerStyle)style
+                                                          vertical:(BOOL)vertical {
+    return [[ORKImageChoiceAnswerFormat alloc] initWithImageChoices:imageChoices
+                                                              style:style
+                                                           vertical:vertical];
+}
+
 + (ORKTextChoiceAnswerFormat *)choiceAnswerFormatWithStyle:(ORKChoiceAnswerStyle)style
                                                textChoices:(NSArray<ORKTextChoice *> *)textChoices {
     return [[ORKTextChoiceAnswerFormat alloc] initWithStyle:style textChoices:textChoices];
@@ -804,6 +812,13 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 }
 
 - (instancetype)initWithImageChoices:(NSArray<ORKImageChoice *> *)imageChoices {
+    self = [self initWithImageChoices:imageChoices style:ORKChoiceAnswerStyleSingleChoice vertical:NO];
+    return self;
+}
+
+- (instancetype)initWithImageChoices:(NSArray<ORKImageChoice *> *)imageChoices
+                               style:(ORKChoiceAnswerStyle)style
+                            vertical:(BOOL)vertical {
     self = [super init];
     if (self) {
         NSMutableArray *choices = [[NSMutableArray alloc] init];
@@ -818,6 +833,8 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
             }
         }
         _imageChoices = choices;
+        _style = style;
+        _vertical = vertical;
         _helper = [[ORKChoiceAnswerFormatHelper alloc] initWithAnswerFormat:self];
     }
     return self;
@@ -834,17 +851,21 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     
     __typeof(self) castObject = object;
     return (isParentSame &&
-            ORKEqualObjects(self.imageChoices, castObject.imageChoices));
+            ORKEqualObjects(self.imageChoices, castObject.imageChoices) &&
+            (_style == castObject.style) &&
+            (_vertical == castObject.vertical));
 }
 
 - (NSUInteger)hash {
-    return super.hash ^ self.imageChoices.hash;
+    return super.hash ^ self.imageChoices.hash ^ _style ^ _vertical;
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
         ORK_DECODE_OBJ_ARRAY(aDecoder, imageChoices, ORKImageChoice);
+        ORK_DECODE_ENUM(aDecoder, style);
+        ORK_DECODE_BOOL(aDecoder, vertical);
     }
     return self;
 }
@@ -852,7 +873,8 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 - (void)encodeWithCoder:(NSCoder *)aCoder {
     [super encodeWithCoder:aCoder];
     ORK_ENCODE_OBJ(aCoder, imageChoices);
-    
+    ORK_ENCODE_ENUM(aCoder, style);
+    ORK_ENCODE_BOOL(aCoder, vertical);
 }
 
 + (BOOL)supportsSecureCoding {
@@ -860,7 +882,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 }
 
 - (ORKQuestionType)questionType {
-    return ORKQuestionTypeSingleChoice;
+    return (_style == ORKChoiceAnswerStyleSingleChoice) ? ORKQuestionTypeSingleChoice : ORKQuestionTypeMultipleChoice;
 }
 
 - (Class)questionResultClass {

--- a/ResearchKit/Common/ORKChoiceAnswerFormatHelper.h
+++ b/ResearchKit/Common/ORKChoiceAnswerFormatHelper.h
@@ -56,6 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray *)selectedIndexesForAnswer:(nullable id)answer;
 
 - (nullable NSString *)stringForChoiceAnswer:(id)answer;
+- (nullable NSString *)labelForChoiceAnswer:(id)answer;
 
 @end
 

--- a/ResearchKit/Common/ORKChoiceAnswerFormatHelper.m
+++ b/ResearchKit/Common/ORKChoiceAnswerFormatHelper.m
@@ -182,4 +182,16 @@
     return [answerStrings componentsJoinedByString:@"\n"];
 }
 
+- (NSString *)labelForChoiceAnswer:(id)answer {
+    NSMutableArray<NSString *> *answerStrings = [[NSMutableArray alloc] init];
+    NSArray *indexes = [self selectedIndexesForAnswer:answer];
+    for (NSNumber *index in indexes) {
+        NSString *text = [[self answerOptionAtIndex:[index integerValue]] text];
+        if (text != nil) {
+            [answerStrings addObject:text];
+        }
+    }
+    return [answerStrings componentsJoinedByString:@", "];
+}
+
 @end

--- a/ResearchKit/Common/ORKImageSelectionView.m
+++ b/ResearchKit/Common/ORKImageSelectionView.m
@@ -131,12 +131,14 @@
 
 
 static const CGFloat SpacerWidth = 10.0;
+static const CGFloat SpacerHeight = 5.0;
 
 @implementation ORKImageSelectionView {
     ORKChoiceAnswerFormatHelper *_helper;
     NSArray *_buttonViews;
     ORKImageChoiceLabel *_choiceLabel;
     ORKImageChoiceLabel *_placeHolderLabel;
+    BOOL *_isVertical;
 }
 
 - (ORKImageChoiceLabel *)makeLabel {
@@ -153,6 +155,8 @@ static const CGFloat SpacerWidth = 10.0;
         NSAssert([answerFormat isKindOfClass:[ORKImageChoiceAnswerFormat class]], @"answerFormat should be an instance of ORKImageChoiceAnswerFormat");
         
         _helper = [[ORKChoiceAnswerFormatHelper alloc] initWithAnswerFormat:answerFormat];
+        
+        _isVertical = answerFormat.isVertical;
         
         _placeHolderLabel = [self makeLabel];
         _placeHolderLabel.text = [ORKLocalizedString(@"PLACEHOLDER_IMAGE_CHOICES", nil) stringByAppendingString:@""];
@@ -219,32 +223,80 @@ static const CGFloat SpacerWidth = 10.0;
     for (ORKChoiceButtonView *buttonView in _buttonViews) {
         NSDictionary *views = NSDictionaryOfVariableBindings(buttonView, _choiceLabel);
         
-        [constraints addObjectsFromArray:
-         [NSLayoutConstraint constraintsWithVisualFormat:@"V:|[buttonView]-30-[_choiceLabel]-|"
-                                                 options:NSLayoutFormatDirectionLeadingToTrailing
-                                                 metrics:nil
-                                                   views:views]];
-        
-        if (previousView) {
-            // ButtonView left trailing
-            [constraints addObject:[NSLayoutConstraint constraintWithItem:buttonView
-                                                                attribute:NSLayoutAttributeLeft
-                                                                relatedBy:NSLayoutRelationEqual
-                                                                   toItem:previousView
-                                                                attribute:NSLayoutAttributeRight
-                                                               multiplier:1.0
-                                                                 constant:SpacerWidth]];
+        if (!_isVertical) {
+            [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[buttonView]-30-[_choiceLabel]-|"
+                                                     options:NSLayoutFormatDirectionLeadingToTrailing
+                                                     metrics:nil
+                                                       views:views]];
             
-            // All ButtonViews has equal width
-            [constraints addObject:[NSLayoutConstraint constraintWithItem:buttonView
-                                                                attribute:NSLayoutAttributeWidth
-                                                                relatedBy:NSLayoutRelationEqual
-                                                                   toItem:previousView
-                                                                attribute:NSLayoutAttributeWidth
-                                                               multiplier:1.0
-                                                                 constant:0.0]];
-            
+            if (previousView) {
+                // ButtonView left trailing
+                [constraints addObject:[NSLayoutConstraint constraintWithItem:buttonView
+                                                                    attribute:NSLayoutAttributeLeft
+                                                                    relatedBy:NSLayoutRelationEqual
+                                                                       toItem:previousView
+                                                                    attribute:NSLayoutAttributeRight
+                                                                   multiplier:1.0
+                                                                     constant:SpacerWidth]];
+                
+                // All ButtonViews has equal width
+                [constraints addObject:[NSLayoutConstraint constraintWithItem:buttonView
+                                                                    attribute:NSLayoutAttributeWidth
+                                                                    relatedBy:NSLayoutRelationEqual
+                                                                       toItem:previousView
+                                                                    attribute:NSLayoutAttributeWidth
+                                                                   multiplier:1.0
+                                                                     constant:0.0]];
+                
+            } else {
+                // ButtonView left trailing
+                [constraints addObject:[NSLayoutConstraint constraintWithItem:buttonView
+                                                                    attribute:NSLayoutAttributeLeft
+                                                                    relatedBy:NSLayoutRelationEqual
+                                                                       toItem:self
+                                                                    attribute:NSLayoutAttributeLeft
+                                                                   multiplier:1.0
+                                                                     constant:SpacerWidth]];
+            }
         } else {
+            if (previousView) {
+                // ButtonView top spacing
+                [constraints addObject:[NSLayoutConstraint constraintWithItem:buttonView
+                                                                    attribute:NSLayoutAttributeTop
+                                                                    relatedBy:NSLayoutRelationEqual
+                                                                       toItem:previousView
+                                                                    attribute:NSLayoutAttributeBottom
+                                                                   multiplier:1.0
+                                                                     constant:SpacerHeight]];
+                
+                // All ButtonViews has equal height
+                [constraints addObject:[NSLayoutConstraint constraintWithItem:buttonView
+                                                                    attribute:NSLayoutAttributeHeight
+                                                                    relatedBy:NSLayoutRelationEqual
+                                                                       toItem:previousView
+                                                                    attribute:NSLayoutAttributeHeight
+                                                                   multiplier:1.0
+                                                                     constant:0.0]];
+
+                // All ButtonViews has equal width
+                [constraints addObject:[NSLayoutConstraint constraintWithItem:buttonView
+                                                                    attribute:NSLayoutAttributeWidth
+                                                                    relatedBy:NSLayoutRelationEqual
+                                                                       toItem:previousView
+                                                                    attribute:NSLayoutAttributeWidth
+                                                                   multiplier:1.0
+                                                                     constant:0.0]];
+                
+            } else {
+                // ButtonView top spacing
+                [constraints addObject:[NSLayoutConstraint constraintWithItem:buttonView
+                                                                    attribute:NSLayoutAttributeTop
+                                                                    relatedBy:NSLayoutRelationEqual
+                                                                       toItem:self
+                                                                    attribute:NSLayoutAttributeTop
+                                                                   multiplier:1.0
+                                                                     constant:SpacerHeight]];
+            }
             // ButtonView left trailing
             [constraints addObject:[NSLayoutConstraint constraintWithItem:buttonView
                                                                 attribute:NSLayoutAttributeLeft
@@ -253,19 +305,48 @@ static const CGFloat SpacerWidth = 10.0;
                                                                 attribute:NSLayoutAttributeLeft
                                                                multiplier:1.0
                                                                  constant:SpacerWidth]];
+            // ButtonView right trailing
+            [constraints addObject:[NSLayoutConstraint constraintWithItem:buttonView
+                                                                attribute:NSLayoutAttributeRight
+                                                                relatedBy:NSLayoutRelationEqual
+                                                                   toItem:self
+                                                                attribute:NSLayoutAttributeRight
+                                                               multiplier:1.0
+                                                                 constant:-SpacerWidth]];
         }
         previousView = buttonView;
     }
     
-    if (previousView) {
-        // ButtonView right trailing
-        [constraints addObject:[NSLayoutConstraint constraintWithItem:previousView
-                                                            attribute:NSLayoutAttributeRight
-                                                            relatedBy:NSLayoutRelationEqual
-                                                               toItem:self
-                                                            attribute:NSLayoutAttributeRight
-                                                           multiplier:1.0
-                                                             constant:-SpacerWidth]];
+    if (!_isVertical) {
+        if (previousView) {
+            // ButtonView right trailing
+            [constraints addObject:[NSLayoutConstraint constraintWithItem:previousView
+                                                                attribute:NSLayoutAttributeRight
+                                                                relatedBy:NSLayoutRelationEqual
+                                                                   toItem:self
+                                                                attribute:NSLayoutAttributeRight
+                                                               multiplier:1.0
+                                                                 constant:-SpacerWidth]];
+        }
+    } else {
+        if (previousView) {
+            // ButtonView bottom spacing
+            [constraints addObject:[NSLayoutConstraint constraintWithItem:previousView
+                                                                attribute:NSLayoutAttributeBottom
+                                                                relatedBy:NSLayoutRelationEqual
+                                                                   toItem:_choiceLabel
+                                                                attribute:NSLayoutAttributeTop
+                                                               multiplier:1.0
+                                                                 constant:-30.0]];
+
+            [constraints addObject:[NSLayoutConstraint constraintWithItem:_choiceLabel
+                                                                attribute:NSLayoutAttributeBottom
+                                                                relatedBy:NSLayoutRelationEqual
+                                                                   toItem:self
+                                                                attribute:NSLayoutAttributeBottom
+                                                               multiplier:1.0
+                                                                 constant:0.0]];
+        }
     }
     [NSLayoutConstraint activateConstraints:constraints];
 }

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -365,7 +365,8 @@ enum TaskListRow: Int, CustomStringConvertible {
 
         // Task with an image choice question.
         case imageChoiceQuestionTask
-        case imageChoiceQuestionStep
+        case imageChoiceQuestionStep1
+        case imageChoiceQuestionStep2
         
         // Task with a location entry.
         case locationQuestionTask
@@ -774,13 +775,19 @@ enum TaskListRow: Int, CustomStringConvertible {
             ORKImageChoice(normalImage: squareShapeImage, selectedImage: nil, text: squareShapeText, value: squareShapeText as NSCoding & NSCopying & NSObjectProtocol)
         ]
         
-        let answerFormat = ORKAnswerFormat.choiceAnswerFormat(with: imageChoces)
+        let answerFormat1 = ORKAnswerFormat.choiceAnswerFormat(with: imageChoces)
         
-        let questionStep = ORKQuestionStep(identifier: String(describing:Identifier.imageChoiceQuestionStep), title: exampleQuestionText, answer: answerFormat)
+        let questionStep1 = ORKQuestionStep(identifier: String(describing:Identifier.imageChoiceQuestionStep1), title: exampleQuestionText, answer: answerFormat1)
+
+        questionStep1.text = exampleDetailText
+
+        let answerFormat2 = ORKAnswerFormat.choiceAnswerFormat(with: imageChoces, style: .singleChoice, vertical: true)
         
-        questionStep.text = exampleDetailText
+        let questionStep2 = ORKQuestionStep(identifier: String(describing:Identifier.imageChoiceQuestionStep2), title: exampleQuestionText, answer: answerFormat2)
+
+        questionStep2.text = exampleDetailText
         
-        return ORKOrderedTask(identifier: String(describing:Identifier.imageChoiceQuestionTask), steps: [questionStep])
+        return ORKOrderedTask(identifier: String(describing:Identifier.imageChoiceQuestionTask), steps: [questionStep1, questionStep2])
     }
     
     /// This task presents just a single location question.


### PR DESCRIPTION
This allows the image choices of the ORKImageChoiceAnswerFormat to be vertically laid out.

This is one example of a possible use case.

![simulator screen shot sep 18 2017 9 30 32 pm](https://user-images.githubusercontent.com/4361804/30575945-1d5897ea-9cb9-11e7-8374-88f43d796fdc.png)
![simulator screen shot sep 18 2017 9 30 36 pm](https://user-images.githubusercontent.com/4361804/30575942-1d5461b6-9cb9-11e7-9849-e31523d83079.png)
![simulator screen shot sep 18 2017 9 30 39 pm](https://user-images.githubusercontent.com/4361804/30575944-1d54ae5a-9cb9-11e7-8fbe-1af0efea15a7.png)
![simulator screen shot sep 18 2017 9 30 42 pm](https://user-images.githubusercontent.com/4361804/30575943-1d5476e2-9cb9-11e7-8a83-5b14b302d2a2.png)

Sample leg image credit to [Ivan Boyko](https://www.iconfinder.com/visualpharm).