### PR TITLE
Improvements to Dynamic Type support in the Trail Making Test.

### DIFF
--- a/ResearchKit/ActiveTasks/ORKCountdownStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKCountdownStepViewController.m
@@ -85,6 +85,7 @@ static const CGFloat ProgressIndicatorOuterMargin = 1.0;
         _textLabel.textAlignment = NSTextAlignmentCenter;
         _textLabel.translatesAutoresizingMaskIntoConstraints = NO;
         _textLabel.text =  ORKLocalizedString(@"COUNTDOWN_LABEL", nil);
+        _textLabel.adjustsFontSizeToFitWidth = YES;
         [self addSubview:_textLabel];
         
         _timeLabel = [ORKCountDownViewLabel new];

--- a/ResearchKit/ActiveTasks/ORKTrailmakingContentView.m
+++ b/ResearchKit/ActiveTasks/ORKTrailmakingContentView.m
@@ -99,6 +99,21 @@
 @end
 
 
+@interface ORKTrailmakingButton : ORKRoundTappingButton
+
+@end
+
+
+@implementation ORKTrailmakingButton
+
++ (UIFont *)defaultFont {
+    // Don't scale too much, because all buttons need to fit on screen and be readable within the circle
+    return [[UIFontMetrics metricsForTextStyle:UIFontTextStyleTitle3] scaledFontForFont:[UIFont systemFontOfSize:20.0] maximumPointSize:30.0];
+}
+
+@end
+
+
 @interface ORKTrailmakingContentView ()
 
 @property (nonatomic, strong) ORKTrailmakingTestView* testView;
@@ -121,7 +136,7 @@
         NSMutableArray* buttons = [NSMutableArray array];
         for (int i = 0; i < 13; i++)
         {
-            ORKRoundTappingButton* b = [[ORKRoundTappingButton alloc] init];
+            ORKTrailmakingButton* b = [[ORKTrailmakingButton alloc] init];
             
             NSString* title;
             if ([trailType isEqual:@"A"]) {

--- a/ResearchKit/ActiveTasks/ORKTrailmakingStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKTrailmakingStepViewController.m
@@ -98,6 +98,8 @@
     }
     
     _timerLabel = [[UILabel alloc] init];
+    _timerLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+    _timerLabel.adjustsFontForContentSizeCategory = YES;
     _timerLabel.textAlignment = NSTextAlignmentCenter;
     
     [self.view addSubview:_timerLabel];
@@ -133,7 +135,7 @@
     }
     
     CGRect labelRect = _trailmakingContentView.testArea;
-    labelRect.size.height = 20;
+    labelRect.size.height = [[UIFontMetrics metricsForTextStyle:UIFontTextStyleBody] scaledValueForValue:20];
     [_timerLabel setFrame:labelRect];
     
     CGRect r = _trailmakingContentView.testArea;


### PR DESCRIPTION
- Make sure the text doesn't grow outside the bubbles
- Make sure the "Starting text in" text doesn't get truncated
- Scale the timer and error text