### PR TITLE
Allow task view controller to be canceled directly

### DIFF
--- a/ResearchKit/Common/ORKTaskViewController.h
+++ b/ResearchKit/Common/ORKTaskViewController.h
@@ -487,6 +487,13 @@ ORK_CLASS_AVAILABLE
  */
 @property (nonatomic, readonly) UINavigationBar *navigationBar;
 
+/**
+ A Boolean value indicating whether the task can be canceled directly, without prompting the "End Task" action sheet.
+ 
+ The default value of this property is `NO`. To allow the task to be canceled directly, set the value to `YES`.
+ */
+@property (nonatomic, assign) BOOL cancelable;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKTaskViewController.h
+++ b/ResearchKit/Common/ORKTaskViewController.h
@@ -488,11 +488,13 @@ ORK_CLASS_AVAILABLE
 @property (nonatomic, readonly) UINavigationBar *navigationBar;
 
 /**
- A Boolean value indicating whether the task can be canceled directly, without prompting the "End Task" action sheet.
+ A Boolean value indicating whether the task view controller can be dismissed directly, without showing the "End Task" action sheet, when
+ a user taps the "Cancel" button.
  
- The default value of this property is `NO`. To allow the task to be canceled directly, set the value to `YES`.
+ The default value of this property is `NO`. To allow the task view controller to be dismissed directly with its results discarded, set
+ the value to `YES`.
  */
-@property (nonatomic, assign) BOOL cancelable;
+@property (nonatomic, assign) BOOL discardable;
 
 @end
 

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -336,7 +336,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     [self setTask: task];
     
     self.showsProgressInNavigationBar = YES;
-    self.cancelable = NO;
+    self.discardable = NO;
     
     _managedResults = [NSMutableDictionary dictionary];
     _managedStepIdentifiers = [NSMutableArray array];
@@ -1338,7 +1338,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
         isStandaloneReviewStep = reviewStep.isStandalone;
     }
     
-    if (self.cancelable || (isCurrentInstructionStep && saveable == NO) || isStandaloneReviewStep || self.currentStepViewController.readOnlyMode) {
+    if (self.discardable || (isCurrentInstructionStep && saveable == NO) || isStandaloneReviewStep || self.currentStepViewController.readOnlyMode) {
         [self finishWithReason:ORKTaskViewControllerFinishReasonDiscarded error:nil];
     } else {
         [self presentCancelOptions:saveable sender:sender];
@@ -1514,7 +1514,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
 
 static NSString *const _ORKTaskRunUUIDRestoreKey = @"taskRunUUID";
 static NSString *const _ORKShowsProgressInNavigationBarRestoreKey = @"showsProgressInNavigationBar";
-static NSString *const _ORKCancelableTaskResotreKey = @"cancelableTask";
+static NSString *const _ORKDiscardableTaskResotreKey = @"discardableTask";
 static NSString *const _ORKManagedResultsRestoreKey = @"managedResults";
 static NSString *const _ORKManagedStepIdentifiersRestoreKey = @"managedStepIdentifiers";
 static NSString *const _ORKHasSetProgressLabelRestoreKey = @"hasSetProgressLabel";
@@ -1532,7 +1532,7 @@ static NSString *const _ORKPresentedDate = @"presentedDate";
     
     [coder encodeObject:_taskRunUUID forKey:_ORKTaskRunUUIDRestoreKey];
     [coder encodeBool:self.showsProgressInNavigationBar forKey:_ORKShowsProgressInNavigationBarRestoreKey];
-    [coder encodeBool:self.cancelable forKey:_ORKCancelableTaskResotreKey];
+    [coder encodeBool:self.discardable forKey:_ORKDiscardableTaskResotreKey];
     [coder encodeObject:_managedResults forKey:_ORKManagedResultsRestoreKey];
     [coder encodeObject:_managedStepIdentifiers forKey:_ORKManagedStepIdentifiersRestoreKey];
     [coder encodeBool:_hasSetProgressLabel forKey:_ORKHasSetProgressLabelRestoreKey];
@@ -1558,7 +1558,7 @@ static NSString *const _ORKPresentedDate = @"presentedDate";
     
     _taskRunUUID = [coder decodeObjectOfClass:[NSUUID class] forKey:_ORKTaskRunUUIDRestoreKey];
     self.showsProgressInNavigationBar = [coder decodeBoolForKey:_ORKShowsProgressInNavigationBarRestoreKey];
-    self.cancelable = [coder decodeBoolForKey:_ORKCancelableTaskResotreKey];
+    self.discardable = [coder decodeBoolForKey:_ORKDiscardableTaskResotreKey];
     
     _outputDirectory = ORKURLFromBookmarkData([coder decodeObjectOfClass:[NSData class] forKey:_ORKOutputDirectoryRestoreKey]);
     [self ensureDirectoryExists:_outputDirectory];

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1514,7 +1514,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
 
 static NSString *const _ORKTaskRunUUIDRestoreKey = @"taskRunUUID";
 static NSString *const _ORKShowsProgressInNavigationBarRestoreKey = @"showsProgressInNavigationBar";
-static NSString *const _ORKDiscardableTaskResotreKey = @"discardableTask";
+static NSString *const _ORKDiscardableTaskRestoreKey = @"discardableTask";
 static NSString *const _ORKManagedResultsRestoreKey = @"managedResults";
 static NSString *const _ORKManagedStepIdentifiersRestoreKey = @"managedStepIdentifiers";
 static NSString *const _ORKHasSetProgressLabelRestoreKey = @"hasSetProgressLabel";
@@ -1532,7 +1532,7 @@ static NSString *const _ORKPresentedDate = @"presentedDate";
     
     [coder encodeObject:_taskRunUUID forKey:_ORKTaskRunUUIDRestoreKey];
     [coder encodeBool:self.showsProgressInNavigationBar forKey:_ORKShowsProgressInNavigationBarRestoreKey];
-    [coder encodeBool:self.discardable forKey:_ORKDiscardableTaskResotreKey];
+    [coder encodeBool:self.discardable forKey:_ORKDiscardableTaskRestoreKey];
     [coder encodeObject:_managedResults forKey:_ORKManagedResultsRestoreKey];
     [coder encodeObject:_managedStepIdentifiers forKey:_ORKManagedStepIdentifiersRestoreKey];
     [coder encodeBool:_hasSetProgressLabel forKey:_ORKHasSetProgressLabelRestoreKey];
@@ -1558,7 +1558,7 @@ static NSString *const _ORKPresentedDate = @"presentedDate";
     
     _taskRunUUID = [coder decodeObjectOfClass:[NSUUID class] forKey:_ORKTaskRunUUIDRestoreKey];
     self.showsProgressInNavigationBar = [coder decodeBoolForKey:_ORKShowsProgressInNavigationBarRestoreKey];
-    self.discardable = [coder decodeBoolForKey:_ORKDiscardableTaskResotreKey];
+    self.discardable = [coder decodeBoolForKey:_ORKDiscardableTaskRestoreKey];
     
     _outputDirectory = ORKURLFromBookmarkData([coder decodeObjectOfClass:[NSData class] forKey:_ORKOutputDirectoryRestoreKey]);
     [self ensureDirectoryExists:_outputDirectory];

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -336,6 +336,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     [self setTask: task];
     
     self.showsProgressInNavigationBar = YES;
+    self.cancelable = NO;
     
     _managedResults = [NSMutableDictionary dictionary];
     _managedStepIdentifiers = [NSMutableArray array];
@@ -1337,7 +1338,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
         isStandaloneReviewStep = reviewStep.isStandalone;
     }
     
-    if ((isCurrentInstructionStep && saveable == NO) || isStandaloneReviewStep || self.currentStepViewController.readOnlyMode) {
+    if (self.cancelable || (isCurrentInstructionStep && saveable == NO) || isStandaloneReviewStep || self.currentStepViewController.readOnlyMode) {
         [self finishWithReason:ORKTaskViewControllerFinishReasonDiscarded error:nil];
     } else {
         [self presentCancelOptions:saveable sender:sender];
@@ -1513,6 +1514,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
 
 static NSString *const _ORKTaskRunUUIDRestoreKey = @"taskRunUUID";
 static NSString *const _ORKShowsProgressInNavigationBarRestoreKey = @"showsProgressInNavigationBar";
+static NSString *const _ORKCancelableTaskResotreKey = @"cancelableTask";
 static NSString *const _ORKManagedResultsRestoreKey = @"managedResults";
 static NSString *const _ORKManagedStepIdentifiersRestoreKey = @"managedStepIdentifiers";
 static NSString *const _ORKHasSetProgressLabelRestoreKey = @"hasSetProgressLabel";
@@ -1530,6 +1532,7 @@ static NSString *const _ORKPresentedDate = @"presentedDate";
     
     [coder encodeObject:_taskRunUUID forKey:_ORKTaskRunUUIDRestoreKey];
     [coder encodeBool:self.showsProgressInNavigationBar forKey:_ORKShowsProgressInNavigationBarRestoreKey];
+    [coder encodeBool:self.cancelable forKey:_ORKCancelableTaskResotreKey];
     [coder encodeObject:_managedResults forKey:_ORKManagedResultsRestoreKey];
     [coder encodeObject:_managedStepIdentifiers forKey:_ORKManagedStepIdentifiersRestoreKey];
     [coder encodeBool:_hasSetProgressLabel forKey:_ORKHasSetProgressLabelRestoreKey];
@@ -1555,6 +1558,7 @@ static NSString *const _ORKPresentedDate = @"presentedDate";
     
     _taskRunUUID = [coder decodeObjectOfClass:[NSUUID class] forKey:_ORKTaskRunUUIDRestoreKey];
     self.showsProgressInNavigationBar = [coder decodeBoolForKey:_ORKShowsProgressInNavigationBarRestoreKey];
+    self.cancelable = [coder decodeBoolForKey:_ORKCancelableTaskResotreKey];
     
     _outputDirectory = ORKURLFromBookmarkData([coder decodeObjectOfClass:[NSData class] forKey:_ORKOutputDirectoryRestoreKey]);
     [self ensureDirectoryExists:_outputDirectory];


### PR DESCRIPTION
Setting an `ORKTaskViewController` to cancelable omits showing the "End Task" action sheet, and dismisses the view controller directly, which can improve the UX for non-data-collecting tasks that are not necessary to deal with user cancellation.