### PR TITLE
Add Info.plist keys for microphone and camera access

### DIFF
--- a/samples/ORKCatalog/ORKCatalog/Supporting Files/Info.plist
+++ b/samples/ORKCatalog/ORKCatalog/Supporting Files/Info.plist
@@ -26,6 +26,10 @@
 	<string>This app reads your HealthKit data during certain tasks.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>This app records your location during certain tasks.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>This app captures photos and video during certain tasks.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>This app records audio when capturing video during certain tasks.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
Adds the necessary Info.plist keys for requesting access to camera and microphone, as required in the Image Capture Step and Video Capture Step from ORKCatalog.app