### PR TITLE
Add support for textContentType from UITextInputTraits to ORKAnswerFormat

### DIFF
--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -4139,7 +4139,7 @@
 				);
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "$(SRCROOT)/ResearchKitTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.researchkit.$(PRODUCT_NAME:rfc1034identifier)";
@@ -4159,7 +4159,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "$(SRCROOT)/ResearchKitTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.researchkit.$(PRODUCT_NAME:rfc1034identifier)";

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -1432,6 +1432,21 @@ ORK_CLASS_AVAILABLE
 @property UIKeyboardType keyboardType;
 
 /**
+ The semantic UITextContentType that applies to the user's input.
+ 
+ If specified the system can improve keyboard suggestions to help with filling forms and other
+ input. By default, the value of this property is `nil` meaning no specific type.
+ */
+@property UITextContentType textContentType;
+
+/**
+ The password generation rules to use for Automatic Secure Passwords.
+ 
+ If specified, overrides the default passsword generation rules for fields with secureTextEntry.
+ */
+@property UITextInputPasswordRules *passwordRules API_AVAILABLE(ios(12));
+
+/**
  Identifies whether the text object should hide the text being entered.
  
  By default, the value of this property is NO.
@@ -1449,6 +1464,17 @@ ORK_CLASS_AVAILABLE
  */
 ORK_CLASS_AVAILABLE
 @interface ORKEmailAnswerFormat : ORKAnswerFormat
+
+/**
+ Identifies whether this email answer format is being used as a username.
+ 
+ For integration with iOS 12's password management functionality. Use this answer format if your
+ username is also an email address, if it is not guaranteed to be an email address, use
+ `ORKTextAnswerFormat` and set the `textContentType` to `UITextContentTypeUsername`.
+ 
+ By default, the value of this property is NO.
+ */
+@property (nonatomic,getter=isUsernameField) BOOL usernameField;
 
 @end
 

--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -1437,14 +1437,14 @@ ORK_CLASS_AVAILABLE
  If specified the system can improve keyboard suggestions to help with filling forms and other
  input. By default, the value of this property is `nil` meaning no specific type.
  */
-@property UITextContentType textContentType;
+@property (nonatomic, copy, nullable) UITextContentType textContentType;
 
 /**
  The password generation rules to use for Automatic Secure Passwords.
  
  If specified, overrides the default passsword generation rules for fields with secureTextEntry.
  */
-@property UITextInputPasswordRules *passwordRules API_AVAILABLE(ios(12));
+@property (nonatomic, copy, nullable) UITextInputPasswordRules *passwordRules API_AVAILABLE(ios(12));
 
 /**
  Identifies whether the text object should hide the text being entered.

--- a/ResearchKit/Common/ORKFormItemCell.m
+++ b/ResearchKit/Common/ORKFormItemCell.m
@@ -698,6 +698,11 @@ static const CGFloat HorizontalMargin = 15.0;
     self.textField.spellCheckingType = answerFormat.spellCheckingType;
     self.textField.keyboardType = answerFormat.keyboardType;
     self.textField.secureTextEntry = answerFormat.secureTextEntry;
+    self.textField.textContentType = answerFormat.textContentType;
+    
+    if (@available(iOS 12.0, *)) {
+        self.textField.passwordRules = answerFormat.passwordRules;
+    }
     
     [self answerDidChange];
 }
@@ -948,6 +953,11 @@ static const CGFloat HorizontalMargin = 15.0;
         _textView.spellCheckingType = textAnswerFormat.spellCheckingType;
         _textView.keyboardType = textAnswerFormat.keyboardType;
         _textView.secureTextEntry = textAnswerFormat.secureTextEntry;
+        _textView.textContentType = textAnswerFormat.textContentType;
+        
+        if (@available(iOS 12.0, *)) {
+            _textView.passwordRules = textAnswerFormat.passwordRules;
+        }
     } else {
         _maxLength = 0;
     }

--- a/ResearchKit/Common/ORKSurveyAnswerCellForText.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForText.m
@@ -65,6 +65,11 @@
         self.textView.spellCheckingType = textAnswerFormat.spellCheckingType;
         self.textView.keyboardType = textAnswerFormat.keyboardType;
         self.textView.secureTextEntry = textAnswerFormat.secureTextEntry;
+        self.textView.textContentType = textAnswerFormat.textContentType;
+        
+        if (@available(iOS 12.0, *)) {
+            self.textView.passwordRules = textAnswerFormat.passwordRules;
+        }
     } else {
         _maxLength = 0;
     }
@@ -284,6 +289,11 @@
         self.textField.spellCheckingType = textFormat.spellCheckingType;
         self.textField.keyboardType = textFormat.keyboardType;
         self.textField.secureTextEntry = textFormat.secureTextEntry;
+        self.textField.textContentType = textFormat.textContentType;
+        
+        if (@available(iOS 12.0, *)) {
+            self.textField.passwordRules = textFormat.passwordRules;
+        }
     }
     NSString *displayValue = (answer && answer != ORKNullAnswerValue()) ? answer : nil;
     

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -172,19 +172,26 @@ static NSString *const _FamilyNameIdentifier = @"family";
                                                              text:self.step.text];
     formStep.useSurveyMode = NO;
     
-    ORKTextAnswerFormat *nameAnswerFormat = [ORKTextAnswerFormat textAnswerFormat];
-    nameAnswerFormat.multipleLines = NO;
-    nameAnswerFormat.autocapitalizationType = UITextAutocapitalizationTypeWords;
-    nameAnswerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
-    nameAnswerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+    ORKTextAnswerFormat *givenNameAnswerFormat = [ORKTextAnswerFormat textAnswerFormat];
+    givenNameAnswerFormat.multipleLines = NO;
+    givenNameAnswerFormat.autocapitalizationType = UITextAutocapitalizationTypeWords;
+    givenNameAnswerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
+    givenNameAnswerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+    givenNameAnswerFormat.textContentType = UITextContentTypeGivenName;
     ORKFormItem *givenNameFormItem = [[ORKFormItem alloc] initWithIdentifier:_GivenNameIdentifier
                                                               text:ORKLocalizedString(@"CONSENT_NAME_GIVEN", nil)
-                                                      answerFormat:nameAnswerFormat];
+                                                      answerFormat:givenNameAnswerFormat];
     givenNameFormItem.placeholder = ORKLocalizedString(@"CONSENT_NAME_PLACEHOLDER", nil);
     
+    ORKTextAnswerFormat *familyNameAnswerFormat = [ORKTextAnswerFormat textAnswerFormat];
+    familyNameAnswerFormat.multipleLines = NO;
+    familyNameAnswerFormat.autocapitalizationType = UITextAutocapitalizationTypeWords;
+    familyNameAnswerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
+    familyNameAnswerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+    familyNameAnswerFormat.textContentType = UITextContentTypeFamilyName;
     ORKFormItem *familyNameFormItem = [[ORKFormItem alloc] initWithIdentifier:_FamilyNameIdentifier
                                                              text:ORKLocalizedString(@"CONSENT_NAME_FAMILY", nil)
-                                                     answerFormat:nameAnswerFormat];
+                                                     answerFormat:familyNameAnswerFormat];
     familyNameFormItem.placeholder = ORKLocalizedString(@"CONSENT_NAME_PLACEHOLDER", nil);
     
     givenNameFormItem.optional = NO;

--- a/ResearchKit/Onboarding/ORKLoginStep.m
+++ b/ResearchKit/Onboarding/ORKLoginStep.m
@@ -79,6 +79,7 @@ NSString *const ORKLoginFormItemIdentifierPassword = @"ORKLoginFormItemPassword"
     
     {
         ORKEmailAnswerFormat *answerFormat = [ORKAnswerFormat emailAnswerFormat];
+        answerFormat.usernameField = YES;
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKLoginFormItemIdentifierEmail
                                                                text:ORKLocalizedString(@"EMAIL_FORM_ITEM_TITLE", nil)
@@ -96,6 +97,7 @@ NSString *const ORKLoginFormItemIdentifierPassword = @"ORKLoginFormItemPassword"
         answerFormat.autocapitalizationType = UITextAutocapitalizationTypeNone;
         answerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
         answerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+        answerFormat.textContentType = UITextContentTypePassword;
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKLoginFormItemIdentifierPassword
                                                                text:ORKLocalizedString(@"PASSWORD_FORM_ITEM_TITLE", nil)

--- a/ResearchKit/Onboarding/ORKRegistrationStep.h
+++ b/ResearchKit/Onboarding/ORKRegistrationStep.h
@@ -90,28 +90,6 @@ ORK_CLASS_AVAILABLE
  @param identifier                              The string that identifies the step (see `ORKStep`).
  @param title                                   The title of the form (see `ORKStep`).
  @param text                                    The text shown immediately below the title (see `ORKStep`).
- @param passcodeRules                           A `UITextInputPasswordRules` object used for generating an automatic secure password that conforms to the `passcodeValidationRegularExpression` if the default generated passwords do not match.
- @param passcodeValidationRegularExpression     The regular expression used to validate the passcode form item (see `ORKTextAnswerFormat`).
- @param passcodeInvalidMessage                  The invalid message displayed for invalid input (see `ORKTextAnswerFormat`).
- @param options                                 The options used for the step (see `ORKRegistrationStepOption`).
- 
- @return An initialized registration step object.
- */
-- (instancetype)initWithIdentifier:(NSString *)identifier
-                             title:(nullable NSString *)title
-                              text:(nullable NSString *)text
-                     passcodeRules:(nullable UITextInputPasswordRules *)passcodeRules
-passcodeValidationRegularExpression:(nullable NSRegularExpression *)passcodeValidationRegularExpression
-            passcodeInvalidMessage:(nullable NSString *)passcodeInvalidMessage
-                           options:(ORKRegistrationStepOption)options API_AVAILABLE(ios(12.0));
-
-/**
- Returns an initialized registration step using the specified identifier,
- title, text, options, passcodeValidationRegularExpression, and passcodeInvalidMessage.
- 
- @param identifier                              The string that identifies the step (see `ORKStep`).
- @param title                                   The title of the form (see `ORKStep`).
- @param text                                    The text shown immediately below the title (see `ORKStep`).
  @param passcodeValidationRegularExpression     The regular expression used to validate the passcode form item (see `ORKTextAnswerFormat`).
  @param passcodeInvalidMessage                  The invalid message displayed for invalid input (see `ORKTextAnswerFormat`).
  @param options                                 The options used for the step (see `ORKRegistrationStepOption`).
@@ -167,11 +145,11 @@ passcodeValidationRegularExpression:(nullable NSRegularExpression *)passcodeVali
 @property (nonatomic, copy, nullable) NSString *passcodeInvalidMessage;
 
 /**
- The invalid message displayed if the passcode does not match the validation regular expression.
- This is a transparent property pointing to its definition in `ORKTextAnswerFormat`.
+ The password generation rules to use for Automatic Secure Passwords.
  
- The passcode validation regular expression property must also be set along with this property.
- By default, there is no invalid message.
+ If specified, overrides the default passsword generation rules for fields with secureTextEntry.
+ The `passcodeRules` should match the `passcodeValidationRegularExpression` or else a passcode
+ may be generated that fails validation.
  */
 @property (nonatomic, nullable) UITextInputPasswordRules *passcodeRules API_AVAILABLE(ios(12.0));
 

--- a/ResearchKit/Onboarding/ORKRegistrationStep.h
+++ b/ResearchKit/Onboarding/ORKRegistrationStep.h
@@ -29,7 +29,7 @@
  */
 
 
-@import Foundation;
+@import UIKit;
 #import <ResearchKit/ORKFormStep.h>
 
 
@@ -82,6 +82,28 @@ ORK_EXTERN NSString *const ORKRegistrationFormItemIdentifierPhoneNumber ORK_AVAI
  */
 ORK_CLASS_AVAILABLE
 @interface ORKRegistrationStep : ORKFormStep
+
+/**
+ Returns an initialized registration step using the specified identifier,
+ title, text, options, passcodeValidationRegularExpression, and passcodeInvalidMessage.
+ 
+ @param identifier                              The string that identifies the step (see `ORKStep`).
+ @param title                                   The title of the form (see `ORKStep`).
+ @param text                                    The text shown immediately below the title (see `ORKStep`).
+ @param passcodeRules                           A `UITextInputPasswordRules` object used for generating an automatic secure password that conforms to the `passcodeValidationRegularExpression` if the default generated passwords do not match.
+ @param passcodeValidationRegularExpression     The regular expression used to validate the passcode form item (see `ORKTextAnswerFormat`).
+ @param passcodeInvalidMessage                  The invalid message displayed for invalid input (see `ORKTextAnswerFormat`).
+ @param options                                 The options used for the step (see `ORKRegistrationStepOption`).
+ 
+ @return An initialized registration step object.
+ */
+- (instancetype)initWithIdentifier:(NSString *)identifier
+                             title:(nullable NSString *)title
+                              text:(nullable NSString *)text
+                     passcodeRules:(nullable UITextInputPasswordRules *)passcodeRules
+passcodeValidationRegularExpression:(nullable NSRegularExpression *)passcodeValidationRegularExpression
+            passcodeInvalidMessage:(nullable NSString *)passcodeInvalidMessage
+                           options:(ORKRegistrationStepOption)options API_AVAILABLE(ios(12.0));
 
 /**
  Returns an initialized registration step using the specified identifier,
@@ -143,6 +165,15 @@ passcodeValidationRegularExpression:(nullable NSRegularExpression *)passcodeVali
  By default, there is no invalid message.
  */
 @property (nonatomic, copy, nullable) NSString *passcodeInvalidMessage;
+
+/**
+ The invalid message displayed if the passcode does not match the validation regular expression.
+ This is a transparent property pointing to its definition in `ORKTextAnswerFormat`.
+ 
+ The passcode validation regular expression property must also be set along with this property.
+ By default, there is no invalid message.
+ */
+@property (nonatomic, nullable) UITextInputPasswordRules *passcodeRules API_AVAILABLE(ios(12.0));
 
 /**
  The regular expression used to validate the phone number form item.

--- a/ResearchKit/Onboarding/ORKRegistrationStep.m
+++ b/ResearchKit/Onboarding/ORKRegistrationStep.m
@@ -54,6 +54,7 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
     
     {
         ORKEmailAnswerFormat *answerFormat = [ORKAnswerFormat emailAnswerFormat];
+        answerFormat.usernameField = YES;
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKRegistrationFormItemIdentifierEmail
                                                                text:ORKLocalizedString(@"EMAIL_FORM_ITEM_TITLE", nil)
@@ -72,6 +73,12 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
         answerFormat.autocapitalizationType = UITextAutocapitalizationTypeNone;
         answerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
         answerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+        
+        if (@available(iOS 12.0, *)) {
+            answerFormat.textContentType = UITextContentTypeNewPassword;
+        } else {
+            answerFormat.textContentType = UITextContentTypePassword;
+        }
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKRegistrationFormItemIdentifierPassword
                                                                text:ORKLocalizedString(@"PASSWORD_FORM_ITEM_TITLE", nil)
@@ -101,6 +108,7 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
     if (options & ORKRegistrationStepIncludeGivenName) {
         ORKTextAnswerFormat *answerFormat = [ORKAnswerFormat textAnswerFormat];
         answerFormat.multipleLines = NO;
+        answerFormat.textContentType = UITextContentTypeGivenName;
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKRegistrationFormItemIdentifierGivenName
                                                                text:ORKLocalizedString(@"CONSENT_NAME_GIVEN", nil)
@@ -114,6 +122,7 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
     if (options & ORKRegistrationStepIncludeFamilyName) {
         ORKTextAnswerFormat *answerFormat = [ORKAnswerFormat textAnswerFormat];
         answerFormat.multipleLines = NO;
+        answerFormat.textContentType = UITextContentTypeFamilyName;
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKRegistrationFormItemIdentifierFamilyName
                                                                text:ORKLocalizedString(@"CONSENT_NAME_FAMILY", nil)
@@ -177,6 +186,7 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
         answerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
         answerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
         answerFormat.keyboardType = UIKeyboardTypeNumbersAndPunctuation;
+        answerFormat.textContentType = UITextContentTypeTelephoneNumber;
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:ORKRegistrationFormItemIdentifierPhoneNumber
                                                                text:ORKLocalizedString(@"PHONE_NUMBER_FORM_ITEM_TITLE", nil)
@@ -192,6 +202,25 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
 
 
 @implementation ORKRegistrationStep
+
+- (instancetype)initWithIdentifier:(NSString *)identifier
+                             title:(NSString *)title
+                              text:(NSString *)text
+                     passcodeRules:(UITextInputPasswordRules *)passcodeRules
+passcodeValidationRegularExpression:(NSRegularExpression *)passcodeValidationRegularExpression
+            passcodeInvalidMessage:(NSString *)passcodeInvalidMessage
+                           options:(ORKRegistrationStepOption)options {
+    self = [self initWithIdentifier:identifier
+                              title:title
+                               text:text
+passcodeValidationRegularExpression:passcodeValidationRegularExpression
+             passcodeInvalidMessage:passcodeInvalidMessage
+                            options:options];
+    if (self) {
+        self.passcodeRules = passcodeRules;
+    }
+    return self;
+}
 
 - (instancetype)initWithIdentifier:(NSString *)identifier
                              title:(NSString *)title
@@ -283,6 +312,14 @@ passcodeValidationRegularExpression:nil
 
 - (void)setPasscodeInvalidMessage:(NSString *)passcodeInvalidMessage {
     [self passwordAnswerFormat].invalidMessage = passcodeInvalidMessage;
+}
+
+- (UITextInputPasswordRules *)passcodeRules {
+    return [self passwordAnswerFormat].passwordRules;
+}
+
+- (void)setPasscodeRules:(UITextInputPasswordRules *)passcodeRules {
+    [self passwordAnswerFormat].passwordRules = passcodeRules;
 }
 
 - (NSRegularExpression *)phoneNumberValidationRegularExpression {

--- a/ResearchKit/Onboarding/ORKRegistrationStep.m
+++ b/ResearchKit/Onboarding/ORKRegistrationStep.m
@@ -206,25 +206,6 @@ static NSArray <ORKFormItem*> *ORKRegistrationFormItems(ORKRegistrationStepOptio
 - (instancetype)initWithIdentifier:(NSString *)identifier
                              title:(NSString *)title
                               text:(NSString *)text
-                     passcodeRules:(UITextInputPasswordRules *)passcodeRules
-passcodeValidationRegularExpression:(NSRegularExpression *)passcodeValidationRegularExpression
-            passcodeInvalidMessage:(NSString *)passcodeInvalidMessage
-                           options:(ORKRegistrationStepOption)options {
-    self = [self initWithIdentifier:identifier
-                              title:title
-                               text:text
-passcodeValidationRegularExpression:passcodeValidationRegularExpression
-             passcodeInvalidMessage:passcodeInvalidMessage
-                            options:options];
-    if (self) {
-        self.passcodeRules = passcodeRules;
-    }
-    return self;
-}
-
-- (instancetype)initWithIdentifier:(NSString *)identifier
-                             title:(NSString *)title
-                              text:(NSString *)text
 passcodeValidationRegularExpression:(NSRegularExpression *)passcodeValidationRegularExpression
             passcodeInvalidMessage:(NSString *)passcodeInvalidMessage
                            options:(ORKRegistrationStepOption)options {

--- a/ResearchKitTests/ORKAnswerFormatTests.m
+++ b/ResearchKitTests/ORKAnswerFormatTests.m
@@ -92,6 +92,11 @@
     answerFormat.multipleLines = NO;
     answerFormat.secureTextEntry = YES;
     answerFormat.keyboardType = UIKeyboardTypeASCIICapable;
+    if (@available(iOS 12.0, *)) {
+        answerFormat.textContentType = UITextContentTypeNewPassword;
+    } else {
+        answerFormat.textContentType = UITextContentTypePassword;
+    }
     answerFormat.maximumLength = 12;
     NSRegularExpression *validationRegularExpression =
     [NSRegularExpression regularExpressionWithPattern:@"^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[$@$!%*?&])[A-Za-z\\d$@$!%*?&]{10,}"
@@ -133,6 +138,11 @@
     XCTAssertFalse(confirmAnswer.multipleLines);
     XCTAssertTrue(confirmAnswer.secureTextEntry);
     XCTAssertEqual(confirmAnswer.keyboardType, UIKeyboardTypeASCIICapable);
+    if (@available(iOS 12.0, *)) {
+        XCTAssertEqual(confirmAnswer.textContentType, UITextContentTypeNewPassword);
+    } else {
+        XCTAssertEqual(confirmAnswer.textContentType, UITextContentTypePassword);
+    }
     XCTAssertEqual(confirmAnswer.maximumLength, 12);
     
     // This property should match the input answer format so that cases that

--- a/Testing/ORKTest/ORKTest/Tasks/TaskFactory+Forms.m
+++ b/Testing/ORKTest/ORKTest/Tasks/TaskFactory+Forms.m
@@ -58,6 +58,11 @@
         answerFormat.autocapitalizationType = UITextAutocapitalizationTypeNone;
         answerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
         answerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+        if (@available(iOS 12.0, *)) {
+            answerFormat.textContentType = UITextContentTypeNewPassword;
+        } else {
+            answerFormat.textContentType = UITextContentTypePassword;
+        }
         
         ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"password"
                                                                text:@"Password"
@@ -274,6 +279,7 @@
             format.autocapitalizationType = UITextAutocapitalizationTypeNone;
             format.autocorrectionType = UITextAutocorrectionTypeNo;
             format.spellCheckingType = UITextSpellCheckingTypeNo;
+            format.textContentType = UITextContentTypeURL;
             
             ORKFormItem *item = [[ORKFormItem alloc] initWithIdentifier:@"url" text:@"URL"
                                                            answerFormat:format];

--- a/Testing/ORKTest/ORKTestTests/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTestTests/ORKESerialization.m
@@ -259,6 +259,23 @@ static NSRegularExpression *regularExpressionsFromDictionary(NSDictionary *dict)
     return regularExpression;
 }
 
+static NSDictionary *dictionaryFromPasswordRules(UITextInputPasswordRules *passwordRules) {
+    NSDictionary *dictionary = passwordRules ?
+    @{
+      @"rules": passwordRules.passwordRulesDescriptor ?: @""
+      } :
+    @{};
+    return dictionary;
+}
+
+static UITextInputPasswordRules *passwordRulesFromDictionary(NSDictionary *dict) {
+    UITextInputPasswordRules *passwordRules;
+    if (dict.count == 1) {
+        passwordRules = [UITextInputPasswordRules passwordRulesWithDescriptor:dict[@"rules"]];
+    }
+    return passwordRules;
+}
+
 static NSMutableDictionary *ORKESerializationEncodingTable(void);
 static id propFromDict(NSDictionary *dict, NSString *propName);
 static NSArray *classEncodingsForClass(Class c) ;
@@ -1186,7 +1203,11 @@ encondingTable =
           PROPERTY(spellCheckingType, NSNumber, NSObject, YES, nil, nil),
           PROPERTY(keyboardType, NSNumber, NSObject, YES, nil, nil),
           PROPERTY(multipleLines, NSNumber, NSObject, YES, nil, nil),
-          PROPERTY(secureTextEntry, NSNumber, NSObject, YES, nil, nil)
+          PROPERTY(secureTextEntry, NSNumber, NSObject, YES, nil, nil),
+          PROPERTY(textContentType, NSString, NSObject, YES, nil, nil),
+          PROPERTY(passwordRules, UITextInputPasswordRules, NSObject, YES,
+                   ^id(id value) { return dictionaryFromPasswordRules((UITextInputPasswordRules *)value); },
+                   ^id(id dict) { return passwordRulesFromDictionary(dict); } )
           })),
    ENTRY(ORKEmailAnswerFormat,
          nil,

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -429,6 +429,8 @@ ORK_MAKE_TEST_INIT(NSRegularExpression, (^{
                                               @"ORKTextAnswerFormat.autocapitalizationType",
                                               @"ORKTextAnswerFormat.autocorrectionType",
                                               @"ORKTextAnswerFormat.spellCheckingType",
+                                              @"ORKTextAnswerFormat.textContentType",
+                                              @"ORKTextAnswerFormat.passwordRules",
                                               @"ORKInstructionStep.image",
                                               @"ORKInstructionStep.auxiliaryImage",
                                               @"ORKInstructionStep.iconImage",

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -1159,6 +1159,7 @@ enum TaskListRow: Int, CustomStringConvertible {
         answerFormatDomain.autocapitalizationType = UITextAutocapitalizationType.none
         answerFormatDomain.autocorrectionType = UITextAutocorrectionType.no
         answerFormatDomain.spellCheckingType = UITextSpellCheckingType.no
+        answerFormatDomain.textContentType = UITextContentType.URL
         let stepDomain = ORKQuestionStep(identifier: String(describing:Identifier.validatedTextQuestionStepDomain), title: NSLocalizedString("Validated Text", comment: ""), question: NSLocalizedString("URL", comment: ""), answer: answerFormatDomain)
         stepDomain.text = exampleDetailText
         


### PR DESCRIPTION
* Also adds support for the `passwordRules` property to support automatic secure passwords.

[`textContentType`](https://developer.apple.com/documentation/uikit/uitextcontenttype?language=objc), introduced in iOS 10, enables UITextFields to provide semantic hints to iOS so the keyboard can make more targeted selections. For instance, if you specify a `textContentType` of `UITextContentTypeGivenName` when the user focuses on the corresponding answer field, the keyboard will recommend the given name of the user from their iCloud profile. By properly annotating UITextFields, filling out a typical name and contact form becomes much easier to do, hopefully resulting in more completed surveys/forms/sign-ups/etc.

iOS 11 introduced functionality for [AutoFilling usernames and passwords](https://developer.apple.com/videos/play/wwdc2017/206) from the iCloud Keychain, and iOS 12 introduced [Automatic Secure Password generation](https://developer.apple.com/videos/play/wwdc2018/204/), both of which are built off of the `textContentType` property. ([Developer Documentation](https://developer.apple.com/documentation/security/password_autofill?language=objc).)

This PR adds the ability to specify the `textContentType` of an `ORKAnswerFormat`. Additionally, it adds support for `passwordRules` and the ability to tag an `ORKEmailAnswerFormat` as a `UITextContentTypeUsername`, for working with Automatic Secure Passwords.

Finally, the `ORKConsentReviewStepViewController`, `ORKLoginStep`, and `ORKRegistrationStep` were updated to set the correct `textContentTypes` where applicable, which leads to easier form completion.

*Note: There appear to be some issues with the iOS 12 changes to AutoFill Passwords, so as of the latest iOS 12 build (12.0 and 12.0.1) it's not working. However the code is in place to set the `textContentType` on these fields for when when these issues are resolved. I've opened [rdar://45200004](https://openradar.appspot.com/radar?id=5052582154207232), [rdar://45088122](https://openradar.appspot.com/radar?id=4966581809446912), and [rdar://45087973](https://openradar.appspot.com/radar?id=4928288753451008) with Apple including simple non-ResearchKit example projects to hopefully help track these issues down.* 