### PR TITLE
Fixed position of ORK_CLASS_AVAILABLE

### DIFF
--- a/ResearchKit/ActiveTasks/ORKHealthClinicalTypeRecorder.h
+++ b/ResearchKit/ActiveTasks/ORKHealthClinicalTypeRecorder.h
@@ -40,8 +40,8 @@ NS_ASSUME_NONNULL_BEGIN
  The `ORKHealthClinicalTypeRecorder` class represents a recorder for collecting health records data from HealthKit during
  an active task.
  */
-ORK_CLASS_AVAILABLE
 #if defined(__IPHONE_12_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_12_0
+ORK_CLASS_AVAILABLE
 @interface ORKHealthClinicalTypeRecorder : ORKRecorder
 
 @property (nonatomic, copy, readonly) HKClinicalType *healthClinicalType;

--- a/ResearchKit/ResearchKit_Private.h
+++ b/ResearchKit/ResearchKit_Private.h
@@ -105,9 +105,7 @@
 #import <ResearchKit/ORKStreamingAudioRecorder.h>
 #import <ResearchKit/ORKDeviceMotionRecorder.h>
 #import <ResearchKit/ORKHealthQuantityTypeRecorder.h>
-#if defined(__IPHONE_12_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_12_0
 #import <ResearchKit/ORKHealthClinicalTypeRecorder.h>
-#endif
 #import <ResearchKit/ORKLocationRecorder.h>
 #import <ResearchKit/ORKPedometerRecorder.h>
 #import <ResearchKit/ORKTouchRecorder.h>


### PR DESCRIPTION
When building project with iOS SDK lower than 12, it causes compilation error because `ORK_CLASS_AVAILABLE` was expecting class which in fact was omitted by `#if defined(__IPHONE_12_0)...`

It was breaking compilation mostly for CocoaPods, which reads all headers specified in .podspec file.
Additionally `ResearchKit_Private.h` was simplified because validation is done directly in `ORKHealthClinicalTypeRecorder.h` file.

Thanks for help to @alistra