### PR TITLE
Timed walk task cleanup

### DIFF
--- a/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.h
+++ b/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.h
@@ -473,44 +473,6 @@ NS_ASSUME_NONNULL_BEGIN
                                      numberOfDisks:(NSUInteger)numberOfDisks
                                            options:(ORKPredefinedTaskOption)options;
 
-
-/**
- Returns a predefined task that consists of a timed walk.
- 
- In a timed walk task, the participant is asked to walk for a specific distance as quickly as
- possible, but safely. The task is immediately administered again by having the patient walk back
- the same distance.
- A timed walk task can be used to measure lower extremity function.
- 
- The presentation of the timed walk task differs from both the fitness check task and the short
- walk task in that the distance is fixed. After a first walk, the user is asked to turn and reverse
- direction.
- 
- The data collected by this task can include accelerometer, device motion, pedometer data,
- and location where available.
- 
- Data collected by the task is in the form of an `ORKTimedWalkResult` object.
- 
- @param identifier                  The task identifier to use for this task, appropriate to the study.
- @param intendedUseDescription      A localized string describing the intended use of the data
-                                      collected. If the value of this parameter is `nil`, the default
-                                      localized text is displayed.
- @param distanceInMeters            The timed walk distance in meters.
- @param timeLimit                   The time limit to complete the trials.
- @param includeAssistiveDeviceForm  A Boolean value that indicates whether to inlude the form step
-                                      about the usage of an assistive device.
- @param options                     Options that affect the features of the predefined task.
- 
- @return An active timed walk task that can be presented with an `ORKTaskViewController` object.
- */
-+ (ORKOrderedTask *)timedWalkTaskWithIdentifier:(NSString *)identifier
-                         intendedUseDescription:(nullable NSString *)intendedUseDescription
-                               distanceInMeters:(double)distanceInMeters
-                                      timeLimit:(NSTimeInterval)timeLimit
-                     includeAssistiveDeviceForm:(BOOL)includeAssistiveDeviceForm
-                                        options:(ORKPredefinedTaskOption)options;
-
-
 /**
  Returns a predefined task that consists of a timed walk, with a distinct turn around step.
 
@@ -534,7 +496,7 @@ NS_ASSUME_NONNULL_BEGIN
  localized text is displayed.
  @param distanceInMeters            The timed walk distance in meters.
  @param timeLimit                   The time limit to complete the trials.
- @param turnAroundTimeLimit         The time limit to complete the turn around step.
+ @param turnAroundTimeLimit         The time limit to complete the turn around step, passing -1 to this parameter will bypass the turnAroundTime step.
  @param includeAssistiveDeviceForm  A Boolean value that indicates whether to inlude the form step
  about the usage of an assistive device.
  @param options                     Options that affect the features of the predefined task.

--- a/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.h
+++ b/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.h
@@ -496,7 +496,7 @@ NS_ASSUME_NONNULL_BEGIN
  localized text is displayed.
  @param distanceInMeters            The timed walk distance in meters.
  @param timeLimit                   The time limit to complete the trials.
- @param turnAroundTimeLimit         The time limit to complete the turn around step, passing a negative value to this parameter will bypass the turnAroundTime step.
+ @param turnAroundTimeLimit         The time limit to complete the turn around step, passing zero or negative value to this parameter will bypass the turnAroundTime step.
  @param includeAssistiveDeviceForm  A Boolean value that indicates whether to inlude the form step
  about the usage of an assistive device.
  @param options                     Options that affect the features of the predefined task.

--- a/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.h
+++ b/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.h
@@ -496,7 +496,7 @@ NS_ASSUME_NONNULL_BEGIN
  localized text is displayed.
  @param distanceInMeters            The timed walk distance in meters.
  @param timeLimit                   The time limit to complete the trials.
- @param turnAroundTimeLimit         The time limit to complete the turn around step, passing -1 to this parameter will bypass the turnAroundTime step.
+ @param turnAroundTimeLimit         The time limit to complete the turn around step, passing a negative value to this parameter will bypass the turnAroundTime step.
  @param includeAssistiveDeviceForm  A Boolean value that indicates whether to inlude the form step
  about the usage of an assistive device.
  @param options                     Options that affect the features of the predefined task.

--- a/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.m
+++ b/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.m
@@ -1529,7 +1529,7 @@ NSString *const ORKTimedWalkTrial2StepIdentifier = @"timed.walk.trial2";
         }
 
         {
-            if (turnAroundTimeLimit >= 0) {
+            if (turnAroundTimeLimit > 0) {
                 ORKTimedWalkStep *step = [[ORKTimedWalkStep alloc] initWithIdentifier:ORKTimedWalkTurnAroundStepIdentifier];
                 step.title = ORKLocalizedString(@"TIMED_WALK_INSTRUCTION_TURN", nil);
                 step.text = ORKLocalizedString(@"TIMED_WALK_INSTRUCTION_TEXT", nil);

--- a/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.m
+++ b/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.m
@@ -1458,12 +1458,12 @@ NSString *const ORKTimedWalkTrial2StepIdentifier = @"timed.walk.trial2";
                                                             answerFormat:answerFormat1];
         formItem1.optional = NO;
 
-        NSArray *textChoices = @[ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE", nil),
-                                 ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_2", nil),
-                                 ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_3", nil),
-                                 ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_4", nil),
-                                 ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_5", nil),
-                                 ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_6", nil)];
+        NSArray *textChoices = @[ [ORKTextChoice choiceWithText:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE", nil) value:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE", nil)],
+                                  [ORKTextChoice choiceWithText:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_2", nil) value:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_2", nil)],
+                                  [ORKTextChoice choiceWithText:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_3", nil) value:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_3", nil)],
+                                  [ORKTextChoice choiceWithText:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_4", nil) value:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_4", nil)],
+                                  [ORKTextChoice choiceWithText:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_5", nil) value:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_5", nil)],
+                                  [ORKTextChoice choiceWithText:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_6", nil) value:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_6", nil)] ];
         ORKAnswerFormat *answerFormat2 = [ORKAnswerFormat valuePickerAnswerFormatWithTextChoices:textChoices];
         ORKFormItem *formItem2 = [[ORKFormItem alloc] initWithIdentifier:ORKTimedWalkFormAssistanceStepIdentifier
                                                                     text:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_TITLE", nil)

--- a/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.m
+++ b/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.m
@@ -1458,12 +1458,12 @@ NSString *const ORKTimedWalkTrial2StepIdentifier = @"timed.walk.trial2";
                                                             answerFormat:answerFormat1];
         formItem1.optional = NO;
 
-        NSArray *textChoices = @[ [ORKTextChoice choiceWithText:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE", nil) value:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE", nil)],
-                                  [ORKTextChoice choiceWithText:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_2", nil) value:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_2", nil)],
-                                  [ORKTextChoice choiceWithText:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_3", nil) value:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_3", nil)],
-                                  [ORKTextChoice choiceWithText:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_4", nil) value:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_4", nil)],
-                                  [ORKTextChoice choiceWithText:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_5", nil) value:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_5", nil)],
-                                  [ORKTextChoice choiceWithText:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_6", nil) value:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_6", nil)] ];
+        NSArray *textChoices = @[ [ORKTextChoice choiceWithText:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE", nil) value:@"TIMED_WALK_QUESTION_2_CHOICE"],
+                                  [ORKTextChoice choiceWithText:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_2", nil) value:@"TIMED_WALK_QUESTION_2_CHOICE_2"],
+                                  [ORKTextChoice choiceWithText:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_3", nil) value:@"TIMED_WALK_QUESTION_2_CHOICE_3"],
+                                  [ORKTextChoice choiceWithText:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_4", nil) value:@"TIMED_WALK_QUESTION_2_CHOICE_4"],
+                                  [ORKTextChoice choiceWithText:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_5", nil) value:@"TIMED_WALK_QUESTION_2_CHOICE_5"],
+                                  [ORKTextChoice choiceWithText:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_6", nil) value:@"TIMED_WALK_QUESTION_2_CHOICE_6"] ];
         ORKAnswerFormat *answerFormat2 = [ORKAnswerFormat valuePickerAnswerFormatWithTextChoices:textChoices];
         ORKFormItem *formItem2 = [[ORKFormItem alloc] initWithIdentifier:ORKTimedWalkFormAssistanceStepIdentifier
                                                                     text:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_TITLE", nil)
@@ -1529,7 +1529,7 @@ NSString *const ORKTimedWalkTrial2StepIdentifier = @"timed.walk.trial2";
         }
 
         {
-            if (turnAroundTimeLimit != -1) {
+            if (turnAroundTimeLimit >= 0) {
                 ORKTimedWalkStep *step = [[ORKTimedWalkStep alloc] initWithIdentifier:ORKTimedWalkTurnAroundStepIdentifier];
                 step.title = ORKLocalizedString(@"TIMED_WALK_INSTRUCTION_TURN", nil);
                 step.text = ORKLocalizedString(@"TIMED_WALK_INSTRUCTION_TEXT", nil);

--- a/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.m
+++ b/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.m
@@ -1411,7 +1411,6 @@ NSString *const ORKReactionTimeStepIdentifier = @"reactionTime";
     return task;
 }
 
-
 #pragma mark - timedWalkTask
 
 NSString *const ORKTimedWalkFormStepIdentifier = @"timed.walk.form";
@@ -1420,141 +1419,6 @@ NSString *const ORKTimedWalkFormAssistanceStepIdentifier = @"timed.walk.form.ass
 NSString *const ORKTimedWalkTrial1StepIdentifier = @"timed.walk.trial1";
 NSString *const ORKTimedWalkTurnAroundStepIdentifier = @"timed.walk.turn.around";
 NSString *const ORKTimedWalkTrial2StepIdentifier = @"timed.walk.trial2";
-
-+ (ORKOrderedTask *)timedWalkTaskWithIdentifier:(NSString *)identifier
-                         intendedUseDescription:(nullable NSString *)intendedUseDescription
-                               distanceInMeters:(double)distanceInMeters
-                                      timeLimit:(NSTimeInterval)timeLimit
-                     includeAssistiveDeviceForm:(BOOL)includeAssistiveDeviceForm
-                                        options:(ORKPredefinedTaskOption)options {
-
-    NSMutableArray *steps = [NSMutableArray array];
-
-    NSLengthFormatter *lengthFormatter = [NSLengthFormatter new];
-    lengthFormatter.numberFormatter.maximumFractionDigits = 1;
-    lengthFormatter.numberFormatter.maximumSignificantDigits = 3;
-    NSString *formattedLength = [lengthFormatter stringFromMeters:distanceInMeters];
-
-    if (!(options & ORKPredefinedTaskOptionExcludeInstructions)) {
-        {
-            ORKInstructionStep *step = [[ORKInstructionStep alloc] initWithIdentifier:ORKInstruction0StepIdentifier];
-            step.title = ORKLocalizedString(@"TIMED_WALK_TITLE", nil);
-            step.text = intendedUseDescription;
-            step.detailText = ORKLocalizedString(@"TIMED_WALK_INTRO_DETAIL", nil);
-            step.shouldTintImages = YES;
-
-            ORKStepArrayAddStep(steps, step);
-        }
-    }
-
-    if (includeAssistiveDeviceForm) {
-        ORKFormStep *step = [[ORKFormStep alloc] initWithIdentifier:ORKTimedWalkFormStepIdentifier
-                                                              title:ORKLocalizedString(@"TIMED_WALK_FORM_TITLE", nil)
-                                                               text:ORKLocalizedString(@"TIMED_WALK_FORM_TEXT", nil)];
-
-        ORKAnswerFormat *answerFormat1 = [ORKAnswerFormat booleanAnswerFormat];
-        ORKFormItem *formItem1 = [[ORKFormItem alloc] initWithIdentifier:ORKTimedWalkFormAFOStepIdentifier
-                                                                    text:ORKLocalizedString(@"TIMED_WALK_QUESTION_TEXT", nil)
-                                                            answerFormat:answerFormat1];
-        formItem1.optional = NO;
-
-        NSArray *textChoices = @[ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE", nil),
-                                 ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_2", nil),
-                                 ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_3", nil),
-                                 ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_4", nil),
-                                 ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_5", nil),
-                                 ORKLocalizedString(@"TIMED_WALK_QUESTION_2_CHOICE_6", nil)];
-        ORKAnswerFormat *answerFormat2 = [ORKAnswerFormat valuePickerAnswerFormatWithTextChoices:textChoices];
-        ORKFormItem *formItem2 = [[ORKFormItem alloc] initWithIdentifier:ORKTimedWalkFormAssistanceStepIdentifier
-                                                                    text:ORKLocalizedString(@"TIMED_WALK_QUESTION_2_TITLE", nil)
-                                                            answerFormat:answerFormat2];
-        formItem2.placeholder = ORKLocalizedString(@"TIMED_WALK_QUESTION_2_TEXT", nil);
-        formItem2.optional = NO;
-
-        step.formItems = @[formItem1, formItem2];
-        step.optional = NO;
-
-        ORKStepArrayAddStep(steps, step);
-    }
-
-    if (!(options & ORKPredefinedTaskOptionExcludeInstructions)) {
-        {
-            ORKInstructionStep *step = [[ORKInstructionStep alloc] initWithIdentifier:ORKInstruction1StepIdentifier];
-            step.title = ORKLocalizedString(@"TIMED_WALK_TITLE", nil);
-            step.text = [NSString localizedStringWithFormat:ORKLocalizedString(@"TIMED_WALK_INTRO_2_TEXT_%@", nil), formattedLength];
-            step.detailText = ORKLocalizedString(@"TIMED_WALK_INTRO_2_DETAIL", nil);
-            step.image = [UIImage imageNamed:@"timer" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
-            step.shouldTintImages = YES;
-
-            ORKStepArrayAddStep(steps, step);
-        }
-    }
-
-    {
-        ORKCountdownStep *step = [[ORKCountdownStep alloc] initWithIdentifier:ORKCountdownStepIdentifier];
-        step.stepDuration = 5.0;
-
-        ORKStepArrayAddStep(steps, step);
-    }
-    
-    {
-        NSMutableArray *recorderConfigurations = [NSMutableArray array];
-        if (!(options & ORKPredefinedTaskOptionExcludePedometer)) {
-            [recorderConfigurations addObject:[[ORKPedometerRecorderConfiguration alloc] initWithIdentifier:ORKPedometerRecorderIdentifier]];
-        }
-        if (!(options & ORKPredefinedTaskOptionExcludeAccelerometer)) {
-            [recorderConfigurations addObject:[[ORKAccelerometerRecorderConfiguration alloc] initWithIdentifier:ORKAccelerometerRecorderIdentifier
-                                                                                                      frequency:100]];
-        }
-        if (!(options & ORKPredefinedTaskOptionExcludeDeviceMotion)) {
-            [recorderConfigurations addObject:[[ORKDeviceMotionRecorderConfiguration alloc] initWithIdentifier:ORKDeviceMotionRecorderIdentifier
-                                                                                                     frequency:100]];
-        }
-        if (! (options & ORKPredefinedTaskOptionExcludeLocation)) {
-            [recorderConfigurations addObject:[[ORKLocationRecorderConfiguration alloc] initWithIdentifier:ORKLocationRecorderIdentifier]];
-        }
-
-        {
-            ORKTimedWalkStep *step = [[ORKTimedWalkStep alloc] initWithIdentifier:ORKTimedWalkTrial1StepIdentifier];
-            step.title = [[NSString alloc] initWithFormat:ORKLocalizedString(@"TIMED_WALK_INSTRUCTION_%@", nil), formattedLength];
-            step.text = ORKLocalizedString(@"TIMED_WALK_INSTRUCTION_TEXT", nil);
-            step.spokenInstruction = step.title;
-            step.recorderConfigurations = recorderConfigurations;
-            step.distanceInMeters = distanceInMeters;
-            step.shouldTintImages = YES;
-            step.image = [UIImage imageNamed:@"timed-walkingman-outbound" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
-            step.stepDuration = timeLimit == 0 ? CGFLOAT_MAX : timeLimit;
-
-            ORKStepArrayAddStep(steps, step);
-        }
-
-        {
-            ORKTimedWalkStep *step = [[ORKTimedWalkStep alloc] initWithIdentifier:ORKTimedWalkTrial2StepIdentifier];
-            step.title = [[NSString alloc] initWithFormat:ORKLocalizedString(@"TIMED_WALK_INSTRUCTION_2", nil), formattedLength];
-            step.text = ORKLocalizedString(@"TIMED_WALK_INSTRUCTION_TEXT", nil);
-            step.spokenInstruction = step.title;
-            step.recorderConfigurations = recorderConfigurations;
-            step.distanceInMeters = distanceInMeters;
-            step.shouldTintImages = YES;
-            step.image = [UIImage imageNamed:@"timed-walkingman-return" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
-            step.stepDuration = timeLimit == 0 ? CGFLOAT_MAX : timeLimit;
-
-            ORKStepArrayAddStep(steps, step);
-        }
-    }
-
-    if (!(options & ORKPredefinedTaskOptionExcludeConclusion)) {
-        ORKInstructionStep *step = [self makeCompletionStep];
-
-        ORKStepArrayAddStep(steps, step);
-    }
-
-    ORKOrderedTask *task = [[ORKOrderedTask alloc] initWithIdentifier:identifier steps:steps];
-    return task;
-}
-
-
-#pragma mark - timedWalkTask
 
 + (ORKOrderedTask *)timedWalkTaskWithIdentifier:(NSString *)identifier
                          intendedUseDescription:(nullable NSString *)intendedUseDescription
@@ -1665,17 +1529,19 @@ NSString *const ORKTimedWalkTrial2StepIdentifier = @"timed.walk.trial2";
         }
 
         {
-            ORKTimedWalkStep *step = [[ORKTimedWalkStep alloc] initWithIdentifier:ORKTimedWalkTurnAroundStepIdentifier];
-            step.title = ORKLocalizedString(@"TIMED_WALK_INSTRUCTION_TURN", nil);
-            step.text = ORKLocalizedString(@"TIMED_WALK_INSTRUCTION_TEXT", nil);
-            step.spokenInstruction = step.title;
-            step.recorderConfigurations = recorderConfigurations;
-            step.distanceInMeters = 1;
-            step.shouldTintImages = YES;
-            step.image = [UIImage imageNamed:@"turnaround" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
-            step.stepDuration = turnAroundTimeLimit == 0 ? CGFLOAT_MAX : turnAroundTimeLimit;
+            if (turnAroundTimeLimit != -1) {
+                ORKTimedWalkStep *step = [[ORKTimedWalkStep alloc] initWithIdentifier:ORKTimedWalkTurnAroundStepIdentifier];
+                step.title = ORKLocalizedString(@"TIMED_WALK_INSTRUCTION_TURN", nil);
+                step.text = ORKLocalizedString(@"TIMED_WALK_INSTRUCTION_TEXT", nil);
+                step.spokenInstruction = step.title;
+                step.recorderConfigurations = recorderConfigurations;
+                step.distanceInMeters = 1;
+                step.shouldTintImages = YES;
+                step.image = [UIImage imageNamed:@"turnaround" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
+                step.stepDuration = turnAroundTimeLimit == 0 ? CGFLOAT_MAX : turnAroundTimeLimit;
 
-            ORKStepArrayAddStep(steps, step);
+                ORKStepArrayAddStep(steps, step);
+            }
         }
 
         {

--- a/ResearchKit/ORKDeprecated.h
+++ b/ResearchKit/ORKDeprecated.h
@@ -32,9 +32,26 @@
 #import "ORKAnswerFormat.h"
 #import "ORKOrderedTask.h"
 #import "ORKRegistrationStep.h"
+#import "ORKOrderedTask+ORKPredefinedActiveTask.h"
 
 
 NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Deprecated to avoid duplicate code paths.
+ */
+@interface ORKOrderedTask (Deprecated)
+
++ (ORKOrderedTask *)timedWalkTaskWithIdentifier:(NSString *)identifier
+                         intendedUseDescription:(nullable NSString *)intendedUseDescription
+                               distanceInMeters:(double)distanceInMeters
+                                      timeLimit:(NSTimeInterval)timeLimit
+                     includeAssistiveDeviceForm:(BOOL)includeAssistiveDeviceForm
+                                        options:(ORKPredefinedTaskOption)options
+__attribute__((deprecated("Use '+timedWalkTaskWithIdentifier:intendedUseDescription:distanceInMeters:timeLimit:turnAroundTimeLimit:includeAssistiveDeviceForm:options' instead.",
+                          "timedWalkTask")));
+
+@end
 
 /**
  Deprecated in v1.5.0 (scheduled for removal in v1.6.0).

--- a/ResearchKit/ORKDeprecated.m
+++ b/ResearchKit/ORKDeprecated.m
@@ -44,6 +44,25 @@
 
 @end
 
+@implementation ORKOrderedTask (Deprecated)
+
++ (ORKOrderedTask *)timedWalkTaskWithIdentifier:(NSString *)identifier
+                         intendedUseDescription:(nullable NSString *)intendedUseDescription
+                               distanceInMeters:(double)distanceInMeters
+                                      timeLimit:(NSTimeInterval)timeLimit
+                     includeAssistiveDeviceForm:(BOOL)includeAssistiveDeviceForm
+                                        options:(ORKPredefinedTaskOption)options {
+    return [self timedWalkTaskWithIdentifier:identifier
+                      intendedUseDescription:intendedUseDescription
+                            distanceInMeters:distanceInMeters
+                                   timeLimit:timeLimit
+                         turnAroundTimeLimit:-1
+                  includeAssistiveDeviceForm:includeAssistiveDeviceForm
+                                     options:options];
+}
+
+@end
+
 
 @implementation ORKTextAnswerFormat (Deprecated)
 


### PR DESCRIPTION
1) deprecate an initializer to avoid duplicate code paths
2) use ORKText choice for picker view instead of NSString which was causing a run time crash