### PR TITLE
Use UIAccessibilityTraitStartsMediaSession on the Start Recording button, so that VoiceOver doesn't speak the button title when you activate it.

### DIFF
--- a/ResearchKit/ActiveTasks/ORKSpeechRecognitionContentView.m
+++ b/ResearchKit/ActiveTasks/ORKSpeechRecognitionContentView.m
@@ -117,6 +117,7 @@
     [self.recordButton setTitle:ORKLocalizedString(@"SPEECH_RECOGNITION_START_RECORD_LABEL", nil)
                        forState:UIControlStateNormal];
     self.recordButton.enabled = YES;
+    self.recordButton.accessibilityTraits = UIAccessibilityTraitButton | UIAccessibilityTraitStartsMediaSession;
     [self addSubview:_recordButton];
 }
 

--- a/ResearchKit/ActiveTasks/ORKSpeechRecognitionContentView.m
+++ b/ResearchKit/ActiveTasks/ORKSpeechRecognitionContentView.m
@@ -118,6 +118,7 @@
                        forState:UIControlStateNormal];
     self.recordButton.enabled = YES;
     self.recordButton.accessibilityTraits = UIAccessibilityTraitButton | UIAccessibilityTraitStartsMediaSession;
+    self.recordButton.accessibilityHint = ORKLocalizedString(@"AX_SPEECH_RECOGNITION_START_RECORDING_HINT", nil);
     [self addSubview:_recordButton];
 }
 

--- a/ResearchKit/Localized/en.lproj/ResearchKit.strings
+++ b/ResearchKit/Localized/en.lproj/ResearchKit.strings
@@ -613,4 +613,6 @@
 "AX_GRAPH_AND_SEPARATOR" = " and ";
 "AX_GRAPH_POINT_%@" = "Point: %@";
 
+"AX_SPEECH_RECOGNITION_START_RECORDING_HINT" = "When recording starts, activate a second time to stop recording.";
+
 "AX_AUDIO_BAR_GRAPH" = "Audio Bar Graph";


### PR DESCRIPTION

Resolves rdar://problem/42294456. Tested on iPhone 7.