### PR TITLE
ORKTest unit tests fail

### DIFF
--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -166,7 +166,7 @@
 		716B126920A7A40400590264 /* ORKdBHLToneAudiometryAudioGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 716B126720A7A40400590264 /* ORKdBHLToneAudiometryAudioGenerator.m */; };
 		71769E2920880C4500A19914 /* ORKdBHLToneAudiometryResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 71769E2720880C4500A19914 /* ORKdBHLToneAudiometryResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		71769E2A20880C4500A19914 /* ORKdBHLToneAudiometryResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 71769E2820880C4500A19914 /* ORKdBHLToneAudiometryResult.m */; };
-		71769E2D208824D100A19914 /* ORKdBHLToneAudiometryOnboardingStep.h in Headers */ = {isa = PBXBuildFile; fileRef = 71769E2B208824D100A19914 /* ORKdBHLToneAudiometryOnboardingStep.h */; };
+		71769E2D208824D100A19914 /* ORKdBHLToneAudiometryOnboardingStep.h in Headers */ = {isa = PBXBuildFile; fileRef = 71769E2B208824D100A19914 /* ORKdBHLToneAudiometryOnboardingStep.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		71769E2E208824D100A19914 /* ORKdBHLToneAudiometryOnboardingStep.m in Sources */ = {isa = PBXBuildFile; fileRef = 71769E2C208824D100A19914 /* ORKdBHLToneAudiometryOnboardingStep.m */; };
 		71769E312088260B00A19914 /* ORKdBHLToneAudiometryOnboardingStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 71769E2F2088260B00A19914 /* ORKdBHLToneAudiometryOnboardingStepViewController.h */; };
 		71769E322088260B00A19914 /* ORKdBHLToneAudiometryOnboardingStepViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 71769E302088260B00A19914 /* ORKdBHLToneAudiometryOnboardingStepViewController.m */; };

--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -160,7 +160,7 @@
 		713D4B1020FE4702002BE28D /* volume_curve_WIRED.plist in Resources */ = {isa = PBXBuildFile; fileRef = 713D4B0F20FE4702002BE28D /* volume_curve_WIRED.plist */; };
 		713D4B1C20FE5464002BE28D /* frequency_dBSPL_EARPODS.plist in Resources */ = {isa = PBXBuildFile; fileRef = 713D4B1B20FE5464002BE28D /* frequency_dBSPL_EARPODS.plist */; };
 		713D4B1E20FE5480002BE28D /* retspl_EARPODS.plist in Resources */ = {isa = PBXBuildFile; fileRef = 713D4B1D20FE5480002BE28D /* retspl_EARPODS.plist */; };
-		716B126420A78C6B00590264 /* ORKEnvironmentSPLMeterResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 716B126220A78C6B00590264 /* ORKEnvironmentSPLMeterResult.h */; };
+		716B126420A78C6B00590264 /* ORKEnvironmentSPLMeterResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 716B126220A78C6B00590264 /* ORKEnvironmentSPLMeterResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		716B126520A78C6B00590264 /* ORKEnvironmentSPLMeterResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 716B126320A78C6B00590264 /* ORKEnvironmentSPLMeterResult.m */; };
 		716B126820A7A40400590264 /* ORKdBHLToneAudiometryAudioGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 716B126620A7A40400590264 /* ORKdBHLToneAudiometryAudioGenerator.h */; };
 		716B126920A7A40400590264 /* ORKdBHLToneAudiometryAudioGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 716B126720A7A40400590264 /* ORKdBHLToneAudiometryAudioGenerator.m */; };

--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -160,7 +160,6 @@
 		713D4B1020FE4702002BE28D /* volume_curve_WIRED.plist in Resources */ = {isa = PBXBuildFile; fileRef = 713D4B0F20FE4702002BE28D /* volume_curve_WIRED.plist */; };
 		713D4B1C20FE5464002BE28D /* frequency_dBSPL_EARPODS.plist in Resources */ = {isa = PBXBuildFile; fileRef = 713D4B1B20FE5464002BE28D /* frequency_dBSPL_EARPODS.plist */; };
 		713D4B1E20FE5480002BE28D /* retspl_EARPODS.plist in Resources */ = {isa = PBXBuildFile; fileRef = 713D4B1D20FE5480002BE28D /* retspl_EARPODS.plist */; };
-		716B126420A78C6B00590264 /* ORKEnvironmentSPLMeterResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 716B126220A78C6B00590264 /* ORKEnvironmentSPLMeterResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		716B126520A78C6B00590264 /* ORKEnvironmentSPLMeterResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 716B126320A78C6B00590264 /* ORKEnvironmentSPLMeterResult.m */; };
 		716B126820A7A40400590264 /* ORKdBHLToneAudiometryAudioGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 716B126620A7A40400590264 /* ORKdBHLToneAudiometryAudioGenerator.h */; };
 		716B126920A7A40400590264 /* ORKdBHLToneAudiometryAudioGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 716B126720A7A40400590264 /* ORKdBHLToneAudiometryAudioGenerator.m */; };
@@ -645,6 +644,7 @@
 		CBD34A571BB1FB9000F204EA /* ORKLocationSelectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = CBD34A551BB1FB9000F204EA /* ORKLocationSelectionView.m */; };
 		CBD34A5A1BB207FC00F204EA /* ORKSurveyAnswerCellForLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = CBD34A581BB207FC00F204EA /* ORKSurveyAnswerCellForLocation.h */; };
 		CBD34A5B1BB207FC00F204EA /* ORKSurveyAnswerCellForLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = CBD34A591BB207FC00F204EA /* ORKSurveyAnswerCellForLocation.m */; };
+		D3C8072A21891EBE00F9A231 /* ORKEnvironmentSPLMeterResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 716B126220A78C6B00590264 /* ORKEnvironmentSPLMeterResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D42FEFB81AF7557000A124F8 /* ORKImageCaptureView.h in Headers */ = {isa = PBXBuildFile; fileRef = D42FEFB61AF7557000A124F8 /* ORKImageCaptureView.h */; };
 		D42FEFB91AF7557000A124F8 /* ORKImageCaptureView.m in Sources */ = {isa = PBXBuildFile; fileRef = D42FEFB71AF7557000A124F8 /* ORKImageCaptureView.m */; };
 		D44239791AF17F5100559D96 /* ORKImageCaptureStep.h in Headers */ = {isa = PBXBuildFile; fileRef = D44239771AF17F5100559D96 /* ORKImageCaptureStep.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -3064,6 +3064,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D3C8072A21891EBE00F9A231 /* ORKEnvironmentSPLMeterResult.h in Headers */,
 				BF1D43851D4904C6007EE90B /* ORKVideoInstructionStep.h in Headers */,
 				BF5161501BE9C53D00174DDD /* ORKWaitStep.h in Headers */,
 				244EFAD21BCEFD83001850D9 /* ORKAnswerFormat_Private.h in Headers */,
@@ -3370,7 +3371,6 @@
 				2E8070941FA7DC5100E4FC7F /* ORKStreamingAudioRecorder.h in Headers */,
 				86C40C561A8D7C5C00081FAC /* ORKTappingIntervalStepViewController.h in Headers */,
 				86AD91101AB7B8A600361FEB /* ORKActiveStepView.h in Headers */,
-				716B126420A78C6B00590264 /* ORKEnvironmentSPLMeterResult.h in Headers */,
 				86C40C9C1A8D7C5C00081FAC /* ORKDeviceMotionRecorder.h in Headers */,
 				86C40E1E1A8D7C5C00081FAC /* ORKConsentSignature.h in Headers */,
 				24898B0D1B7186C000B0E7E7 /* ORKScaleRangeImageView.h in Headers */,

--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -160,13 +160,13 @@
 		713D4B1020FE4702002BE28D /* volume_curve_WIRED.plist in Resources */ = {isa = PBXBuildFile; fileRef = 713D4B0F20FE4702002BE28D /* volume_curve_WIRED.plist */; };
 		713D4B1C20FE5464002BE28D /* frequency_dBSPL_EARPODS.plist in Resources */ = {isa = PBXBuildFile; fileRef = 713D4B1B20FE5464002BE28D /* frequency_dBSPL_EARPODS.plist */; };
 		713D4B1E20FE5480002BE28D /* retspl_EARPODS.plist in Resources */ = {isa = PBXBuildFile; fileRef = 713D4B1D20FE5480002BE28D /* retspl_EARPODS.plist */; };
-		716B126420A78C6B00590264 /* ORKEnvironmentSPLMeterResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 716B126220A78C6B00590264 /* ORKEnvironmentSPLMeterResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		716B126420A78C6B00590264 /* ORKEnvironmentSPLMeterResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 716B126220A78C6B00590264 /* ORKEnvironmentSPLMeterResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		716B126520A78C6B00590264 /* ORKEnvironmentSPLMeterResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 716B126320A78C6B00590264 /* ORKEnvironmentSPLMeterResult.m */; };
 		716B126820A7A40400590264 /* ORKdBHLToneAudiometryAudioGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 716B126620A7A40400590264 /* ORKdBHLToneAudiometryAudioGenerator.h */; };
 		716B126920A7A40400590264 /* ORKdBHLToneAudiometryAudioGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 716B126720A7A40400590264 /* ORKdBHLToneAudiometryAudioGenerator.m */; };
 		71769E2920880C4500A19914 /* ORKdBHLToneAudiometryResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 71769E2720880C4500A19914 /* ORKdBHLToneAudiometryResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		71769E2A20880C4500A19914 /* ORKdBHLToneAudiometryResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 71769E2820880C4500A19914 /* ORKdBHLToneAudiometryResult.m */; };
-		71769E2D208824D100A19914 /* ORKdBHLToneAudiometryOnboardingStep.h in Headers */ = {isa = PBXBuildFile; fileRef = 71769E2B208824D100A19914 /* ORKdBHLToneAudiometryOnboardingStep.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		71769E2D208824D100A19914 /* ORKdBHLToneAudiometryOnboardingStep.h in Headers */ = {isa = PBXBuildFile; fileRef = 71769E2B208824D100A19914 /* ORKdBHLToneAudiometryOnboardingStep.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		71769E2E208824D100A19914 /* ORKdBHLToneAudiometryOnboardingStep.m in Sources */ = {isa = PBXBuildFile; fileRef = 71769E2C208824D100A19914 /* ORKdBHLToneAudiometryOnboardingStep.m */; };
 		71769E312088260B00A19914 /* ORKdBHLToneAudiometryOnboardingStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 71769E2F2088260B00A19914 /* ORKdBHLToneAudiometryOnboardingStepViewController.h */; };
 		71769E322088260B00A19914 /* ORKdBHLToneAudiometryOnboardingStepViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 71769E302088260B00A19914 /* ORKdBHLToneAudiometryOnboardingStepViewController.m */; };

--- a/ResearchKit/ActiveTasks/ORKRangeOfMotionStep.m
+++ b/ResearchKit/ActiveTasks/ORKRangeOfMotionStep.m
@@ -81,14 +81,14 @@
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
-        ORK_DECODE_INTEGER(aDecoder, limbOption);
+        ORK_DECODE_ENUM(aDecoder, limbOption);
     }
     return self;
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
     [super encodeWithCoder:aCoder];
-    ORK_ENCODE_INTEGER(aCoder, limbOption);
+    ORK_ENCODE_ENUM(aCoder, limbOption);
 }
 
 - (BOOL)isEqual:(id)object {

--- a/ResearchKit/ActiveTasks/ORKSpeechRecognitionStep.m
+++ b/ResearchKit/ActiveTasks/ORKSpeechRecognitionStep.m
@@ -87,7 +87,7 @@
     
     __typeof(self) castObject = object;
     return (isParentSame &&
-            ([self.speechRecognizerLocale isEqual:castObject.speechRecognizerLocale]));
+            [self.speechRecognizerLocale isEqual:castObject.speechRecognizerLocale]);
 }
 
 - (BOOL)allowsBackNavigation {

--- a/ResearchKit/ActiveTasks/ORKSpeechRecognitionStep.m
+++ b/ResearchKit/ActiveTasks/ORKSpeechRecognitionStep.m
@@ -87,7 +87,7 @@
     
     __typeof(self) castObject = object;
     return (isParentSame &&
-            (self.speechRecognizerLocale == castObject.speechRecognizerLocale));
+            ([self.speechRecognizerLocale isEqual:castObject.speechRecognizerLocale]));
 }
 
 - (BOOL)allowsBackNavigation {

--- a/ResearchKit/ActiveTasks/ORKToneAudiometryStep.m
+++ b/ResearchKit/ActiveTasks/ORKToneAudiometryStep.m
@@ -75,7 +75,7 @@
 - (void)encodeWithCoder:(NSCoder *)aCoder {
     [super encodeWithCoder:aCoder];
     ORK_ENCODE_DOUBLE(aCoder, toneDuration);
-    ORK_DECODE_BOOL(aCoder, practiceStep);
+    ORK_ENCODE_BOOL(aCoder, practiceStep);
 }
 
 + (BOOL)supportsSecureCoding {

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -1107,8 +1107,8 @@ Returns an initialized numeric answer format using the specified style, unit des
                       maximum:(nullable NSNumber *)maximum;
 
 /**
-Returns an initialized numeric answer format using the specified style, unit designation, range
- values, and optional default.
+ Returns an initialized numeric answer format using the specified style, unit designation, range
+ values, and precision.
  
  This method is the designated initializer.
  

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -4,7 +4,6 @@
  Copyright (c) 2016, Ricardo Sánchez-Sáez.
  Copyright (c) 2017, Macro Yau.
  Copyright (c) 2017, Sage Bionetworks.
- Copyright (c) 2018, Brian Ganninger.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -1108,24 +1107,6 @@ Returns an initialized numeric answer format using the specified style, unit des
                       maximum:(nullable NSNumber *)maximum;
 
 /**
- Returns an initialized numeric answer format using the specified style, unit designation, and range
- values. Previous desiginated initializer (backwards compatibility)
- 
- @param style                   The style of the numeric answer (decimal or integer).
- @param unit                    A string that displays a localized version of the unit designation.
- @param minimum                 The minimum value to apply, or `nil` if none is specified.
- @param maximum                 The maximum value to apply, or `nil` if none is specified.
- @param maximumFractionDigits   The maximum fraction digits, or `nil` if no maximum is specified.
-
- @return An initialized numeric answer format.
- */
-- (instancetype)initWithStyle:(ORKNumericAnswerStyle)style
-                         unit:(nullable NSString *)unit
-                      minimum:(nullable NSNumber *)minimum
-                      maximum:(nullable NSNumber *)maximum
-        maximumFractionDigits:(nullable NSNumber *)maximumFractionDigits;
-
-/**
 Returns an initialized numeric answer format using the specified style, unit designation, range
  values, and optional default.
  
@@ -1136,7 +1117,6 @@ Returns an initialized numeric answer format using the specified style, unit des
  @param minimum                 The minimum value to apply, or `nil` if none is specified.
  @param maximum                 The maximum value to apply, or `nil` if none is specified.
  @param maximumFractionDigits   The maximum fraction digits, or `nil` if no maximum is specified.
- @param defaultNumericAnswer    The default numeric answer, or `nil` if no default is specified.
 
  @return An initialized numeric answer format.
  */
@@ -1144,8 +1124,7 @@ Returns an initialized numeric answer format using the specified style, unit des
                          unit:(nullable NSString *)unit
                       minimum:(nullable NSNumber *)minimum
                       maximum:(nullable NSNumber *)maximum
-        maximumFractionDigits:(nullable NSNumber *)maximumFractionDigits
-         defaultNumericAnswer:(nullable NSNumber *)defaultNumericAnswer NS_DESIGNATED_INITIALIZER;
+        maximumFractionDigits:(nullable NSNumber *)maximumFractionDigits NS_DESIGNATED_INITIALIZER;
 
 /**
  The style of numeric entry (decimal or integer). (read-only)

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -1120,10 +1120,10 @@ Returns an initialized numeric answer format using the specified style, unit des
  @return An initialized numeric answer format.
  */
 - (instancetype)initWithStyle:(ORKNumericAnswerStyle)style
-                         unit:(NSString *)unit
-                      minimum:(NSNumber *)minimum
-                      maximum:(NSNumber *)maximum
-        maximumFractionDigits:(NSNumber *)maximumFractionDigits;
+                         unit:(nullable NSString *)unit
+                      minimum:(nullable NSNumber *)minimum
+                      maximum:(nullable NSNumber *)maximum
+        maximumFractionDigits:(nullable NSNumber *)maximumFractionDigits;
 
 /**
 Returns an initialized numeric answer format using the specified style, unit designation, range

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -4,6 +4,7 @@
  Copyright (c) 2016, Ricardo Sánchez-Sáez.
  Copyright (c) 2017, Macro Yau.
  Copyright (c) 2017, Sage Bionetworks.
+ Copyright (c) 2018, Brian Ganninger.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -1094,8 +1095,6 @@ ORK_CLASS_AVAILABLE
 Returns an initialized numeric answer format using the specified style, unit designation, and range
  values.
  
- This method is the designated initializer.
- 
  @param style                   The style of the numeric answer (decimal or integer).
  @param unit                    A string that displays a localized version of the unit designation.
  @param minimum                 The minimum value to apply, or `nil` if none is specified.
@@ -1109,10 +1108,8 @@ Returns an initialized numeric answer format using the specified style, unit des
                       maximum:(nullable NSNumber *)maximum;
 
 /**
-Returns an initialized numeric answer format using the specified style, unit designation, and range
- values.
- 
- This method is the designated initializer.
+ Returns an initialized numeric answer format using the specified style, unit designation, and range
+ values. Previous desiginated initializer (backwards compatibility)
  
  @param style                   The style of the numeric answer (decimal or integer).
  @param unit                    A string that displays a localized version of the unit designation.
@@ -1123,10 +1120,32 @@ Returns an initialized numeric answer format using the specified style, unit des
  @return An initialized numeric answer format.
  */
 - (instancetype)initWithStyle:(ORKNumericAnswerStyle)style
+                         unit:(NSString *)unit
+                      minimum:(NSNumber *)minimum
+                      maximum:(NSNumber *)maximum
+        maximumFractionDigits:(NSNumber *)maximumFractionDigits;
+
+/**
+Returns an initialized numeric answer format using the specified style, unit designation, range
+ values, and optional default.
+ 
+ This method is the designated initializer.
+ 
+ @param style                   The style of the numeric answer (decimal or integer).
+ @param unit                    A string that displays a localized version of the unit designation.
+ @param minimum                 The minimum value to apply, or `nil` if none is specified.
+ @param maximum                 The maximum value to apply, or `nil` if none is specified.
+ @param maximumFractionDigits   The maximum fraction digits, or `nil` if no maximum is specified.
+ @param defaultNumericAnswer    The default numeric answer, or `nil` if no default is specified.
+
+ @return An initialized numeric answer format.
+ */
+- (instancetype)initWithStyle:(ORKNumericAnswerStyle)style
                          unit:(nullable NSString *)unit
                       minimum:(nullable NSNumber *)minimum
                       maximum:(nullable NSNumber *)maximum
-        maximumFractionDigits:(nullable NSNumber *)maximumFractionDigits NS_DESIGNATED_INITIALIZER;
+        maximumFractionDigits:(nullable NSNumber *)maximumFractionDigits
+         defaultNumericAnswer:(nullable NSNumber *)defaultNumericAnswer NS_DESIGNATED_INITIALIZER;
 
 /**
  The style of numeric entry (decimal or integer). (read-only)

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1487,15 +1487,6 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
                       minimum:(NSNumber *)minimum
                       maximum:(NSNumber *)maximum
         maximumFractionDigits:(NSNumber *)maximumFractionDigits {
-    return [self initWithStyle:style unit:unit minimum:minimum maximum:minimum maximumFractionDigits:maximumFractionDigits defaultNumericAnswer:nil];
-}
-
-- (instancetype)initWithStyle:(ORKNumericAnswerStyle)style
-                         unit:(NSString *)unit
-                      minimum:(NSNumber *)minimum
-                      maximum:(NSNumber *)maximum
-        maximumFractionDigits:(NSNumber *)maximumFractionDigits
-         defaultNumericAnswer:(NSNumber *)defaultNumericAnswer {
     self = [super init];
     if (self) {
         _style = style;
@@ -1503,7 +1494,6 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         _minimum = [minimum copy];
         _maximum = [maximum copy];
         _maximumFractionDigits = [maximumFractionDigits copy];
-        _defaultNumericAnswer = [defaultNumericAnswer copy];
     }
     return self;
 }
@@ -1540,8 +1530,8 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
                                                                                        unit:[_unit copy]
                                                                                     minimum:[_minimum copy]
                                                                                     maximum:[_maximum copy]
-                                                                      maximumFractionDigits:[_maximumFractionDigits copy]
-                                                                       defaultNumericAnswer:[_defaultNumericAnswer copy]];
+                                                                      maximumFractionDigits:[_maximumFractionDigits copy]];
+    answerFormat.defaultNumericAnswer = [_defaultNumericAnswer copy];
     return answerFormat;
 }
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -5,6 +5,7 @@
  Copyright (c) 2017, Medable Inc. All rights reserved.
  Copyright (c) 2017, Macro Yau.
  Copyright (c) 2017, Sage Bionetworks.
+ Copyright (c) 2018, Brian Ganninger.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -5,7 +5,6 @@
  Copyright (c) 2017, Medable Inc. All rights reserved.
  Copyright (c) 2017, Macro Yau.
  Copyright (c) 2017, Sage Bionetworks.
- Copyright (c) 2018, Brian Ganninger.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -1531,7 +1530,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
                                                                                     minimum:[_minimum copy]
                                                                                     maximum:[_maximum copy]
                                                                       maximumFractionDigits:[_maximumFractionDigits copy]];
-    answerFormat.defaultNumericAnswer = [_defaultNumericAnswer copy];
+    answerFormat->defaultNumericAnswer = [_defaultNumericAnswer copy];
     return answerFormat;
 }
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1530,7 +1530,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
                                                                                     minimum:[_minimum copy]
                                                                                     maximum:[_maximum copy]
                                                                       maximumFractionDigits:[_maximumFractionDigits copy]];
-    answerFormat->defaultNumericAnswer = [_defaultNumericAnswer copy];
+    answerFormat->_defaultNumericAnswer = [_defaultNumericAnswer copy];
     return answerFormat;
 }
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1486,6 +1486,15 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
                       minimum:(NSNumber *)minimum
                       maximum:(NSNumber *)maximum
         maximumFractionDigits:(NSNumber *)maximumFractionDigits {
+    return [self initWithStyle:style unit:unit minimum:minimum maximum:minimum maximumFractionDigits:maximumFractionDigits defaultNumericAnswer:nil];
+}
+
+- (instancetype)initWithStyle:(ORKNumericAnswerStyle)style
+                         unit:(NSString *)unit
+                      minimum:(NSNumber *)minimum
+                      maximum:(NSNumber *)maximum
+        maximumFractionDigits:(NSNumber *)maximumFractionDigits
+         defaultNumericAnswer:(NSNumber *)defaultNumericAnswer {
     self = [super init];
     if (self) {
         _style = style;
@@ -1493,7 +1502,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         _minimum = [minimum copy];
         _maximum = [maximum copy];
         _maximumFractionDigits = [maximumFractionDigits copy];
-        
+        _defaultNumericAnswer = [defaultNumericAnswer copy];
     }
     return self;
 }
@@ -1519,7 +1528,6 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     ORK_ENCODE_OBJ(aCoder, maximum);
     ORK_ENCODE_OBJ(aCoder, defaultNumericAnswer);
     ORK_ENCODE_OBJ(aCoder, maximumFractionDigits);
-
 }
 
 + (BOOL)supportsSecureCoding {

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1539,8 +1539,8 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
                                                                                        unit:[_unit copy]
                                                                                     minimum:[_minimum copy]
                                                                                     maximum:[_maximum copy]
-                                                                      maximumFractionDigits:[_maximumFractionDigits copy]];
-    answerFormat->_defaultNumericAnswer = [_defaultNumericAnswer copy];
+                                                                      maximumFractionDigits:[_maximumFractionDigits copy]
+                                                                       defaultNumericAnswer:[_defaultNumericAnswer copy]];
     return answerFormat;
 }
 

--- a/ResearchKit/Common/ORKFormStep.m
+++ b/ResearchKit/Common/ORKFormStep.m
@@ -116,6 +116,7 @@
     if (self) {
         ORK_DECODE_OBJ_ARRAY(aDecoder, formItems, ORKFormItem);
         ORK_DECODE_OBJ_CLASS(aDecoder, footnote, NSString);
+        ORK_DECODE_BOOL(aDecoder, useCardView);
     }
     return self;
 }
@@ -124,6 +125,7 @@
     [super encodeWithCoder:aCoder];
     ORK_ENCODE_OBJ(aCoder, formItems);
     ORK_ENCODE_OBJ(aCoder, footnote);
+    ORK_ENCODE_BOOL(aCoder, useCardView);
 }
 
 + (BOOL)supportsSecureCoding {

--- a/ResearchKit/Common/ORKQuestionStep.m
+++ b/ResearchKit/Common/ORKQuestionStep.m
@@ -118,6 +118,8 @@
     if (self) {
         ORK_DECODE_OBJ_CLASS(aDecoder, answerFormat, ORKAnswerFormat);
         ORK_DECODE_OBJ_CLASS(aDecoder, placeholder, NSString);
+        ORK_DECODE_OBJ_CLASS(aDecoder, question, NSString);
+        ORK_DECODE_BOOL(aDecoder, useCardView);
     }
     return self;
 }
@@ -127,6 +129,8 @@
     
     ORK_ENCODE_OBJ(aCoder, answerFormat);
     ORK_ENCODE_OBJ(aCoder, placeholder);
+    ORK_ENCODE_OBJ(aCoder, question);
+    ORK_ENCODE_BOOL(aCoder, useCardView);
 }
 
 + (BOOL)supportsSecureCoding {

--- a/ResearchKit/ResearchKit.h
+++ b/ResearchKit/ResearchKit.h
@@ -74,6 +74,7 @@
 #import <ResearchKit/ORKQuestionResult.h>
 #import <ResearchKit/ORKSignatureResult.h>
 #import <ResearchKit/ORKVideoInstructionStepResult.h>
+#import <ResearchKit/ORKEnvironmentSPLMeterResult.h>
 #import <ResearchKit/ORKWebViewStepResult.h>
 #import <ResearchKit/ORKResultPredicate.h>
 

--- a/ResearchKit/ResearchKit.h
+++ b/ResearchKit/ResearchKit.h
@@ -36,7 +36,6 @@
 #import <ResearchKit/ORKConsentReviewStep.h>
 #import <ResearchKit/ORKConsentSharingStep.h>
 #import <ResearchKit/ORKFormStep.h>
-#import <ResearchKit/ORKdBHLToneAudiometryOnboardingStep.h>
 #import <ResearchKit/ORKImageCaptureStep.h>
 #import <ResearchKit/ORKInstructionStep.h>
 #import <ResearchKit/ORKLoginStep.h>
@@ -75,7 +74,6 @@
 #import <ResearchKit/ORKQuestionResult.h>
 #import <ResearchKit/ORKSignatureResult.h>
 #import <ResearchKit/ORKVideoInstructionStepResult.h>
-#import <ResearchKit/ORKEnvironmentSPLMeterResult.h>
 #import <ResearchKit/ORKWebViewStepResult.h>
 #import <ResearchKit/ORKResultPredicate.h>
 

--- a/ResearchKit/ResearchKit.h
+++ b/ResearchKit/ResearchKit.h
@@ -36,6 +36,7 @@
 #import <ResearchKit/ORKConsentReviewStep.h>
 #import <ResearchKit/ORKConsentSharingStep.h>
 #import <ResearchKit/ORKFormStep.h>
+#import <ResearchKit/ORKdBHLToneAudiometryOnboardingStep.h>
 #import <ResearchKit/ORKImageCaptureStep.h>
 #import <ResearchKit/ORKInstructionStep.h>
 #import <ResearchKit/ORKLoginStep.h>

--- a/ResearchKit/ResearchKit.h
+++ b/ResearchKit/ResearchKit.h
@@ -75,6 +75,7 @@
 #import <ResearchKit/ORKSignatureResult.h>
 #import <ResearchKit/ORKVideoInstructionStepResult.h>
 #import <ResearchKit/ORKWebViewStepResult.h>
+#import <ResearchKit/ORKEnvironmentSPLMeterResult.h>
 #import <ResearchKit/ORKResultPredicate.h>
 
 #import <ResearchKit/ORKTextButton.h>

--- a/ResearchKit/ResearchKit_Private.h
+++ b/ResearchKit/ResearchKit_Private.h
@@ -115,7 +115,5 @@
 #import <ResearchKit/ORKTouchRecorder.h>
 #import <ResearchKit/ORKHTMLPDFPageRenderer.h>
 
-#import <ResearchKit/ORKEnvironmentSPLMeterResult.h>
-
 // For custom steps
 #import <ResearchKit/ORKCustomStepView.h>

--- a/ResearchKit/ResearchKit_Private.h
+++ b/ResearchKit/ResearchKit_Private.h
@@ -70,6 +70,7 @@
 #import <ResearchKit/ORKTimedWalkStep.h>
 #import <ResearchKit/ORKToneAudiometryStep.h>
 #import <ResearchKit/ORKdBHLToneAudiometryStep.h>
+#import <ResearchKit/ORKdBHLToneAudiometryOnboardingStep.h>
 #import <ResearchKit/ORKTowerOfHanoiStep.h>
 #import <ResearchKit/ORKTrailmakingStep.h>
 #import <ResearchKit/ORKWalkingTaskStep.h>
@@ -113,6 +114,8 @@
 #import <ResearchKit/ORKPedometerRecorder.h>
 #import <ResearchKit/ORKTouchRecorder.h>
 #import <ResearchKit/ORKHTMLPDFPageRenderer.h>
+
+#import <ResearchKit/ORKEnvironmentSPLMeterResult.h>
 
 // For custom steps
 #import <ResearchKit/ORKCustomStepView.h>

--- a/Testing/ORKTest/ORKTestTests/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTestTests/ORKESerialization.m
@@ -588,7 +588,8 @@ internalEncodingTable =
          },
          (@{
             PROPERTY(answerFormat, ORKAnswerFormat, NSObject, YES, nil, nil),
-            PROPERTY(placeholder, NSString, NSObject, YES, nil, nil)
+            PROPERTY(placeholder, NSString, NSObject, YES, nil, nil),
+            PROPERTY(question, NSString, NSObject, YES, nil, nil)
             })),
    ENTRY(ORKInstructionStep,
          ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {

--- a/Testing/ORKTest/ORKTestTests/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTestTests/ORKESerialization.m
@@ -1177,7 +1177,7 @@ internalEncodingTable =
           })),
   ENTRY(ORKNumericAnswerFormat,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
-            return [[ORKNumericAnswerFormat alloc] initWithStyle:((NSNumber *)GETPROP(dict, style)).integerValue unit:GETPROP(dict, unit) minimum:GETPROP(dict, minimum) maximum:GETPROP(dict, maximum) maximumFractionDigits:GETPROP(dict, maximumFractionDigits) defaultNumericAnswer:GETPROP(dict, defaultNumericAnswer)];
+            return [[ORKNumericAnswerFormat alloc] initWithStyle:((NSNumber *)GETPROP(dict, style)).integerValue unit:GETPROP(dict, unit) minimum:GETPROP(dict, minimum) maximum:GETPROP(dict, maximum) maximumFractionDigits:GETPROP(dict, maximumFractionDigits)];
         },
         (@{
           PROPERTY(style, NSNumber, NSObject, NO,
@@ -1186,7 +1186,6 @@ internalEncodingTable =
           PROPERTY(unit, NSString, NSObject, NO, nil, nil),
           PROPERTY(minimum, NSNumber, NSObject, NO, nil, nil),
           PROPERTY(maximum, NSNumber, NSObject, NO, nil, nil),
-          PROPERTY(defaultNumericAnswer, NSNumber, NSObject, NO, nil, nil),
           PROPERTY(maximumFractionDigits, NSNumber, NSObject, NO, nil, nil),
           })),
   ENTRY(ORKScaleAnswerFormat,

--- a/Testing/ORKTest/ORKTestTests/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTestTests/ORKESerialization.m
@@ -453,9 +453,9 @@ static NSArray *numberFormattingStyleTable() {
 #define GETPROP(d,x) getter(d, @ESTRINGIFY(x))
 static NSMutableDictionary *ORKESerializationEncodingTable() {
     static dispatch_once_t onceToken;
-    static NSMutableDictionary *encondingTable = nil;
+    static NSMutableDictionary *internalEncodingTable = nil;
     dispatch_once(&onceToken, ^{
-encondingTable =
+internalEncodingTable =
 [@{
    ENTRY(ORKResultSelector,
          ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
@@ -1681,7 +1681,7 @@ encondingTable =
    } mutableCopy];
         
         if (@available(iOS 12.0, *)) {
-            [encondingTable addEntriesFromDictionary:@{ ENTRY(ORKHealthClinicalTypeRecorderConfiguration,
+            [internalEncodingTable addEntriesFromDictionary:@{ ENTRY(ORKHealthClinicalTypeRecorderConfiguration,
                                                               ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
                                                                   return [[ORKHealthClinicalTypeRecorderConfiguration alloc] initWithIdentifier:GETPROP(dict, identifier) healthClinicalType:GETPROP(dict, healthClinicalType) healthFHIRResourceType:GETPROP(dict, healthFHIRResourceType)];
                                                               },
@@ -1691,7 +1691,7 @@ encondingTable =
                                                                  })) }];
         }
     });
-    return encondingTable;
+    return internalEncodingTable;
 }
 #undef GETPROP
 

--- a/Testing/ORKTest/ORKTestTests/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTestTests/ORKESerialization.m
@@ -1183,7 +1183,7 @@ internalEncodingTable =
           })),
   ENTRY(ORKNumericAnswerFormat,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
-            return [[ORKNumericAnswerFormat alloc] initWithStyle:((NSNumber *)GETPROP(dict, style)).integerValue unit:GETPROP(dict, unit) minimum:GETPROP(dict, minimum) maximum:GETPROP(dict, maximum) maximumFractionDigits:GETPROP(dict, maximumFractionDigits)];
+            return [[ORKNumericAnswerFormat alloc] initWithStyle:((NSNumber *)GETPROP(dict, style)).integerValue unit:GETPROP(dict, unit) minimum:GETPROP(dict, minimum) maximum:GETPROP(dict, maximum) maximumFractionDigits:GETPROP(dict, maximumFractionDigits) defaultNumericAnswer:GETPROP(dict, defaultNumericAnswer)];
         },
         (@{
           PROPERTY(style, NSNumber, NSObject, NO,

--- a/Testing/ORKTest/ORKTestTests/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTestTests/ORKESerialization.m
@@ -915,6 +915,15 @@ internalEncodingTable =
          (@{
             PROPERTY(eyeSide, NSNumber, NSObject, NO, nil, nil),
             })),
+   ENTRY(ORKAmslerGridResult,
+         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
+             return [[ORKAmslerGridResult alloc] initWithIdentifier:GETPROP(dict, identifier)image:GETPROP(dict, image) path:GETPROP(dict, path) eyeSide:(ORKAmslerGridEyeSide)[GETPROP(dict, eyeSide) integerValue]];
+         },
+         (@{
+            PROPERTY(eyeSide, NSNumber, NSObject, NO, nil, nil),
+            PROPERTY(image, UIImage, NSObject, NO, nil, nil),
+            PROPERTY(path, UIBezierPath, NSArray, NO, nil, nil),
+            })),
   ENTRY(ORKConsentDocument,
         nil,
         (@{

--- a/Testing/ORKTest/ORKTestTests/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTestTests/ORKESerialization.m
@@ -894,20 +894,27 @@ encondingTable =
          },
          (@{
             })),
-  ENTRY(ORKAccelerometerRecorderConfiguration,
+   ENTRY(ORKAccelerometerRecorderConfiguration,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
             return [[ORKAccelerometerRecorderConfiguration alloc] initWithIdentifier:GETPROP(dict, identifier) frequency:((NSNumber *)GETPROP(dict, frequency)).doubleValue];
         },
         (@{
           PROPERTY(frequency, NSNumber, NSObject, NO, nil, nil),
           })),
-  ENTRY(ORKAudioRecorderConfiguration,
+   ENTRY(ORKAudioRecorderConfiguration,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
             return [[ORKAudioRecorderConfiguration alloc] initWithIdentifier:GETPROP(dict, identifier) recorderSettings:GETPROP(dict, recorderSettings)];
         },
         (@{
           PROPERTY(recorderSettings, NSDictionary, NSObject, NO, nil, nil),
           })),
+   ENTRY(ORKAmslerGridStep,
+         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
+             return [[ORKAmslerGridStep alloc] initWithIdentifier:GETPROP(dict, identifier)];
+         },
+         (@{
+            PROPERTY(eyeSide, NSNumber, NSObject, NO, nil, nil),
+            })),
   ENTRY(ORKConsentDocument,
         nil,
         (@{
@@ -918,14 +925,14 @@ encondingTable =
           PROPERTY(signatures, ORKConsentSignature, NSArray, NO, nil, nil),
           PROPERTY(htmlReviewContent, NSString, NSObject, NO, nil, nil),
           })),
-  ENTRY(ORKConsentSharingStep,
+   ENTRY(ORKConsentSharingStep,
         ^(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
             return [[ORKConsentSharingStep alloc] initWithIdentifier:GETPROP(dict, identifier)];
         },
         (@{
            PROPERTY(localizedLearnMoreHTMLContent, NSString, NSObject, YES, nil, nil),
            })),
-  ENTRY(ORKConsentReviewStep,
+   ENTRY(ORKConsentReviewStep,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
             return [[ORKConsentReviewStep alloc] initWithIdentifier:GETPROP(dict, identifier) signature:GETPROP(dict, signature) inDocument:GETPROP(dict,consentDocument)];
         },
@@ -934,13 +941,13 @@ encondingTable =
           PROPERTY(reasonForConsent, NSString, NSObject, YES, nil, nil),
           PROPERTY(signature, ORKConsentSignature, NSObject, NO, nil, nil),
           })),
-  ENTRY(ORKFitnessStep,
+   ENTRY(ORKFitnessStep,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
             return [[ORKFitnessStep alloc] initWithIdentifier:GETPROP(dict, identifier)];
         },
         (@{
            })),
-  ENTRY(ORKConsentSection,
+   ENTRY(ORKConsentSection,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
             return [[ORKConsentSection alloc] initWithType:((NSNumber *)GETPROP(dict, type)).integerValue];
         },
@@ -960,7 +967,7 @@ encondingTable =
                    ^id(id string) { return [NSURL URLWithString:string]; }),
           PROPERTY(omitFromDocument, NSNumber, NSObject, YES, nil, nil),
           })),
-  ENTRY(ORKConsentSignature,
+   ENTRY(ORKConsentSignature,
         nil,
         (@{
           PROPERTY(identifier, NSString, NSObject, YES, nil, nil),
@@ -972,7 +979,7 @@ encondingTable =
           PROPERTY(requiresSignatureImage, NSNumber, NSObject, YES, nil, nil),
           PROPERTY(signatureDateFormatString, NSString, NSObject, YES, nil, nil),
           })),
-  ENTRY(ORKRegistrationStep,
+   ENTRY(ORKRegistrationStep,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
             return [[ORKRegistrationStep alloc] initWithIdentifier:GETPROP(dict, identifier) title:GETPROP(dict, title) text:GETPROP(dict, text) options:((NSNumber *)GETPROP(dict, options)).integerValue];
         },

--- a/Testing/ORKTest/ORKTestTests/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTestTests/ORKESerialization.m
@@ -550,6 +550,14 @@ encondingTable =
          @{
            PROPERTY(consentDocument, ORKConsentDocument, NSObject, NO, nil, nil)
            }),
+   ENTRY(ORKPDFViewerStep,
+         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
+             return [[ORKPDFViewerStep alloc] initWithIdentifier:GETPROP(dict, identifier)
+                                                          pdfURL:GETPROP(dict, pdfURL)];
+         },
+         @{
+           PROPERTY(pdfURL, NSURL, NSObject, YES, nil, nil)
+           }),
    ENTRY(ORKPasscodeStep,
          ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
              return [[ORKPasscodeStep alloc] initWithIdentifier:GETPROP(dict, identifier)];

--- a/Testing/ORKTest/ORKTestTests/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTestTests/ORKESerialization.m
@@ -861,6 +861,15 @@ encondingTable =
          },
          (@{
             })),
+   ENTRY(ORKEnvironmentSPLMeterStep,
+         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
+             return [[ORKEnvironmentSPLMeterStep alloc] initWithIdentifier:GETPROP(dict, identifier)];
+         },
+         (@{
+            PROPERTY(thresholdValue, NSNumber, NSObject, NO, nil, nil),
+            PROPERTY(samplingInterval, NSNumber, NSObject, NO, nil, nil),
+            PROPERTY(requiredContiguousSamples, NSNumber, NSObject, NO, nil, nil),
+            })),
   ENTRY(ORKAccelerometerRecorderConfiguration,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
             return [[ORKAccelerometerRecorderConfiguration alloc] initWithIdentifier:GETPROP(dict, identifier) frequency:((NSNumber *)GETPROP(dict, frequency)).doubleValue];

--- a/Testing/ORKTest/ORKTestTests/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTestTests/ORKESerialization.m
@@ -1679,6 +1679,17 @@ encondingTable =
             })),
    
    } mutableCopy];
+        
+        if (@available(iOS 12.0, *)) {
+            [encondingTable addEntriesFromDictionary:@{ ENTRY(ORKHealthClinicalTypeRecorderConfiguration,
+                                                              ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
+                                                                  return [[ORKHealthClinicalTypeRecorderConfiguration alloc] initWithIdentifier:GETPROP(dict, identifier) healthClinicalType:GETPROP(dict, healthClinicalType) healthFHIRResourceType:GETPROP(dict, healthFHIRResourceType)];
+                                                              },
+                                                              (@{
+                                                                 PROPERTY(healthClinicalType, HKClinicalType, NSObject, NO, nil, nil),
+                                                                 PROPERTY(healthFHIRResourceType, NSString, NSObject, NO, nil, nil),
+                                                                 })) }];
+        }
     });
     return encondingTable;
 }

--- a/Testing/ORKTest/ORKTestTests/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTestTests/ORKESerialization.m
@@ -870,6 +870,12 @@ encondingTable =
             PROPERTY(samplingInterval, NSNumber, NSObject, NO, nil, nil),
             PROPERTY(requiredContiguousSamples, NSNumber, NSObject, NO, nil, nil),
             })),
+   ENTRY(ORKStreamingAudioRecorderConfiguration,
+         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
+             return [[ORKStreamingAudioRecorderConfiguration alloc] initWithIdentifier:GETPROP(dict, identifier)];
+         },
+         (@{
+            })),
   ENTRY(ORKAccelerometerRecorderConfiguration,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
             return [[ORKAccelerometerRecorderConfiguration alloc] initWithIdentifier:GETPROP(dict, identifier) frequency:((NSNumber *)GETPROP(dict, frequency)).doubleValue];

--- a/Testing/ORKTest/ORKTestTests/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTestTests/ORKESerialization.m
@@ -805,14 +805,7 @@ internalEncodingTable =
             })),
    ENTRY(ORKRangeOfMotionStep,
          ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
-             return [[ORKRangeOfMotionStep alloc] initWithIdentifier:GETPROP(dict, identifier)];
-         },
-         (@{
-            PROPERTY(limbOption, NSNumber, NSObject, YES, nil, nil),
-            })),
-   ENTRY(ORKShoulderRangeOfMotionStep,
-         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
-             return [[ORKShoulderRangeOfMotionStep alloc] initWithIdentifier:GETPROP(dict, identifier)];
+             return [[ORKRangeOfMotionStep alloc] initWithIdentifier:GETPROP(dict, identifier) limbOption:[GETPROP(dict, identifier) integerValue]];
          },
          (@{
             PROPERTY(limbOption, NSNumber, NSObject, YES, nil, nil),

--- a/Testing/ORKTest/ORKTestTests/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTestTests/ORKESerialization.m
@@ -866,9 +866,17 @@ encondingTable =
              return [[ORKEnvironmentSPLMeterStep alloc] initWithIdentifier:GETPROP(dict, identifier)];
          },
          (@{
-            PROPERTY(thresholdValue, NSNumber, NSObject, NO, nil, nil),
-            PROPERTY(samplingInterval, NSNumber, NSObject, NO, nil, nil),
-            PROPERTY(requiredContiguousSamples, NSNumber, NSObject, NO, nil, nil),
+            PROPERTY(thresholdValue, NSNumber, NSObject, YES, nil, nil),
+            PROPERTY(samplingInterval, NSNumber, NSObject, YES, nil, nil),
+            PROPERTY(requiredContiguousSamples, NSNumber, NSObject, YES, nil, nil),
+            })),
+   ENTRY(ORKEnvironmentSPLMeterResult,
+         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
+             return [[ORKEnvironmentSPLMeterResult alloc] initWithIdentifier:GETPROP(dict, identifier)];
+         },
+         (@{
+            PROPERTY(sensitivityOffset, NSNumber, NSObject, YES, nil, nil),
+            PROPERTY(recordedSPLMeterSamples, NSNumber, NSArray, YES, nil, nil)
             })),
    ENTRY(ORKStreamingAudioRecorderConfiguration,
          ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {

--- a/Testing/ORKTest/ORKTestTests/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTestTests/ORKESerialization.m
@@ -1016,6 +1016,12 @@ internalEncodingTable =
         (@{
           PROPERTY(frequency, NSNumber, NSObject, NO, nil, nil),
           })),
+   ENTRY(ORKdBHLToneAudiometryOnboardingStep,
+         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
+             return [[ORKdBHLToneAudiometryOnboardingStep alloc] initWithIdentifier:GETPROP(dict, identifier)];
+         },
+         (@{
+            })),
   ENTRY(ORKFormStep,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
             return [[ORKFormStep alloc] initWithIdentifier:GETPROP(dict, identifier)];

--- a/Testing/ORKTest/ORKTestTests/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTestTests/ORKESerialization.m
@@ -855,6 +855,12 @@ encondingTable =
          (@{
             PROPERTY(numberOfDisks, NSNumber, NSObject, YES, nil, nil),
             })),
+   ENTRY(ORKSpeechInNoiseStep,
+         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
+             return [[ORKSpeechInNoiseStep alloc] initWithIdentifier:GETPROP(dict, identifier)];
+         },
+         (@{
+            })),
   ENTRY(ORKAccelerometerRecorderConfiguration,
         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
             return [[ORKAccelerometerRecorderConfiguration alloc] initWithIdentifier:GETPROP(dict, identifier) frequency:((NSNumber *)GETPROP(dict, frequency)).doubleValue];

--- a/Testing/ORKTest/ORKTestTests/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTestTests/ORKESerialization.m
@@ -1,6 +1,7 @@
 /*
  Copyright (c) 2015, Apple Inc. All rights reserved.
  Copyright (c) 2015-2016, Ricardo Sánchez-Sáez.
+ Copyright (c) 2018, Brian Ganninger.
 
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -860,6 +861,15 @@ encondingTable =
              return [[ORKSpeechInNoiseStep alloc] initWithIdentifier:GETPROP(dict, identifier)];
          },
          (@{
+            })),
+   ENTRY(ORKSpeechRecognitionStep,
+         ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {
+             return [[ORKSpeechRecognitionStep alloc] initWithIdentifier:GETPROP(dict, identifier) image:nil text:GETPROP(dict, speechRecognitionText)];
+         },
+         (@{
+            PROPERTY(shouldHideTranscript, NSNumber, NSObject, YES, nil, nil),
+            PROPERTY(speechRecognitionText, NSString, NSObject, YES, nil, nil),
+            PROPERTY(speechRecognizerLocale, NSString, NSObject, YES, nil, nil)
             })),
    ENTRY(ORKEnvironmentSPLMeterStep,
          ^id(NSDictionary *dict, ORKESerializationPropertyGetter getter) {

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -695,8 +695,10 @@ ORK_MAKE_TEST_INIT(NSRegularExpression, (^{
                                               @"ORKSignatureResult.signatureImage",
                                               @"ORKSignatureResult.signaturePath",
                                               @"ORKPageStep.steps",
+                                              
                                               @"ORKRegistrationStep.phoneNumberValidationRegularExpression",
-                                              @"ORKRegistrationStep.phoneNumberInvalidMessage"];
+                                              @"ORKRegistrationStep.phoneNumberInvalidMessage",
+                                              @"ORKTableStep.bulletIconNames"];
     
     // Test Each class
     for (Class aClass in classesWithSecureCoding) {
@@ -1005,6 +1007,8 @@ ORK_MAKE_TEST_INIT(NSRegularExpression, (^{
                                                                              @"ORKVideoInstructionStepViewController" : @"ORKVideoInstructionStep",
                                                                              @"ORKVisualConsentStepViewController" : @"ORKVisualConsentStep",
                                                                              @"ORKWalkingTaskStepViewController" : @"ORKWalkingTaskStep",
+                                                                             @"ORKTableStepViewController" : @"ORKTableStep",
+                                                                             @"ORKdBHLToneAudiometryStepViewController" : @"ORKdBHLToneAudiometryStep"
                                                                              };
     
     NSDictionary <NSString *, NSDictionary *> *kvMapForStep = @{ // Steps that require modification to validate

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -884,6 +884,11 @@ ORK_MAKE_TEST_INIT(NSRegularExpression, (^{
                                        @"ORKStepResult.isPreviousResult",
                                        @"ORKTextAnswerFormat.validationRegex",
                                        @"ORKVideoCaptureStep.duration",
+                                       @"ORKQuestionStep.useCardView",
+                                       @"ORKFormStep.useCardView",
+                                       @"ORKSpeechRecognitionStep.shouldHideTranscript",
+                                       @"ORKTableStep.isBulleted",
+                                       @"ORKPDFViewerStep.actionBarOption"
                                        ];
     
     NSArray *hashExclusionList = @[
@@ -896,8 +901,10 @@ ORK_MAKE_TEST_INIT(NSRegularExpression, (^{
                                    @"ORKNumericAnswerFormat.minimum",
                                    @"ORKNumericAnswerFormat.maximum",
                                    @"ORKNumericAnswerFormat.maximumFractionDigits",
+                                   @"ORKNumericAnswerFormat.defaultNumericAnswer",
                                    @"ORKVideoCaptureStep.duration",
                                    @"ORKTextAnswerFormat.validationRegularExpression",
+                                   @"ORKPDFViewerStep.pdfURL"
                                    ];
     
     // Test Each class

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -382,7 +382,8 @@ ORK_MAKE_TEST_INIT(NSRegularExpression, (^{
                                                      [ORKCollector class], // ORKCollector doesn't support JSON serialization
                                                      [ORKHealthCollector class],
                                                      [ORKHealthCorrelationCollector class],
-                                                     [ORKMotionActivityCollector class]
+                                                     [ORKMotionActivityCollector class],
+                                                     [ORKShoulderRangeOfMotionStep class],
                                                      ];
     
     if ((classesExcludedForORKESerialization.count + classesWithORKSerialization.count) != classesWithSecureCoding.count) {

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -468,7 +468,8 @@ ORK_MAKE_TEST_INIT(NSRegularExpression, (^{
                                               @"ORKSignatureResult.signatureImage",
                                               @"ORKSignatureResult.signaturePath",
                                               @"ORKPageStep.steps",
-                                              @"ORKNavigablePageStep.steps"
+                                              @"ORKNavigablePageStep.steps",
+                                              @"ORKNumericAnswerFormat.defaultNumericAnswer"
                                               ];
     NSArray *allowedUnTouchedKeys = @[@"_class"];
     

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -457,6 +457,8 @@ ORK_MAKE_TEST_INIT(NSRegularExpression, (^{
                                               @"ORKLoginStep.loginViewControllerClass",
                                               @"ORKRegistrationStep.passcodeValidationRegularExpression",
                                               @"ORKRegistrationStep.passcodeInvalidMessage",
+                                              @"ORKRegistrationStep.phoneNumberValidationRegularExpression",
+                                              @"ORKRegistrationStep.phoneNumberInvalidMessage",
                                               @"ORKSignatureResult.signatureImage",
                                               @"ORKSignatureResult.signaturePath",
                                               @"ORKPageStep.steps",
@@ -693,8 +695,8 @@ ORK_MAKE_TEST_INIT(NSRegularExpression, (^{
                                               @"ORKSignatureResult.signatureImage",
                                               @"ORKSignatureResult.signaturePath",
                                               @"ORKPageStep.steps",
-                                              @"ORKNavigablePageStep.steps",
-                                              ];
+                                              @"ORKRegistrationStep.phoneNumberValidationRegularExpression",
+                                              @"ORKRegistrationStep.phoneNumberInvalidMessage"];
     
     // Test Each class
     for (Class aClass in classesWithSecureCoding) {

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -462,7 +462,7 @@ ORK_MAKE_TEST_INIT(NSRegularExpression, (^{
                                               @"ORKSignatureResult.signatureImage",
                                               @"ORKSignatureResult.signaturePath",
                                               @"ORKPageStep.steps",
-                                              @"ORKNavigablePageStep.steps",
+                                              @"ORKNavigablePageStep.steps"
                                               ];
     NSArray *allowedUnTouchedKeys = @[@"_class"];
     
@@ -698,7 +698,13 @@ ORK_MAKE_TEST_INIT(NSRegularExpression, (^{
                                               
                                               @"ORKRegistrationStep.phoneNumberValidationRegularExpression",
                                               @"ORKRegistrationStep.phoneNumberInvalidMessage",
-                                              @"ORKTableStep.bulletIconNames"];
+                                              @"ORKTableStep.bulletIconNames",
+                                              @"ORKAmslerGridResult.image",
+                                              @"ORKHealthClinicalTypeRecorderConfiguration.healthClinicalType",
+                                              @"ORKHealthClinicalTypeRecorderConfiguration.healthFHIRResourceType",
+                                              @"ORKInstructionStep.attributedDetailText",
+                                              @"ORKOrderedTask.progressLabelColor"
+                                              ];
     
     // Test Each class
     for (Class aClass in classesWithSecureCoding) {

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -373,9 +373,9 @@ ORK_MAKE_TEST_INIT(NSRegularExpression, (^{
                                                      [ORKStepNavigationRule class],     // abstract base class
                                                      [ORKSkipStepNavigationRule class],     // abstract base class
                                                      [ORKStepModifier class],     // abstract base class
-                                                     [ORKPredicateSkipStepNavigationRule class],     // NSPredicate doesn't yet support JSON serialzation
-                                                     [ORKKeyValueStepModifier class],     // NSPredicate doesn't yet support JSON serialzation
-                                                     [ORKCollector class], // ORKCollector doesn't support JSON serialzation
+                                                     [ORKPredicateSkipStepNavigationRule class],     // NSPredicate doesn't yet support JSON serialization
+                                                     [ORKKeyValueStepModifier class],     // NSPredicate doesn't yet support JSON serialization
+                                                     [ORKCollector class], // ORKCollector doesn't support JSON serialization
                                                      [ORKHealthCollector class],
                                                      [ORKHealthCorrelationCollector class],
                                                      [ORKMotionActivityCollector class]

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -214,6 +214,7 @@ ORK_MAKE_TEST_INIT(ORKAccelerometerRecorderConfiguration, ^{return [super initWi
 ORK_MAKE_TEST_INIT(ORKHealthQuantityTypeRecorderConfiguration, ^{ return [super initWithIdentifier:@"testRecorder"];});
 ORK_MAKE_TEST_INIT(ORKAudioRecorderConfiguration, ^{ return [super initWithIdentifier:@"testRecorder"];});
 ORK_MAKE_TEST_INIT(ORKDeviceMotionRecorderConfiguration, ^{ return [super initWithIdentifier:@"testRecorder"];});
+ORK_MAKE_TEST_INIT(ORKHealthClinicalTypeRecorderConfiguration, ^{return [self initWithIdentifier:@"testRecorder" healthClinicalType:[HKClinicalType clinicalTypeForIdentifier:HKClinicalTypeIdentifierAllergyRecord] healthFHIRResourceType:nil];});
 ORK_MAKE_TEST_INIT(CLCircularRegion, (^{
     return [self initWithCenter:CLLocationCoordinate2DMake(2.0, 3.0) radius:100.0 identifier:@"identifier"];
 }))

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -241,6 +241,9 @@ ORK_MAKE_TEST_INIT(HKCorrelationType, (^{
 ORK_MAKE_TEST_INIT(HKCharacteristicType, (^{
     return [HKCharacteristicType characteristicTypeForIdentifier:HKCharacteristicTypeIdentifierBloodType];
 }))
+ORK_MAKE_TEST_INIT(HKClinicalType, (^{
+    return [HKClinicalType clinicalTypeForIdentifier:HKClinicalTypeIdentifierAllergyRecord];
+}))
 
 ORK_MAKE_TEST_INIT(NSNumber, (^{
     return [self initWithInt:123];

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -1,5 +1,6 @@
 /*
  Copyright (c) 2015, Apple Inc. All rights reserved.
+ Copyright (c) 2018, Brian Ganninger.
  
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -703,7 +703,8 @@ ORK_MAKE_TEST_INIT(NSRegularExpression, (^{
                                               @"ORKHealthClinicalTypeRecorderConfiguration.healthClinicalType",
                                               @"ORKHealthClinicalTypeRecorderConfiguration.healthFHIRResourceType",
                                               @"ORKInstructionStep.attributedDetailText",
-                                              @"ORKOrderedTask.progressLabelColor"
+                                              @"ORKOrderedTask.progressLabelColor",
+                                              @"ORKQuestionStep.question"
                                               ];
     
     // Test Each class


### PR DESCRIPTION
This PR addresses the majority of unit test failures mentioned in issue #1151 for ORKTest/ResearchKit.

- covers serialization for tone audiometry, PDF viewer, speech in noise, environmental SPL meter, speech recognition, and Amsler grid steps
- covers serialization for streaming audio recorder and clinical recorder configurations, numeric answer format

No new warnings. Down to a single failure - ORKNumericAnswerFormat is not serializing as JSON properly. I'd appreciate another set of eyes to figure that out though as I'm stumped at the moment.