### PR TITLE
Suppress ORKPasscodeTextField input overflow

### DIFF
--- a/ResearchKit/Common/ORKPasscodeStepViewController.m
+++ b/ResearchKit/Common/ORKPasscodeStepViewController.m
@@ -638,7 +638,9 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
     
     ORKPasscodeTextField *passcodeTextField = _passcodeStepView.textField;
-    [passcodeTextField insertText:string];
+    if (passcodeTextField.text.length < passcodeTextField.numberOfDigits) {
+        [passcodeTextField insertText:string];
+    }
 
     // Disable input while changing states.
     if (_isChangingState) {


### PR DESCRIPTION
This patches the undesirable behavior that the ORKPasscodeTextField displays trailing, excessive digits if keystrokes are registered in quick succession.

![orkpasscodetextfield_overflow](https://user-images.githubusercontent.com/7240152/37239391-b44c48a6-2475-11e8-9fcc-9dcbb620ae45.png)
