### PR TITLE
Add accessibility labels to PDF Viewer action buttons.

### DIFF
--- a/ResearchKit/Common/ORKPDFViewerStepView.m
+++ b/ResearchKit/Common/ORKPDFViewerStepView.m
@@ -390,6 +390,8 @@ const CGFloat PDFhideViewAnimationDuration = 0.5;
     
     _pdfActionsView.translatesAutoresizingMaskIntoConstraints = NO;
     [_parentStackView addArrangedSubview:_pdfActionsView];
+    
+    [self updateActionButtonAccessibilityLabels];
 }
 
 - (void)setupPDFStackView {
@@ -511,6 +513,14 @@ const CGFloat PDFhideViewAnimationDuration = 0.5;
     _pdfActionsView.annotationActionButton.alpha = !_isFreehandDrawingActive ? PDFInactiveButtonAlpha : 1.0;
     _pdfActionsView.searchActionButton.alpha = _searchBar.isHidden ? PDFInactiveButtonAlpha : 1.0;
     _pdfActionsView.shareActionButton.alpha = PDFInactiveButtonAlpha;
+    [self updateActionButtonAccessibilityLabels];
+}
+
+- (void)updateActionButtonAccessibilityLabels {
+    _pdfActionsView.thumbnailActionButton.accessibilityLabel = _pdfThumbnailView.isHidden ?ORKLocalizedString(@"AX_BUTTON_SHOW_PDF_THUMBNAIL" , nil) : ORKLocalizedString(@"AX_BUTTON_HIDE_PDF_THUMBNAIL", nil);
+    _pdfActionsView.annotationActionButton.accessibilityLabel = ORKLocalizedString(@"AX_BUTTON_ANNOTATE" , nil);
+    _pdfActionsView.searchActionButton.accessibilityLabel = _searchBar.isHidden ? ORKLocalizedString(@"AX_BUTTON_SHOW_SEARCH", nil) : ORKLocalizedString(@"AX_BUTTON_HIDE_SEARCH", nil);
+    _pdfActionsView.shareActionButton.accessibilityLabel = ORKLocalizedString(@"AX_BUTTON_SHARE", nil);
 }
 
 - (void)shareButtonAction {

--- a/ResearchKit/Localized/en.lproj/ResearchKit.strings
+++ b/ResearchKit/Localized/en.lproj/ResearchKit.strings
@@ -572,6 +572,13 @@
 
 /* Accessibility */
 "AX_BUTTON_BACK" = "Back";
+"AX_BUTTON_SHOW_PDF_THUMBNAIL" = "Show PDF Thumbnail";
+"AX_BUTTON_HIDE_PDF_THUMBNAIL" = "Hide PDF Thumbnail";
+"AX_BUTTON_ANNOTATE" = "Annotate";
+"AX_BUTTON_SHOW_SEARCH" = "Show Search Bar";
+"AX_BUTTON_HIDE_SEARCH" = "Hide Search Bar";
+"AX_BUTTON_SHARE" = "Share";
+
 
 "AX_IMAGE_ILLUSTRATION" = "Illustration of %@";
 


### PR DESCRIPTION
Resolves rdar://problem/42255725. Tested on iPhone 8.