### PR TITLE
Use fixed accessibility label for the completion view.

### DIFF
--- a/ResearchKit/Common/ORKCompletionStepViewController.m
+++ b/ResearchKit/Common/ORKCompletionStepViewController.m
@@ -135,6 +135,10 @@ static const CGFloat TickViewSize = 122;
     return [super accessibilityTraits] | UIAccessibilityTraitImage;
 }
 
+- (NSString *)accessibilityLabel {
+    return ORKLocalizedString(@"AX_COMPLETION_ILLUSTRATION", nil);
+}
+
 @end
 
 
@@ -164,10 +168,6 @@ static const CGFloat TickViewSize = 122;
     if (animated) {
         [_completionStepView setAnimationPoint:1 animated:YES];
     }
-    
-    UILabel *captionLabel = self.stepView.headerView.captionLabel;
-    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, captionLabel);
-    _completionStepView.accessibilityLabel = [NSString localizedStringWithFormat:ORKLocalizedString(@"AX_IMAGE_ILLUSTRATION", nil), captionLabel.accessibilityLabel];
 }
 
 - (void)setCheckmarkColor:(UIColor *)checkmarkColor {

--- a/ResearchKit/Localized/en.lproj/ResearchKit.strings
+++ b/ResearchKit/Localized/en.lproj/ResearchKit.strings
@@ -573,7 +573,7 @@
 /* Accessibility */
 "AX_BUTTON_BACK" = "Back";
 
-"AX_IMAGE_ILLUSTRATION" = "Illustration of %@";
+"AX_COMPLETION_ILLUSTRATION" = "Illustration of a check mark in a blue circle conveying success";
 
 "AX_SIGNVIEW_LABEL" = "Designated signature field";
 "AX_SIGNVIEW_HINT" = "Touch the screen and move your finger to sign";


### PR DESCRIPTION
The completion view looks like it's now just always a check in a blue
circle. Update the label to a fixed string. This avoids interpolating
nil, which was happening because captionLabel is not visible here (and
as such moving focus to it with a screen change is also inappropriate).

Resolves rdar://problem/42294298. Tested on iPhone 8.