### PR TITLE
Fix for ORKFormStepViewController getting stuck in a "skipped" state

### DIFF
--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -392,6 +392,7 @@
         }
     }
     
+    _skipped = NO;
     [self updateButtonStates];
     [self notifyDelegateOnResultChange];
 }
@@ -914,6 +915,7 @@
             [self removeAnswerForIdentifier:formItemIdentifier];
         }
         
+        _skipped = NO;
         [self updateButtonStates];
         [self notifyDelegateOnResultChange];
     }
@@ -981,6 +983,7 @@
         [self removeAnswerForIdentifier:cell.formItem.identifier];
     }
     
+    _skipped = NO;
     [self updateButtonStates];
     [self notifyDelegateOnResultChange];
 }

--- a/Testing/ORKTest/ORKTest/Tasks/TaskFactory+Forms.m
+++ b/Testing/ORKTest/ORKTest/Tasks/TaskFactory+Forms.m
@@ -686,7 +686,31 @@
     }
     
     {
-        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"step5" title:@"Optional Form Items" text:@"Required form with no required items"];
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"step5" title:@"Optional Form Items" text:@"Optional form with custom validation"];
+        NSMutableArray *items = [NSMutableArray new];
+        [steps addObject:step];
+        
+        {
+            ORKFormItem *item = [[ORKFormItem alloc] initWithSectionTitle:@"Optional"];
+            [items addObject:item];
+        }
+        
+        {
+            ORKTextAnswerFormat *format = [ORKAnswerFormat textAnswerFormatWithMaximumLength:12];
+            format.multipleLines = NO;
+            ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"text"
+                                                                   text:@"Text"
+                                                           answerFormat:format];
+            item.placeholder = @"Input the value \"Valid\" to proceed.";
+            item.optional = NO;
+            [items addObject:item];
+        }
+        
+        [step setFormItems:items];
+    }
+    
+    {
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"step6" title:@"Optional Form Items" text:@"Required form with no required items"];
         NSMutableArray *items = [NSMutableArray new];
         [steps addObject:step];
         
@@ -715,10 +739,23 @@
         
         [step setFormItems:items];
         step.optional = NO;
+        
+        step.shouldPresentStepBlock = ^BOOL(ORKTaskViewController *taskViewController, ORKStep *step) {
+            ORKTextQuestionResult *textResult = (ORKTextQuestionResult *)[[taskViewController.result stepResultForStepIdentifier:@"step5"] resultForIdentifier:@"text"];
+            BOOL isValid = [textResult.answer isEqualToString:@"Valid"];
+            if (!isValid) {
+                UIAlertController *alert = [UIAlertController alertControllerWithTitle:nil
+                                                                               message:@"Invalid text field value."
+                                                                        preferredStyle:UIAlertControllerStyleAlert];
+                [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+                [taskViewController presentViewController:alert animated:YES completion:nil];
+            }
+            return isValid;
+        };
     }
     
     {
-        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"step6" title:@"Optional Form Items" text:@"Required form with some required items"];
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"step7" title:@"Optional Form Items" text:@"Required form with some required items"];
         NSMutableArray *items = [NSMutableArray new];
         [steps addObject:step];
         
@@ -773,7 +810,7 @@
     }
     
     {
-        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"step7" title:@"Optional Form Items" text:@"Required form with all items required"];
+        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:@"step8" title:@"Optional Form Items" text:@"Required form with all items required"];
         NSMutableArray *items = [NSMutableArray new];
         [steps addObject:step];
         


### PR DESCRIPTION
When the user taps the Skip button on a form step, ORKFormStepViewController [sets a private `_skipped` field to `YES`](https://github.com/ResearchKit/ResearchKit/blob/master/ResearchKit/Common/ORKFormStepViewController.m#L739). It [checks the value](https://github.com/ResearchKit/ResearchKit/blob/master/ResearchKit/Common/ORKFormStepViewController.m#L702) of `_skipped` whenever it needs to produce an ORKStepResult.

This can cause the form step to get into a bad state in the following scenario:

1. User taps Skip
2. Forward navigation is prevented, for example by an `ORKTaskViewControllerDelegate` instance implementing `taskViewController:shouldPresentStep:` and returning `NO`

At this point, the user is still viewing the current form step, but `_skipped` is still true. Thus, all of the results for that step will remain empty, even if the user attempts to change their answers (because the `result` property getter ignores any entered answers if `_skipped` is true).

In this pull request, I added some code to reset `_skipped` to NO when the answers are updated in the form step. I also added a sample form step to the `ORKTest` app to demonstrate this.