### PR TITLE
[Misc] Fix unit tests

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -729,7 +729,7 @@ ORK_CLASS_AVAILABLE
  
  @return An initialized image choice answer format.
  */
-- (instancetype)initWithImageChoices:(NSArray<ORKImageChoice *> *)imageChoices NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithImageChoices:(NSArray<ORKImageChoice *> *)imageChoices;
 
 /**
  Returns an initialized image choice answer format using the specified array of images.

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -1080,17 +1080,37 @@ Returns an initialized numeric answer format using the specified style, unit des
  
  This method is the designated initializer.
  
- @param style       The style of the numeric answer (decimal or integer).
- @param unit        A string that displays a localized version of the unit designation.
- @param minimum     The minimum value to apply, or `nil` if none is specified.
- @param maximum     The maximum value to apply, or `nil` if none is specified.
- 
+ @param style                   The style of the numeric answer (decimal or integer).
+ @param unit                    A string that displays a localized version of the unit designation.
+ @param minimum                 The minimum value to apply, or `nil` if none is specified.
+ @param maximum                 The maximum value to apply, or `nil` if none is specified.
+
  @return An initialized numeric answer format.
  */
 - (instancetype)initWithStyle:(ORKNumericAnswerStyle)style
                          unit:(nullable NSString *)unit
                       minimum:(nullable NSNumber *)minimum
-                      maximum:(nullable NSNumber *)maximum NS_DESIGNATED_INITIALIZER;
+                      maximum:(nullable NSNumber *)maximum;
+
+/**
+Returns an initialized numeric answer format using the specified style, unit designation, and range
+ values.
+ 
+ This method is the designated initializer.
+ 
+ @param style                   The style of the numeric answer (decimal or integer).
+ @param unit                    A string that displays a localized version of the unit designation.
+ @param minimum                 The minimum value to apply, or `nil` if none is specified.
+ @param maximum                 The maximum value to apply, or `nil` if none is specified.
+ @param maximumFractionDigits   The maximum fraction digits, or `nil` if no maximum is specified.
+
+ @return An initialized numeric answer format.
+ */
+- (instancetype)initWithStyle:(ORKNumericAnswerStyle)style
+                         unit:(nullable NSString *)unit
+                      minimum:(nullable NSNumber *)minimum
+                      maximum:(nullable NSNumber *)maximum
+        maximumFractionDigits:(nullable NSNumber *)maximumFractionDigits NS_DESIGNATED_INITIALIZER;
 
 /**
  The style of numeric entry (decimal or integer). (read-only)
@@ -1121,12 +1141,13 @@ Returns an initialized numeric answer format using the specified style, unit des
 @property (copy, nullable) NSNumber *maximum;
 
 /**
- The decimal scale (number of digits to the right of the decimal point) allowed value for the
+ The maximum number of fraction digits to the right of the decimal point for the
  numeric answer.
  
- The default value of this property is `nil`, which means that no limit scale value is used.
+ The default value of this property is `nil`, which means that there's no maximum number of fraction
+ digits.
  */
-@property (copy, nullable) NSNumber *scale;
+@property (copy, nullable) NSNumber *maximumFractionDigits;
 
 @end
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1463,17 +1463,29 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 }
 
 - (instancetype)initWithStyle:(ORKNumericAnswerStyle)style {
-    self = [self initWithStyle:style unit:nil minimum:nil maximum:nil];
-    return self;
+    return [self initWithStyle:style unit:nil minimum:nil maximum:nil];
 }
 
-- (instancetype)initWithStyle:(ORKNumericAnswerStyle)style unit:(NSString *)unit minimum:(NSNumber *)minimum maximum:(NSNumber *)maximum {
+- (instancetype)initWithStyle:(ORKNumericAnswerStyle)style
+                         unit:(NSString *)unit
+                      minimum:(NSNumber *)minimum
+                      maximum:(NSNumber *)maximum {
+    return [self initWithStyle:style unit:unit minimum:minimum maximum:maximum maximumFractionDigits:nil];
+}
+
+- (instancetype)initWithStyle:(ORKNumericAnswerStyle)style
+                         unit:(NSString *)unit
+                      minimum:(NSNumber *)minimum
+                      maximum:(NSNumber *)maximum
+        maximumFractionDigits:(NSNumber *)maximumFractionDigits {
     self = [super init];
     if (self) {
         _style = style;
         _unit = [unit copy];
-        self.minimum = minimum;
-        self.maximum = maximum;
+        _minimum = [minimum copy];
+        _maximum = [maximum copy];
+        _maximumFractionDigits = [maximumFractionDigits copy];
+        
     }
     return self;
 }
@@ -1485,6 +1497,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         ORK_DECODE_OBJ_CLASS(aDecoder, unit, NSString);
         ORK_DECODE_OBJ_CLASS(aDecoder, minimum, NSNumber);
         ORK_DECODE_OBJ_CLASS(aDecoder, maximum, NSNumber);
+        ORK_DECODE_OBJ_CLASS(aDecoder, maximumFractionDigits, NSNumber);
     }
     return self;
 }
@@ -1495,7 +1508,8 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     ORK_ENCODE_OBJ(aCoder, unit);
     ORK_ENCODE_OBJ(aCoder, minimum);
     ORK_ENCODE_OBJ(aCoder, maximum);
-    
+    ORK_ENCODE_OBJ(aCoder, maximumFractionDigits);
+
 }
 
 + (BOOL)supportsSecureCoding {
@@ -1506,7 +1520,8 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     ORKNumericAnswerFormat *answerFormat = [[[self class] allocWithZone:zone] initWithStyle:_style
                                                                                        unit:[_unit copy]
                                                                                     minimum:[_minimum copy]
-                                                                                    maximum:[_maximum copy]];
+                                                                                    maximum:[_maximum copy]
+                                                                      maximumFractionDigits:[_maximumFractionDigits copy]];
     return answerFormat;
 }
 
@@ -1518,6 +1533,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
             ORKEqualObjects(self.unit, castObject.unit) &&
             ORKEqualObjects(self.minimum, castObject.minimum) &&
             ORKEqualObjects(self.maximum, castObject.maximum) &&
+            ORKEqualObjects(self.maximumFractionDigits, castObject.maximumFractionDigits) &&
             (_style == castObject.style));
 }
 
@@ -1637,10 +1653,10 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     NSString *sanitizedText = text;
     if (_style == ORKNumericAnswerStyleDecimal) {
         sanitizedText = [self removeDecimalSeparatorsFromText:text numAllowed:1 separator:(NSString *)separator];
-        if (self.scale) {
+        if (self.maximumFractionDigits) {
             NSArray *components = [sanitizedText componentsSeparatedByString:separator];
-            if([components count] >= 2 && [components[1] length] > [self.scale integerValue]) {
-                NSString *rightOfDecimal = [components[1] substringToIndex:[self.scale integerValue]];
+            if([components count] >= 2 && [components[1] length] > [self.maximumFractionDigits integerValue]) {
+                NSString *rightOfDecimal = [components[1] substringToIndex:[self.maximumFractionDigits integerValue]];
                 sanitizedText = [NSString stringWithFormat:@"%@%@%@", components[0], separator, rightOfDecimal];
             }
         }

--- a/ResearchKitTests/ORKRecorderTests.m
+++ b/ResearchKitTests/ORKRecorderTests.m
@@ -304,7 +304,7 @@
 
 
 static BOOL ork_doubleEqual(double x, double y) {
-    static double K = 1;
+    static double K = 2;
     return (fabs(x-y) < K * DBL_EPSILON * fabs(x+y) || fabs(x-y) < DBL_MIN);
 }
 

--- a/Testing/ORKTest/ORKTestTests/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTestTests/ORKESerialization.m
@@ -1048,7 +1048,7 @@ encondingTable =
           })),
   ENTRY(ORKNumericAnswerFormat,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
-            return [[ORKNumericAnswerFormat alloc] initWithStyle:((NSNumber *)GETPROP(dict, style)).integerValue unit:GETPROP(dict, unit) minimum:GETPROP(dict, minimum) maximum:GETPROP(dict, maximum)];
+            return [[ORKNumericAnswerFormat alloc] initWithStyle:((NSNumber *)GETPROP(dict, style)).integerValue unit:GETPROP(dict, unit) minimum:GETPROP(dict, minimum) maximum:GETPROP(dict, maximum) maximumFractionDigits:GETPROP(dict, maximumFractionDigits)];
         },
         (@{
           PROPERTY(style, NSNumber, NSObject, NO,
@@ -1057,6 +1057,7 @@ encondingTable =
           PROPERTY(unit, NSString, NSObject, NO, nil, nil),
           PROPERTY(minimum, NSNumber, NSObject, NO, nil, nil),
           PROPERTY(maximum, NSNumber, NSObject, NO, nil, nil),
+          PROPERTY(maximumFractionDigits, NSNumber, NSObject, NO, nil, nil),
           })),
   ENTRY(ORKScaleAnswerFormat,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {

--- a/Testing/ORKTest/ORKTestTests/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTestTests/ORKESerialization.m
@@ -69,6 +69,15 @@ static NSArray *ORKNumericAnswerStyleTable() {
     return table;
 }
 
+static NSArray *ORKImageChoiceAnswerStyleTable() {
+    static NSArray *table = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        table = @[@"singleChoice", @"multipleChoice"];
+    });
+    return table;
+}
+
 static id tableMapForward(NSInteger index, NSArray *table) {
     return table[index];
 }
@@ -127,6 +136,14 @@ static ORKNumericAnswerStyle ORKNumericAnswerStyleFromString(NSString *s) {
 }
 
 static NSString *ORKNumericAnswerStyleToString(ORKNumericAnswerStyle style) {
+    return tableMapForward(style, ORKNumericAnswerStyleTable());
+}
+
+static ORKNumericAnswerStyle ORKImageChoiceAnswerStyleFromString(NSString *s) {
+    return tableMapReverse(s, ORKNumericAnswerStyleTable());
+}
+
+static NSString *ORKImageChoiceAnswerStyleToString(ORKNumericAnswerStyle style) {
     return tableMapForward(style, ORKNumericAnswerStyleTable());
 }
 
@@ -985,10 +1002,14 @@ encondingTable =
             })),
   ENTRY(ORKImageChoiceAnswerFormat,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
-            return [[ORKImageChoiceAnswerFormat alloc] initWithImageChoices:GETPROP(dict, imageChoices)];
+            return [[ORKImageChoiceAnswerFormat alloc] initWithImageChoices:GETPROP(dict, imageChoices) style:((NSNumber *)GETPROP(dict, style)).integerValue vertical:((NSNumber *)GETPROP(dict, vertical)).boolValue];
         },
         (@{
           PROPERTY(imageChoices, ORKImageChoice, NSArray, NO, nil, nil),
+          PROPERTY(style, NSNumber, NSObject, NO,
+                   ^id(id number) { return ORKImageChoiceAnswerStyleToString(((NSNumber *)number).integerValue); },
+                   ^id(id string) { return @(ORKImageChoiceAnswerStyleFromString(string)); }),
+          PROPERTY(vertical, NSNumber, NSObject, NO, nil, nil),
           })),
   ENTRY(ORKTextChoiceAnswerFormat,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -867,6 +867,7 @@ ORK_MAKE_TEST_INIT(NSRegularExpression, (^{
                                    @"ORKConsentSection.customAnimationURL",
                                    @"ORKNumericAnswerFormat.minimum",
                                    @"ORKNumericAnswerFormat.maximum",
+                                   @"ORKNumericAnswerFormat.maximumFractionDigits",
                                    @"ORKVideoCaptureStep.duration",
                                    @"ORKTextAnswerFormat.validationRegularExpression",
                                    ];


### PR DESCRIPTION
This PR fixes three separate unit test failures:

- Localization recorder failure. The `ork_doubleEqual()` method had too high of a precision, and failed for the *latitude* double floating point rounding errors when boxing and unboxing into `NSNumber`. Original value:  *37.3131699999999995043*, compared value: *37.313169999999978188*, difference: *2.13162820728030055761e-14*, minimumDifference: *1.65703761823010543768e-14*. I increased the K value (units of errors in the last place) from *1* to *2*.
  
<img width="1752" alt="screenshot 2017-11-15 23 10 38" src="https://user-images.githubusercontent.com/444313/32880216-b63dd314-ca61-11e7-9cdb-f1ec99eb5923.png">

- `ORKESerializationTests` failure due to not handling the new `scale` property of `ORKNumericAnswerFormat`. I took the chance to rename `scale` to `maximumFractionDigits` which is coherent with the `NSNumberFormatter` property.
- `ORKESerializationTests` failure due to not handling the new `style` and `vertical` property of `ORKImageChoiceAnswerFormat`.