### PR TITLE
Added phone number form item for ORKRegistrationStep #1068

### DIFF
--- a/ResearchKit/Localized/en.lproj/ResearchKit.strings
+++ b/ResearchKit/Localized/en.lproj/ResearchKit.strings
@@ -115,6 +115,8 @@
 "GENDER_FORM_ITEM_PLACEHOLDER" = "Pick a gender";
 "DOB_FORM_ITEM_TITLE" = "Date of Birth";
 "DOB_FORM_ITEM_PLACEHOLDER" = "Pick a date";
+"PHONE_NUMBER_FORM_ITEM_TITLE" = "Phone Number";
+"PHONE_NUMBER_FORM_ITEM_PLACEHOLDER" = "+1 (555) 555 5555";
 
 /* Verification step */
 "VERIFICATION_NAV_TITLE" = "Verification";

--- a/ResearchKit/Onboarding/ORKRegistrationStep.h
+++ b/ResearchKit/Onboarding/ORKRegistrationStep.h
@@ -53,7 +53,10 @@ typedef NS_OPTIONS(NSUInteger, ORKRegistrationStepOption) {
     ORKRegistrationStepIncludeGender = (1 << 3),
     
     /// Include the date of birth field.
-    ORKRegistrationStepIncludeDOB = (1 << 4)
+    ORKRegistrationStepIncludeDOB = (1 << 4),
+    
+    /// Include the user phone number.
+    ORKRegistrationStepIncludePhoneNumber = (1 << 5)
 } ORK_ENUM_AVAILABLE;
 
 
@@ -67,6 +70,7 @@ ORK_EXTERN NSString *const ORKRegistrationFormItemIdentifierGivenName ORK_AVAILA
 ORK_EXTERN NSString *const ORKRegistrationFormItemIdentifierFamilyName ORK_AVAILABLE_DECL;
 ORK_EXTERN NSString *const ORKRegistrationFormItemIdentifierGender ORK_AVAILABLE_DECL;
 ORK_EXTERN NSString *const ORKRegistrationFormItemIdentifierDOB ORK_AVAILABLE_DECL;
+ORK_EXTERN NSString *const ORKRegistrationFormItemIdentifierPhoneNumber ORK_AVAILABLE_DECL;
 
 
 /**
@@ -139,6 +143,24 @@ passcodeValidationRegularExpression:(nullable NSRegularExpression *)passcodeVali
  By default, there is no invalid message.
  */
 @property (nonatomic, copy, nullable) NSString *passcodeInvalidMessage;
+
+/**
+ The regular expression used to validate the phone number form item.
+ This is a transparent property pointing to its definition in `ORKTextAnswerFormat`.
+ 
+ The phone number invalid message property must also be set along with this property.
+ By default, there is no validation on the phone number.
+ */
+@property (nonatomic, copy, nullable) NSRegularExpression *phoneNumberValidationRegularExpression;
+
+/**
+ The invalid message displayed if the phone number does not match the validation regular expression.
+ This is a transparent property pointing to its definition in `ORKTextAnswerFormat`.
+ 
+ The phone number validation regular expression property must also be set along with this property.
+ By default, there is no invalid message.
+ */
+@property (nonatomic, copy, nullable) NSString *phoneNumberInvalidMessage;
 
 @end
 

--- a/ResearchKit/Onboarding/ORKRegistrationStep.m
+++ b/ResearchKit/Onboarding/ORKRegistrationStep.m
@@ -43,6 +43,7 @@ NSString *const ORKRegistrationFormItemIdentifierGivenName = @"ORKRegistrationFo
 NSString *const ORKRegistrationFormItemIdentifierFamilyName = @"ORKRegistrationFormItemFamilyName";
 NSString *const ORKRegistrationFormItemIdentifierGender = @"ORKRegistrationFormItemGender";
 NSString *const ORKRegistrationFormItemIdentifierDOB = @"ORKRegistrationFormItemDOB";
+NSString *const ORKRegistrationFormItemIdentifierPhoneNumber = @"ORKRegistrationFormItemPhoneNumber";
 
 static id ORKFindInArrayByFormItemId(NSArray *array, NSString *formItemIdentifier) {
     return findInArrayByKey(array, @"identifier", formItemIdentifier);
@@ -91,7 +92,7 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
         [formItems addObject:item];
     }
     
-    if (options & (ORKRegistrationStepIncludeFamilyName | ORKRegistrationStepIncludeGivenName | ORKRegistrationStepIncludeDOB | ORKRegistrationStepIncludeGender)) {
+    if (options & (ORKRegistrationStepIncludeFamilyName | ORKRegistrationStepIncludeGivenName | ORKRegistrationStepIncludeDOB | ORKRegistrationStepIncludeGender | ORKRegistrationStepIncludePhoneNumber)) {
         ORKFormItem *item = [[ORKFormItem alloc] initWithSectionTitle:ORKLocalizedString(@"ADDITIONAL_INFO_SECTION_TITLE", nil)];
         
         [formItems addObject:item];
@@ -169,6 +170,23 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
         [formItems addObject:item];
     }
     
+    if (options & ORKRegistrationStepIncludePhoneNumber) {
+        ORKTextAnswerFormat *answerFormat = [ORKAnswerFormat textAnswerFormat];
+        answerFormat.multipleLines = NO;
+        answerFormat.autocapitalizationType = UITextAutocapitalizationTypeNone;
+        answerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
+        answerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+        answerFormat.keyboardType = UIKeyboardTypeNumbersAndPunctuation;
+        
+        ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKRegistrationFormItemIdentifierPhoneNumber
+                                                               text:ORKLocalizedString(@"PHONE_NUMBER_FORM_ITEM_TITLE", nil)
+                                                       answerFormat:answerFormat
+                                                           optional:NO];
+        item.placeholder = ORKLocalizedString(@"PHONE_NUMBER_FORM_ITEM_PLACEHOLDER", nil);
+        
+        [formItems addObject:item];
+    }
+    
     return formItems;
 }
 
@@ -224,6 +242,12 @@ passcodeValidationRegularExpression:nil
     return passwordAnswerFormat;
 }
 
+- (ORKTextAnswerFormat *)phoneNumberAnswerFormat {
+    ORKFormItem *phoneNumberFormItem = ORKFindInArrayByFormItemId(self.formItems, ORKRegistrationFormItemIdentifierPhoneNumber);
+    ORKTextAnswerFormat *phoneNumberAnswerFormat = (ORKTextAnswerFormat *)phoneNumberFormItem.answerFormat;
+    return phoneNumberAnswerFormat;
+}
+
 - (NSArray <ORKFormItem *> *)formItems {
     if (![super formItems]) {
         self.formItems = ORKRegistrationFormItems(_options);
@@ -261,6 +285,22 @@ passcodeValidationRegularExpression:nil
     [self passwordAnswerFormat].invalidMessage = passcodeInvalidMessage;
 }
 
+- (NSRegularExpression *)phoneNumberValidationRegularExpression {
+    return [self phoneNumberAnswerFormat].validationRegularExpression;
+}
+
+- (void)setPhoneNumberValidationRegularExpression:(NSRegularExpression *)phoneNumberValidationRegularExpression {
+    [self phoneNumberAnswerFormat].validationRegularExpression = phoneNumberValidationRegularExpression;
+}
+
+- (NSString *)phoneNumberInvalidMessage {
+    return [self phoneNumberAnswerFormat].invalidMessage;
+}
+
+- (void)setPhoneNumberInvalidMessage:(NSString *)phoneNumberInvalidMessage {
+    [self phoneNumberAnswerFormat].invalidMessage = phoneNumberInvalidMessage;
+}
+
 + (BOOL)supportsSecureCoding {
     return YES;
 }
@@ -269,7 +309,8 @@ passcodeValidationRegularExpression:nil
     self = [super initWithCoder:aDecoder];
     if (self) {
         
-        // `passcodeValidationRegularExpression` and `passcodeInvalidMessage` are transparent
+        // `passcodeValidationRegularExpression`, `passcodeInvalidMessage`,
+        // `phoneNumberValidationRegularExpression`, and `phoneNumberInvalidMessage` are transparent
         // properties. The corresponding decoding for these properties takes place in the answer
         // format's `-initWithCode:` method, invoked from super's (ORKFormStep) implementation.
         ORK_DECODE_INTEGER(aDecoder, options);
@@ -280,7 +321,8 @@ passcodeValidationRegularExpression:nil
 - (void)encodeWithCoder:(NSCoder *)aCoder {
     [super encodeWithCoder:aCoder];
     
-    // `passcodeValidationRegularExpression` and `passcodeInvalidMessage` are transparent
+    // `passcodeValidationRegularExpression`, `passcodeInvalidMessage`,
+    // `phoneNumberValidationRegularExpression`, and `phoneNumberInvalidMessage` are transparent
     // properties. The corresponding encoding for these properties takes place in the answer format's
     // `-encodeWithCoder:` method, invoked from super's (ORKFormStep) implementation.
     ORK_ENCODE_INTEGER(aCoder, options);
@@ -289,7 +331,8 @@ passcodeValidationRegularExpression:nil
 - (instancetype)copyWithZone:(NSZone *)zone {
     ORKRegistrationStep *step = [super copyWithZone:zone];
     
-    // `passcodeValidationRegularExpression` and `passcodeInvalidMessage` are transparent
+    // `passcodeValidationRegularExpression`, `passcodeInvalidMessage`,
+    // `phoneNumberValidationRegularExpression`, and `phoneNumberInvalidMessage` are transparent
     // properties. The corresponding copying of these properties happens in the answer format
     // `-copyWithZone:` method, invoked from the super's (ORKFormStep) implementation.
     step->_options = self.options;
@@ -299,7 +342,8 @@ passcodeValidationRegularExpression:nil
 - (BOOL)isEqual:(id)object {
     BOOL isParentSame = [super isEqual:object];
     
-    // `passcodeValidationRegularExpression` and `passcodeInvalidMessage` are transparent
+    // `passcodeValidationRegularExpression`, `passcodeInvalidMessage`,
+    // `phoneNumberValidationRegularExpression`, and `phoneNumberInvalidMessage` are transparent
     // properties. The corresponding equality test for these properties takes place in the answer
     // format's `-isEqual:` method, invoked from super's (ORKFormStep) implementation.
     __typeof(self) castObject = object;

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -1200,7 +1200,7 @@ enum TaskListRow: Int, CustomStringConvertible {
         let passcodeValidationRegularExpressionPattern = "^(?=.*\\d).{4,8}$"
         let passcodeValidationRegularExpression = try! NSRegularExpression(pattern: passcodeValidationRegularExpressionPattern)
         let passcodeInvalidMessage = NSLocalizedString("A valid password must be 4 and 8 digits long and include at least one numeric character.", comment: "")
-        let registrationOptions: ORKRegistrationStepOption = [.includePhoneNumber]
+        let registrationOptions: ORKRegistrationStepOption = [.includeGivenName, .includeFamilyName, .includeGender, .includeDOB, .includePhoneNumber]
         let registrationStep = ORKRegistrationStep(identifier: String(describing:Identifier.registrationStep), title: registrationTitle, text: exampleDetailText, passcodeValidationRegularExpression: passcodeValidationRegularExpression, passcodeInvalidMessage: passcodeInvalidMessage, options: registrationOptions)
         registrationStep.phoneNumberValidationRegularExpression = try! NSRegularExpression(pattern: "^[+]{1,1}[1]{1,1}\\s{1,1}[(]{1,1}[1-9]{3,3}[)]{1,1}\\s{1,1}[1-9]{3,3}\\s{1,1}[1-9]{4,4}$")
         registrationStep.phoneNumberInvalidMessage = "Invalid phone number"

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -1200,8 +1200,10 @@ enum TaskListRow: Int, CustomStringConvertible {
         let passcodeValidationRegularExpressionPattern = "^(?=.*\\d).{4,8}$"
         let passcodeValidationRegularExpression = try! NSRegularExpression(pattern: passcodeValidationRegularExpressionPattern)
         let passcodeInvalidMessage = NSLocalizedString("A valid password must be 4 and 8 digits long and include at least one numeric character.", comment: "")
-        let registrationOptions: ORKRegistrationStepOption = [.includeGivenName, .includeFamilyName, .includeGender, .includeDOB]
+        let registrationOptions: ORKRegistrationStepOption = [.includePhoneNumber]
         let registrationStep = ORKRegistrationStep(identifier: String(describing:Identifier.registrationStep), title: registrationTitle, text: exampleDetailText, passcodeValidationRegularExpression: passcodeValidationRegularExpression, passcodeInvalidMessage: passcodeInvalidMessage, options: registrationOptions)
+        registrationStep.phoneNumberValidationRegularExpression = try! NSRegularExpression(pattern: "^[+]{1,1}[1]{1,1}\\s{1,1}[(]{1,1}[1-9]{3,3}[)]{1,1}\\s{1,1}[1-9]{3,3}\\s{1,1}[1-9]{4,4}$")
+        registrationStep.phoneNumberInvalidMessage = "Invalid phone number"
         
         /*
         A wait step allows you to upload the data from the user registration onto your server before presenting the verification step.


### PR DESCRIPTION
Added phone number form item for ORKRegistrationStep.  Includes properties phoneNumberValidationRegularExpression and phoneNumberInvalidMessage.  Added localized strings in english for PHONE_NUMBER_FORM_ITEM_TITLE and PHONE_NUMBER_FORM_ITEM_PLACEHOLDER.  PHONE_NUMBER_FORM_ITEM_PLACEHOLDER defaults to +1 (555) 555 5555 unless developer sets place holder in the steps place holder.  Updated ORKCatalog.