### PR TITLE
Option to require scrolling to the bottom of ORKConsentReviewStep

### DIFF
--- a/ResearchKit/Consent/ORKConsentReviewController.h
+++ b/ResearchKit/Consent/ORKConsentReviewController.h
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ORKConsentReviewController : UIViewController
 
-- (instancetype)initWithHTML:(NSString *)html delegate:(id<ORKConsentReviewControllerDelegate>)delegate;
+- (instancetype)initWithHTML:(NSString *)html delegate:(id<ORKConsentReviewControllerDelegate>)delegate requiresScrollToBottom:(BOOL)requiresScrollToBottom;
 
 @property (nonatomic, strong, nullable) UIWebView *webView;
 

--- a/ResearchKit/Consent/ORKConsentReviewStep.h
+++ b/ResearchKit/Consent/ORKConsentReviewStep.h
@@ -67,30 +67,12 @@ ORK_CLASS_AVAILABLE
 /**
  Returns an initialized consent review step using the specified identifier, signature, and consent document.
 
- @param identifier             The identifier for the step.
- @param signature              The signature to be collected, if any.
- @param consentDocument        The consent document to be reviewed.
- @param requiresScrollToBottom Pass `YES` to require the user to scroll to the bottom of the consent
-                                   document before enabling the `Agree` button.
- 
- @return An initialized consent review step.
- */
-- (instancetype)initWithIdentifier:(NSString *)identifier
-                         signature:(nullable ORKConsentSignature *)signature
-                        inDocument:(ORKConsentDocument *)consentDocument
-            requiresScrollToBottom:(BOOL)requiresScrollToBottom;
-
-/**
-Returns initialized consent review step using the specified identifier, signature, and consent document.
-
-This method is a convenience initializer.
-
  @param identifier      The identifier for the step.
  @param signature       The signature to be collected, if any.
  @param consentDocument The consent document to be reviewed.
-
-@return An initialized consent review step.
-*/
+ 
+ @return An initialized consent review step.
+ */
 - (instancetype)initWithIdentifier:(NSString *)identifier
                          signature:(nullable ORKConsentSignature *)signature
                         inDocument:(ORKConsentDocument *)consentDocument;

--- a/ResearchKit/Consent/ORKConsentReviewStep.h
+++ b/ResearchKit/Consent/ORKConsentReviewStep.h
@@ -75,7 +75,8 @@ ORK_CLASS_AVAILABLE
  */
 - (instancetype)initWithIdentifier:(NSString *)identifier
                          signature:(nullable ORKConsentSignature *)signature
-                        inDocument:(ORKConsentDocument *)consentDocument;
+                        inDocument:(ORKConsentDocument *)consentDocument
+            requiresScrollToBottom:(BOOL)requiresScrollToBottom;
 
 /// @name Properties
 
@@ -95,6 +96,11 @@ ORK_CLASS_AVAILABLE
  the consent document.
  */
 @property (nonatomic, strong, readonly, nullable) ORKConsentSignature *signature;
+
+/**
+ When set to YES, the consent document must be scrolled to the bottom to enable the `Agree` button.
+ */
+@property (nonatomic) BOOL requiresScrollToBottom;
 
 /**
  A user-visible description of the reason for agreeing to consent in a localized string.

--- a/ResearchKit/Consent/ORKConsentReviewStep.h
+++ b/ResearchKit/Consent/ORKConsentReviewStep.h
@@ -67,9 +67,11 @@ ORK_CLASS_AVAILABLE
 /**
  Returns an initialized consent review step using the specified identifier, signature, and consent document.
 
- @param identifier      The identifier for the step.
- @param signature       The signature to be collected, if any.
- @param consentDocument The consent document to be reviewed.
+ @param identifier             The identifier for the step.
+ @param signature              The signature to be collected, if any.
+ @param consentDocument        The consent document to be reviewed.
+ @param requiresScrollToBottom Pass `YES` to require the user to scroll to the bottom of the consent
+                                   document before enabling the `Agree` button.
  
  @return An initialized consent review step.
  */
@@ -77,6 +79,21 @@ ORK_CLASS_AVAILABLE
                          signature:(nullable ORKConsentSignature *)signature
                         inDocument:(ORKConsentDocument *)consentDocument
             requiresScrollToBottom:(BOOL)requiresScrollToBottom;
+
+/**
+Returns initialized consent review step using the specified identifier, signature, and consent document.
+
+This method is a convenience initializer.
+
+ @param identifier      The identifier for the step.
+ @param signature       The signature to be collected, if any.
+ @param consentDocument The consent document to be reviewed.
+
+@return An initialized consent review step.
+*/
+- (instancetype)initWithIdentifier:(NSString *)identifier
+                         signature:(nullable ORKConsentSignature *)signature
+                        inDocument:(ORKConsentDocument *)consentDocument;
 
 /// @name Properties
 

--- a/ResearchKit/Consent/ORKConsentReviewStep.m
+++ b/ResearchKit/Consent/ORKConsentReviewStep.m
@@ -47,16 +47,6 @@
     return [ORKConsentReviewStepViewController class];
 }
 
-- (instancetype)initWithIdentifier:(NSString *)identifier signature:(ORKConsentSignature *)signature inDocument:(ORKConsentDocument *)consentDocument requiresScrollToBottom:(BOOL)requiresScrollToBottom {
-    self = [super initWithIdentifier:identifier];
-    if (self) {
-        _consentDocument = consentDocument;
-        _signature = signature;
-        _requiresScrollToBottom = requiresScrollToBottom;
-    }
-    return self;
-}
-
 - (instancetype)initWithIdentifier:(NSString *)identifier signature:(ORKConsentSignature *)signature inDocument:(ORKConsentDocument *)consentDocument {
     self = [super initWithIdentifier:identifier];
     if (self) {

--- a/ResearchKit/Consent/ORKConsentReviewStep.m
+++ b/ResearchKit/Consent/ORKConsentReviewStep.m
@@ -57,6 +57,16 @@
     return self;
 }
 
+- (instancetype)initWithIdentifier:(NSString *)identifier signature:(ORKConsentSignature *)signature inDocument:(ORKConsentDocument *)consentDocument {
+    self = [super initWithIdentifier:identifier];
+    if (self) {
+        _consentDocument = consentDocument;
+        _signature = signature;
+        _requiresScrollToBottom = NO;
+    }
+    return self;
+}
+
 - (instancetype)copyWithZone:(NSZone *)zone {
     ORKConsentReviewStep *step = [super copyWithZone:zone];
     step->_consentDocument = self.consentDocument;

--- a/ResearchKit/Consent/ORKConsentReviewStep.m
+++ b/ResearchKit/Consent/ORKConsentReviewStep.m
@@ -47,11 +47,12 @@
     return [ORKConsentReviewStepViewController class];
 }
 
-- (instancetype)initWithIdentifier:(NSString *)identifier signature:(ORKConsentSignature *)signature inDocument:(ORKConsentDocument *)consentDocument {
+- (instancetype)initWithIdentifier:(NSString *)identifier signature:(ORKConsentSignature *)signature inDocument:(ORKConsentDocument *)consentDocument requiresScrollToBottom:(BOOL)requiresScrollToBottom {
     self = [super initWithIdentifier:identifier];
     if (self) {
         _consentDocument = consentDocument;
         _signature = signature;
+        _requiresScrollToBottom = requiresScrollToBottom;
     }
     return self;
 }
@@ -61,6 +62,7 @@
     step->_consentDocument = self.consentDocument;
     step->_signature = self.signature;
     step->_reasonForConsent = self.reasonForConsent;
+    step->_requiresScrollToBottom = self.requiresScrollToBottom;
     return step;
 }
 
@@ -70,6 +72,7 @@
         ORK_DECODE_OBJ_CLASS(aDecoder, consentDocument, ORKConsentDocument);
         ORK_DECODE_OBJ_CLASS(aDecoder, signature, ORKConsentSignature);
         ORK_DECODE_OBJ_CLASS(aDecoder, reasonForConsent, NSString);
+        ORK_DECODE_BOOL(aDecoder, requiresScrollToBottom);
     }
     return self;
 }
@@ -79,6 +82,7 @@
     ORK_ENCODE_OBJ(aCoder, consentDocument);
     ORK_ENCODE_OBJ(aCoder, signature);
     ORK_ENCODE_OBJ(aCoder, reasonForConsent);
+    ORK_ENCODE_BOOL(aCoder, requiresScrollToBottom);
 }
 
 + (BOOL)supportsSecureCoding {
@@ -92,11 +96,12 @@
     return (isParentSame &&
             ORKEqualObjects(self.consentDocument, castObject.consentDocument) &&
             ORKEqualObjects(self.signature, castObject.signature) &&
-            ORKEqualObjects(self.reasonForConsent, castObject.reasonForConsent));
+            ORKEqualObjects(self.reasonForConsent, castObject.reasonForConsent)) &&
+            (self.requiresScrollToBottom == castObject.requiresScrollToBottom);
 }
 
 - (NSUInteger)hash {
-    return super.hash ^ self.consentDocument.hash ^ self.signature.hash ^ self.reasonForConsent.hash;
+    return super.hash ^ self.consentDocument.hash ^ self.signature.hash ^ self.reasonForConsent.hash ^ (_requiresScrollToBottom ? 0xf : 0x0);
 }
 
 - (BOOL)showsProgress {

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -231,7 +231,7 @@ static NSString *const _FamilyNameIdentifier = @"family";
     NSString *html = [document mobileHTMLWithTitle:ORKLocalizedString(@"CONSENT_REVIEW_TITLE", nil)
                                              detail:ORKLocalizedString(@"CONSENT_REVIEW_INSTRUCTION", nil)];
 
-    ORKConsentReviewController *reviewViewController = [[ORKConsentReviewController alloc] initWithHTML:html delegate:self];
+    ORKConsentReviewController *reviewViewController = [[ORKConsentReviewController alloc] initWithHTML:html delegate:self requiresScrollToBottom:[[self consentReviewStep] requiresScrollToBottom]];
     reviewViewController.localizedReasonForConsent = [[self consentReviewStep] reasonForConsent];
     return reviewViewController;
 }

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -1346,7 +1346,7 @@ enum TaskListRow: Int, CustomStringConvertible {
         */
         let signature = consentDocument.signatures!.first
         
-        let reviewConsentStep = ORKConsentReviewStep(identifier: String(describing:Identifier.consentReviewStep), signature: signature, in: consentDocument)
+        let reviewConsentStep = ORKConsentReviewStep(identifier: String(describing:Identifier.consentReviewStep), signature: signature, in: consentDocument, requiresScrollToBottom: true);
         
         // In a real application, you would supply your own localized text.
         reviewConsentStep.title = NSLocalizedString("Consent Document", comment: "")

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -1346,7 +1346,8 @@ enum TaskListRow: Int, CustomStringConvertible {
         */
         let signature = consentDocument.signatures!.first
         
-        let reviewConsentStep = ORKConsentReviewStep(identifier: String(describing:Identifier.consentReviewStep), signature: signature, in: consentDocument, requiresScrollToBottom: true);
+        let reviewConsentStep = ORKConsentReviewStep(identifier: String(describing:Identifier.consentReviewStep), signature: signature, in: consentDocument)
+        reviewConsentStep.requiresScrollToBottom = true
         
         // In a real application, you would supply your own localized text.
         reviewConsentStep.title = NSLocalizedString("Consent Document", comment: "")


### PR DESCRIPTION
This adds an additional property to `ORKConsentReviewStep` called `requresScrollToBottom`.  When set to true, the "Agree" button will not be activated until the user scrolls all the way to thee bottom of the content.  This is for a particular research project we are working with where it's very important that the participant fully read and understand the consent - and we figured it would make sense to contribute back to ResearchKit in case someone else could use the feature.

![mustscroll](https://user-images.githubusercontent.com/1008462/42818157-b8e9946a-8995-11e8-8c5e-410837fc47b5.gif)
