### PR TITLE
Accessibility fixes for the transcript view in the Speech Recognition task.

### DIFF
--- a/ResearchKit/Common/ORKAnswerTextView.m
+++ b/ResearchKit/Common/ORKAnswerTextView.m
@@ -38,6 +38,7 @@
 
 @implementation ORKAnswerTextView {
     UITextView *_placeholderTextView;
+    NSArray<UIAccessibilityCustomAction *> *_accessibilityCustomActions;
 }
 
 - (instancetype)init {
@@ -147,6 +148,26 @@
 + (UIFont *)defaultFont {
     UIFontDescriptor *descriptor = [UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleSubheadline];
     return [UIFont systemFontOfSize:((NSNumber *)[descriptor objectForKey:UIFontDescriptorSizeAttribute]).doubleValue + 2.0];
+}
+
+- (BOOL)accessibilityDismissKeyboardForAction:(UIAccessibilityCustomAction *)customAction
+{
+    [self resignFirstResponder];
+    return YES;
+}
+
+- (NSArray<UIAccessibilityCustomAction *> *)accessibilityCustomActions
+{
+    NSArray<UIAccessibilityCustomAction *> *actions = nil;
+    if (self.isFirstResponder) {
+        if (_accessibilityCustomActions == nil) {
+            // Users of accessibility technologies may not be able to tap outside the view to dismiss the keyboard, so provide an action for it here.
+            UIAccessibilityCustomAction *dismissKeyboardAction = [[UIAccessibilityCustomAction alloc] initWithName:ORKLocalizedString(@"AX_DISMISS_KEYBOARD_CUSTOM_ACTION", nil) target:self selector:@selector(accessibilityDismissKeyboardForAction:)];
+            _accessibilityCustomActions = @[dismissKeyboardAction];
+        }
+        actions = _accessibilityCustomActions;
+    }
+    return actions;
 }
 
 @end

--- a/ResearchKit/Common/ORKCustomStepView.m
+++ b/ResearchKit/Common/ORKCustomStepView.m
@@ -317,4 +317,11 @@
     }
 }
 
+- (NSArray *)accessibilityElements
+{
+    // Needed to support the "Edit Transcript" view for speech recognition pages
+    // This works around an issue with navigating table view cells outside of a table view using VoiceOver
+    return self.cell.accessibilityElements;
+}
+
 @end

--- a/ResearchKit/Common/ORKSurveyAnswerCellForText.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForText.m
@@ -104,6 +104,10 @@
         [self applyAnswerFormat];
         
         [self answerDidChange];
+        
+        // Avoid exposing both this cell and its inner text view as elements to accessibility
+        // See also ORKCustomStepView -accessibilityElements
+        self.accessibilityElements = @[self.textView];
     }
     [super prepareView];
 }

--- a/ResearchKit/Localized/en.lproj/ResearchKit.strings
+++ b/ResearchKit/Localized/en.lproj/ResearchKit.strings
@@ -608,6 +608,8 @@
 "AX_TOWER_OF_HANOI_TOWER_CONTAINS" = "Has disk with sizes %@";
 "AX_TOWER_OF_HANOI_TOWER_EMPTY" = "Empty";
 
+"AX_DISMISS_KEYBOARD_CUSTOM_ACTION" = "Dismiss keyboard";
+
 "AX_GRAPH_RANGE_FORMAT_%@_%@" = "Range from %@ to %@";
 "AX_GRAPH_STACK_PREFIX" = "Stack composed of";
 "AX_GRAPH_AND_SEPARATOR" = " and ";


### PR DESCRIPTION

- Expose only one element for the text view.
- Expose a custom action to allow dismissing the keyboard.

Resolves rdar://problem/42294608. Tested on iPhone 7 with VoiceOver and Switch Control.