### PR TITLE
Make the ORKImageCaptureCameraPreviewView take the full width of the screen.

### DIFF
--- a/ResearchKit/Common/ORKImageCaptureCameraPreviewView.m
+++ b/ResearchKit/Common/ORKImageCaptureCameraPreviewView.m
@@ -78,6 +78,9 @@
 - (void)setUpConstraints {
     NSMutableArray *constraints = [NSMutableArray new];
     
+    [_templateImageView setContentHuggingPriority:1 forAxis:UILayoutConstraintAxisHorizontal];
+    [_templateImageView setContentHuggingPriority:1 forAxis:UILayoutConstraintAxisVertical];
+    
     // Make the insets for the template image view changeable later
     _templateImageViewTopInsetConstraint = [NSLayoutConstraint constraintWithItem:_templateImageView
                                                               attribute:NSLayoutAttributeTop

--- a/ResearchKit/Common/ORKImageCaptureCameraPreviewView.m
+++ b/ResearchKit/Common/ORKImageCaptureCameraPreviewView.m
@@ -78,8 +78,14 @@
 - (void)setUpConstraints {
     NSMutableArray *constraints = [NSMutableArray new];
     
-    [_templateImageView setContentHuggingPriority:1 forAxis:UILayoutConstraintAxisHorizontal];
-    [_templateImageView setContentHuggingPriority:1 forAxis:UILayoutConstraintAxisVertical];
+    [_templateImageView setContentHuggingPriority:0 forAxis:UILayoutConstraintAxisHorizontal];
+    [_templateImageView setContentHuggingPriority:0 forAxis:UILayoutConstraintAxisVertical];
+    [_templateImageView setContentCompressionResistancePriority:0 forAxis:UILayoutConstraintAxisHorizontal];
+    [_templateImageView setContentCompressionResistancePriority:0 forAxis:UILayoutConstraintAxisVertical];
+    [_capturedImageView setContentHuggingPriority:0 forAxis:UILayoutConstraintAxisHorizontal];
+    [_capturedImageView setContentHuggingPriority:0 forAxis:UILayoutConstraintAxisVertical];
+    [_capturedImageView setContentCompressionResistancePriority:0 forAxis:UILayoutConstraintAxisHorizontal];
+    [_capturedImageView setContentCompressionResistancePriority:0 forAxis:UILayoutConstraintAxisVertical];
     
     // Make the insets for the template image view changeable later
     _templateImageViewTopInsetConstraint = [NSLayoutConstraint constraintWithItem:_templateImageView
@@ -120,11 +126,11 @@
     
     // Make the captured image view use the available space (taking into account the layout margins)
     NSDictionary *views = @{ @"capturedImageView": _capturedImageView };
-    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-[capturedImageView]-|"
+    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[capturedImageView]|"
                                                                              options:NSLayoutFormatDirectionLeadingToTrailing
                                                                              metrics:nil
                                                                                views:views]];
-    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-[capturedImageView]-|"
+    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[capturedImageView]|"
                                                                              options:NSLayoutFormatDirectionLeadingToTrailing
                                                                              metrics:nil
                                                                                views:views]];

--- a/ResearchKit/Common/ORKImageCaptureCameraPreviewView.m
+++ b/ResearchKit/Common/ORKImageCaptureCameraPreviewView.m
@@ -126,11 +126,11 @@
     
     // Make the captured image view use the available space (taking into account the layout margins)
     NSDictionary *views = @{ @"capturedImageView": _capturedImageView };
-    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[capturedImageView]|"
+    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-[capturedImageView]-|"
                                                                              options:NSLayoutFormatDirectionLeadingToTrailing
                                                                              metrics:nil
                                                                                views:views]];
-    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[capturedImageView]|"
+    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-[capturedImageView]-|"
                                                                              options:NSLayoutFormatDirectionLeadingToTrailing
                                                                              metrics:nil
                                                                                views:views]];

--- a/ResearchKit/Common/ORKImageCaptureView.m
+++ b/ResearchKit/Common/ORKImageCaptureView.m
@@ -215,7 +215,7 @@
                                                                                         views:views]];
     
     [_variableConstraints addObjectsFromArray:
-     [NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_headerView]-[_continueSkipContainer]|"
+     [NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_headerView]-(>=0)-|"
                                              options:NSLayoutFormatDirectionLeadingToTrailing
                                              metrics:nil
                                                views:views]];


### PR DESCRIPTION
Previously the size of the camera capture view was dependent on the templateImage size. This is somewhat unintuitive https://github.com/ResearchKit/ResearchKit/issues/1021. Additionally this setup messed up the constraints in the ORKNavigationContainerView, causing it to hide the skip button, and take up most of the screen in landscape.

Previously:
![screen shot 2018-02-12 at 11 42 47 am](https://user-images.githubusercontent.com/758035/36123237-ddb7a098-1000-11e8-83ba-f3ff4f65845f.png)
![screen shot 2018-02-12 at 2 32 04 pm](https://user-images.githubusercontent.com/758035/36123455-8309663a-1001-11e8-9e5b-dc69e01c4fbd.png)

Now:
![screen shot 2018-02-12 at 12 38 47 pm](https://user-images.githubusercontent.com/758035/36123355-37e8dd20-1001-11e8-99d2-6b3c45503514.png)
![screen shot 2018-02-12 at 2 33 01 pm](https://user-images.githubusercontent.com/758035/36123489-ac9bef72-1001-11e8-9481-b292423e687b.png)