### PR TITLE
NSHealthShareUsageDescription must be longer than one word

### DIFF
--- a/samples/ORKSample/ORKSample/Info.plist
+++ b/samples/ORKSample/ORKSample/Info.plist
@@ -27,7 +27,7 @@
 	<key>NSFaceIDUsageDescription</key>
 	<string>This app uses Face ID during passcode step.</string>
 	<key>NSHealthShareUsageDescription</key>
-	<string>HealthKit</string>
+	<string>Health Share Usage description must be longer than one word</string>
 	<key>NSHealthUpdateUsageDescription</key>
 	<string>Use healthkit</string>
 	<key>NSMicrophoneUsageDescription</key>


### PR DESCRIPTION
NSHealthShareUsageDescription must be longer than one word, otherwise HealthKit will throw a runtime exception during the on-boarding or profile view controller. This can cause a crash in the ORKSample app.