### PR TITLE
Improve usability of tests that use ORKRoundTappingButton.

### DIFF
--- a/ResearchKit/ActiveTasks/ORKTappingContentView.m
+++ b/ResearchKit/ActiveTasks/ORKTappingContentView.m
@@ -84,10 +84,14 @@
         _tapButton1 = [[ORKRoundTappingButton alloc] init];
         _tapButton1.translatesAutoresizingMaskIntoConstraints = NO;
         [_tapButton1 setTitle:ORKLocalizedString(@"TAP_BUTTON_TITLE", nil) forState:UIControlStateNormal];
+        _tapButton1.accessibilityLabel = ORKLocalizedString(@"AX_TAP_BUTTON_1_LABEL", nil);
+        _tapButton1.accessibilityHint = ORKLocalizedString(@"AX_TAP_BUTTON_HINT", nil);
         
         _tapButton2 = [[ORKRoundTappingButton alloc] init];
         _tapButton2.translatesAutoresizingMaskIntoConstraints = NO;
         [_tapButton2 setTitle:ORKLocalizedString(@"TAP_BUTTON_TITLE", nil) forState:UIControlStateNormal];
+        _tapButton2.accessibilityLabel = ORKLocalizedString(@"AX_TAP_BUTTON_2_LABEL", nil);
+        _tapButton2.accessibilityHint = ORKLocalizedString(@"AX_TAP_BUTTON_HINT", nil);
         
         _lastTappedButton = -1;
         

--- a/ResearchKit/ActiveTasks/ORKTappingIntervalStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKTappingIntervalStepViewController.m
@@ -170,6 +170,14 @@
     }
     // Update label
     [_tappingContentView setTapCount:_hitButtonCount];
+    if (UIAccessibilityIsVoiceOverRunning()) {
+        static NSNumberFormatter *TapCountAnnouncementFormatter = nil;
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            TapCountAnnouncementFormatter = [[NSNumberFormatter alloc] init];
+        });
+        UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, [TapCountAnnouncementFormatter stringFromNumber:@(_hitButtonCount)]);
+    }
 }
 
 - (void)releaseTouch:(UITouch *)touch onButton:(ORKTappingButtonIdentifier)buttonIdentifier {
@@ -240,6 +248,23 @@
 
 - (IBAction)buttonPressed:(id)button forEvent:(UIEvent *)event {
     
+    if (UIAccessibilityIsVoiceOverRunning()) {
+        if (!_tappingContentView.isAccessibilityElement) {
+            // Make the buttons directly tappable with VoiceOver
+            _tappingContentView.isAccessibilityElement = YES;
+            _tappingContentView.accessibilityLabel = ORKLocalizedString(@"AX_TAP_BUTTON_DIRECT_TOUCH_AREA", nil);
+            _tappingContentView.accessibilityTraits = UIAccessibilityTraitAllowsDirectInteraction;
+            // Ensure that VoiceOver is aware of the direct touch area so that the first tap gets registered
+            UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, _tappingContentView);
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                // Work around an issue in VoiceOver where announcements don't get spoken if they happen during a button activation
+                UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, ORKLocalizedString(@"AX_TAP_BUTTON_DIRECT_TOUCH_ANNOUNCEMENT", nil));
+            });
+            // Don't actually handle this as a tap yet.
+            return;
+        }
+    }
+    
     if (self.samples == nil) {
         // Start timer on first touch event on button
         _samples = [NSMutableArray array];
@@ -248,10 +273,6 @@
     }
     
     NSInteger index = (button == _tappingContentView.tapButton1) ? ORKTappingButtonIdentifierLeft : ORKTappingButtonIdentifierRight;
-    
-    if ( _tappingContentView.lastTappedButton == index ) {
-        UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, ORKLocalizedString(@"TAP_BUTTON_TITLE", nil));
-    }
     _tappingContentView.lastTappedButton = index;
     
     [self receiveTouch:[[event touchesForView:button] anyObject] onButton:index];

--- a/ResearchKit/ActiveTasks/ORKToneAudiometryContentView.m
+++ b/ResearchKit/ActiveTasks/ORKToneAudiometryContentView.m
@@ -88,6 +88,14 @@
         _leftLabel.translatesAutoresizingMaskIntoConstraints = NO;
         _rightLabel.translatesAutoresizingMaskIntoConstraints = NO;
         
+        _leftButton.accessibilityLabel = ORKLocalizedString(@"AX_TONE_AUDIOMETRY_BUTTON_LEFT_EAR_LABEL", nil);
+        _leftButton.accessibilityHint = ORKLocalizedString(@"AX_TONE_AUDIOMETRY_BUTTON_LEFT_EAR_HINT", nil);
+        _rightButton.accessibilityLabel = ORKLocalizedString(@"AX_TONE_AUDIOMETRY_BUTTON_RIGHT_EAR_LABEL", nil);
+        _rightButton.accessibilityHint = ORKLocalizedString(@"AX_TONE_AUDIOMETRY_BUTTON_RIGHT_EAR_HINT", nil);
+        // The labels will be included in the button accessibility label, so we should not expose them additionally here.
+        _leftLabel.isAccessibilityElement = NO;
+        _rightLabel.isAccessibilityElement = NO;
+        
         [self addSubview:_captionLabel];
         [self addSubview:_progressView];
         [self addSubview:_leftButton];

--- a/ResearchKit/ActiveTasks/ORKToneAudiometryStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKToneAudiometryStepViewController.m
@@ -100,6 +100,13 @@
     [self.toneAudiometryContentView.rightButton addTarget:self action:@selector(buttonPressed:forEvent:) forControlEvents:UIControlEventTouchDown];
     self.currentTestIndex = 0;
     self.audioGenerator = [ORKAudioGenerator new];
+    
+    if (UIAccessibilityIsVoiceOverRunning() && !self.toneAudiometryStep.practiceStep) {
+        // Make it possible to tap the buttons as quickly as possible.
+        self.toneAudiometryContentView.isAccessibilityElement = YES;
+        self.toneAudiometryContentView.accessibilityLabel = ORKLocalizedString(@"AX_TAP_BUTTON_DIRECT_TOUCH_AREA", nil);
+        self.toneAudiometryContentView.accessibilityTraits = UIAccessibilityTraitAllowsDirectInteraction;
+    }
 }
 
 - (void)generateFrequencyCombination {
@@ -119,6 +126,11 @@
     [super viewDidAppear:animated];
     
     [self start];
+    
+    if (UIAccessibilityIsVoiceOverRunning() && !self.toneAudiometryStep.practiceStep) {
+        // Put focus on the buttons immediately so that the first tap gets registered instead of just moving focus
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, self.toneAudiometryContentView);
+    }
 }
 
 - (void)viewWillDisappear:(BOOL)animated {

--- a/ResearchKit/ActiveTasks/ORKTrailmakingContentView.m
+++ b/ResearchKit/ActiveTasks/ORKTrailmakingContentView.m
@@ -113,6 +113,9 @@
     if (self) {
         self.layoutMargins = ORKStandardFullScreenLayoutMarginsForView(self);
         self.translatesAutoresizingMaskIntoConstraints = NO;
+        self.isAccessibilityElement = YES;
+        self.accessibilityLabel = ORKLocalizedString(@"AX_TAP_BUTTON_DIRECT_TOUCH_AREA", nil);
+        self.accessibilityTraits = UIAccessibilityTraitAllowsDirectInteraction;
 
         self.testView = [[ORKTrailmakingTestView alloc] init];
         _testView.translatesAutoresizingMaskIntoConstraints = NO;

--- a/ResearchKit/ActiveTasks/ORKTrailmakingStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKTrailmakingStepViewController.m
@@ -164,6 +164,10 @@
     [super viewDidAppear:animated];
     [self start];
     _updateTimer = [NSTimer scheduledTimerWithTimeInterval:0.1 target:self selector:@selector(timerUpdated:) userInfo:nil repeats:YES];
+    if (UIAccessibilityIsVoiceOverRunning()) {
+        // Put focus on the direct touch area immediately so that the first touch gets registered
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, _trailmakingContentView);
+    }
 }
 
 - (void)viewWillDisappear:(BOOL)animated {

--- a/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryContentView.m
+++ b/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryContentView.m
@@ -53,6 +53,7 @@
         [_tapButton setDiameter:200];
         _tapButton.translatesAutoresizingMaskIntoConstraints = NO;
         [_tapButton setTitle:ORKLocalizedString(@"TAP_BUTTON_TITLE", nil) forState:UIControlStateNormal];
+        _tapButton.accessibilityTraits = UIAccessibilityTraitButton | UIAccessibilityTraitAllowsDirectInteraction;
 
         [self addSubview:_tapButton];
         self.translatesAutoresizingMaskIntoConstraints = NO;
@@ -67,6 +68,13 @@
 - (void)willMoveToWindow:(UIWindow *)newWindow {
     [super willMoveToWindow:newWindow];
     [self updateConstraintConstantsForWindow:newWindow];
+}
+
+- (void)didMoveToWindow {
+    if (self.window != nil && UIAccessibilityIsVoiceOverRunning()) {
+        // Ensure that VoiceOver is aware of the direct touch area so that the first tap gets registered
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, _tapButton);
+    }
 }
 
 - (void)tintColorDidChange {

--- a/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.m
+++ b/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.m
@@ -519,6 +519,9 @@ NSString *const ORKTappingStepIdentifier = @"tapping";
             } else {
                 step.text = ORKLocalizedString(@"TAPPING_INSTRUCTION_LEFT", nil);
             }
+            if (UIAccessibilityIsVoiceOverRunning()) {
+                step.text = [NSString stringWithFormat:ORKLocalizedString(@"AX_TAPPING_INSTRUCTION_VOICEOVER", nil), step.text];
+            }
             step.stepDuration = duration;
             step.shouldContinueOnFinish = YES;
             step.recorderConfigurations = recorderConfigurations;
@@ -1534,10 +1537,15 @@ NSString *const ORKToneAudiometryStepIdentifier = @"tone.audiometry";
         }
     }
     
+    NSString *instructionText = shortSpeechInstruction ? : ORKLocalizedString(@"TONE_AUDIOMETRY_INSTRUCTION", nil);
     {
         ORKToneAudiometryStep *step = [[ORKToneAudiometryStep alloc] initWithIdentifier:ORKToneAudiometryPracticeStepIdentifier];
         step.title = ORKLocalizedString(@"TONE_AUDIOMETRY_TASK_TITLE", nil);
-        step.text = speechInstruction ? : ORKLocalizedString(@"TONE_AUDIOMETRY_PREP_TEXT", nil);
+        NSString *prepText = speechInstruction ? : ORKLocalizedString(@"TONE_AUDIOMETRY_PREP_TEXT", nil);
+        if (UIAccessibilityIsVoiceOverRunning()) {
+            prepText = [NSString stringWithFormat:ORKLocalizedString(@"AX_TONE_AUDIOMETRY_PREP_TEXT_VOICEOVER", nil), prepText, instructionText];
+        }
+        step.text = prepText;
         step.toneDuration = CGFLOAT_MAX;
         step.practiceStep = YES;
         ORKStepArrayAddStep(steps, step);
@@ -1555,7 +1563,7 @@ NSString *const ORKToneAudiometryStepIdentifier = @"tone.audiometry";
     {
         ORKToneAudiometryStep *step = [[ORKToneAudiometryStep alloc] initWithIdentifier:ORKToneAudiometryStepIdentifier];
         step.title = ORKLocalizedString(@"TONE_AUDIOMETRY_TASK_TITLE", nil);
-        step.text = shortSpeechInstruction ? : ORKLocalizedString(@"TONE_AUDIOMETRY_INSTRUCTION", nil);
+        step.text = instructionText;
         step.toneDuration = toneDuration;
 
         ORKStepArrayAddStep(steps, step);
@@ -1635,6 +1643,9 @@ NSString *const ORKdBHLToneAudiometryStep2Identifier = @"dBHL2.tone.audiometry";
             ORKInstructionStep *step = [[ORKInstructionStep alloc] initWithIdentifier:ORKInstruction1StepIdentifier];
             step.title = ORKLocalizedString(@"dBHL_TONE_AUDIOMETRY_TASK_TITLE", nil);
             step.text = ORKLocalizedString(@"dBHL_TONE_AUDIOMETRY_INTRO_TEXT", nil);
+            if (UIAccessibilityIsVoiceOverRunning()) {
+                step.text = [NSString stringWithFormat:ORKLocalizedString(@"AX_dBHL_TONE_AUDIOMETRY_INTRO_TEXT", nil), step.text];
+            }
             step.image = [UIImage imageNamed:@"audiometry" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
             step.shouldTintImages = YES;
             
@@ -2559,6 +2570,9 @@ NSString *const ORKTrailmakingStepIdentifier = @"trailmaking";
             step.title = ORKLocalizedString(@"TRAILMAKING_TASK_TITLE", nil);
             step.text = trailmakingInstruction ? : ORKLocalizedString(@"TRAILMAKING_INTRO_TEXT",nil);
             step.detailText = ORKLocalizedString(@"TRAILMAKING_CALL_TO_ACTION", nil);
+            if (UIAccessibilityIsVoiceOverRunning()) {
+                step.detailText = [NSString stringWithFormat:ORKLocalizedString(@"AX_TRAILMAKING_CALL_TO_ACTION_VOICEOVER", nil), step.detailText];
+            }
             step.image = [UIImage imageNamed:@"trailmaking" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
             step.shouldTintImages = YES;
             

--- a/ResearchKit/Common/ORKRoundTappingButton.m
+++ b/ResearchKit/Common/ORKRoundTappingButton.m
@@ -62,10 +62,4 @@ static const CGFloat RoundTappingButtonDiameter = 104;
     return [UIFont systemFontOfSize:((NSNumber *)[descriptor objectForKey:UIFontDescriptorSizeAttribute]).doubleValue + 3.0];
 }
 
-#pragma mark Accessibility
-
-- (UIAccessibilityTraits)accessibilityTraits {
-    return [super accessibilityTraits] | UIAccessibilityTraitAllowsDirectInteraction;
-}
-
 @end

--- a/ResearchKit/Localized/en.lproj/ResearchKit.strings
+++ b/ResearchKit/Localized/en.lproj/ResearchKit.strings
@@ -614,3 +614,22 @@
 "AX_GRAPH_POINT_%@" = "Point: %@";
 
 "AX_AUDIO_BAR_GRAPH" = "Audio Bar Graph";
+
+"AX_TAP_BUTTON_DIRECT_TOUCH_AREA" = "Tappable Buttons";
+"AX_TONE_AUDIOMETRY_BUTTON_LEFT_EAR_LABEL" = "Tap for Left Ear";
+"AX_TONE_AUDIOMETRY_BUTTON_LEFT_EAR_HINT" = "Activate to start the test. When the test starts, tap directly on this button when you hear a sound in your left ear.";
+"AX_TONE_AUDIOMETRY_BUTTON_RIGHT_EAR_LABEL" = "Tap for Right Ear";
+"AX_TONE_AUDIOMETRY_BUTTON_RIGHT_EAR_HINT" = "Activate to start the test. When the test starts, tap directly on this button when you hear a sound in your right ear.";
+/* This contains the visual text, followed by a VoiceOver-specific description, followed by the visual text on the following page (since VoiceOver users may not have a chance to hear the visual text before needing to perform the actions). */
+"AX_TONE_AUDIOMETRY_PREP_TEXT_VOICEOVER" = "%@ Using VoiceOver, explore the screen by touch to learn where the buttons for each ear are located. When the test starts, the buttons will be directly tappable. %@";
+"AX_TAP_BUTTON_1_LABEL" = "Tap for one finger";
+"AX_TAP_BUTTON_2_LABEL" = "Tap for other finger";
+"AX_TAP_BUTTON_HINT" = "Activate to make the buttons directly tappable.";
+/* This contains the visual text, followed by a VoiceOver-specific description. */
+"AX_TAPPING_INSTRUCTION_VOICEOVER" = "%@ Using VoiceOver, explore the screen by touch to learn where the buttons are located. Activate either button to make the buttons directly tappable.";
+"AX_TAP_BUTTON_DIRECT_TOUCH_ANNOUNCEMENT" = "Buttons are now directly tappable.";
+/* This contains the visual text, followed by a VoiceOver-specific description. */
+"AX_dBHL_TONE_AUDIOMETRY_INTRO_TEXT" = "%@ Using VoiceOver, the button will be directly tappable. It will be located near the center of the screen.";
+
+/* This contains the visual text, followed by a VoiceOver-specific description. */
+"AX_TRAILMAKING_CALL_TO_ACTION_VOICEOVER" = "%@ Using VoiceOver, the buttons in the test will be directly tappable.";


### PR DESCRIPTION
- In the tone audiometry test, the user has a chance to determine the location of the buttons during the practice step. Once the test begins, the buttons become directly tappable.
- In the two finger tapping interval test, the user can also determine the location of the buttons first. Then on the first activation of either button, the buttons become directly tappable, but the tap is not registered yet.
- In the dBHL tone audiometry test, the user is given instructions about the button and it is directly tappable.
- In the trailmaking test, the user is given instructions about the buttons and they are directly tappable.