### PR TITLE
Show time-left-label for audio task

### DIFF
--- a/ResearchKit/ActiveTasks/ORKAudioContentView.m
+++ b/ResearchKit/ActiveTasks/ORKAudioContentView.m
@@ -334,7 +334,7 @@ static const CGFloat ValueLineMargin = 1.5;
     static NSDateComponentsFormatter *formatter = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        NSDateComponentsFormatter *formatter = [NSDateComponentsFormatter new];
+        formatter = [NSDateComponentsFormatter new];
         formatter.unitsStyle = NSDateComponentsFormatterUnitsStylePositional;
         formatter.zeroFormattingBehavior = NSDateComponentsFormatterZeroFormattingBehaviorPad;
         formatter.allowedUnits = NSCalendarUnitMinute | NSCalendarUnitSecond;


### PR DESCRIPTION
Probably due to a typo. The formatter which is used to format the string showing the remaining time for the audio task is always nil.