### PR TITLE
Use UIAccessibilityTraitStartsMediaSession on the Play Audio button, so that VoiceOver doesn't speak the button title when you activate it.

### DIFF
--- a/ResearchKit/ActiveTasks/ORKSpeechInNoiseContentView.m
+++ b/ResearchKit/ActiveTasks/ORKSpeechInNoiseContentView.m
@@ -94,6 +94,7 @@
     [self.playButton setTitle:ORKLocalizedString(@"SPEECH_IN_NOISE_START_AUDIO_LABEL", nil)
                        forState:UIControlStateNormal];
     self.playButton.enabled = YES;
+    self.playButton.accessibilityTraits = UIAccessibilityTraitButton | UIAccessibilityTraitStartsMediaSession;
     [self addSubview:_playButton];
 }
 


### PR DESCRIPTION

Resolves rdar://problem/42294815. Tested on iPhone 7.