### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+[homepage]: https://www.contributor-covenant.org
+
+# Code of Conduct
+To be a truly great community, [ResearchKit](http://researchkit.org) needs to welcome contributors from all walks of life,
+with different backgrounds, and with a wide range of experience. A diverse and friendly
+community will have more great ideas, more unique perspectives, and produce more innovative solutions. We will work diligently to make the ResearchKit community welcoming to everyone.
+
+To give clarity of what is expected of our members, the ResearchKit community has adopted the code of conduct 
+defined by [contributor-covenant.org][homepage]. This document is used across many open source 
+communities, and we think it articulates our values well. The full text is copied below:
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [rk-conduct@apple.com](mailto:rk-conduct@apple.com). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4.1,
+available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html)
+
+For answers to common questions about this code of conduct, see
+[https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ for medical research or for other research projects.
     * [Programming Guide](http://researchkit.org/docs/docs/Overview/GuideOverview.html)
     *  [Framework Reference](http://researchkit.org/docs/index.html)
 * [Best Practices](../../wiki/best-practices)
+* [Code of Conduct](CODE_OF_CONDUCT.md)
 * [Contributing to ResearchKit](CONTRIBUTING.md)
 * [Website](http://researchkit.org) and [Blog](http://researchkit.org/blog.html)
 * [ResearchKit BSD License](#license)


### PR DESCRIPTION
Address #1193 with the latest version from http://contributor-covenant.org. This matches what Swift does for their project to welcome the widest audience possible. Improves the "health" of the project from a GitHub perspective: https://github.com/ResearchKit/ResearchKit/community

Requires the creation of an email address for anonymous reporting per comments in the ticket and likely legal approval of this particular document's inclusion (presumably feasible since Swift was able to do so already.)