### PR TITLE
Minor example project onboarding cleanup

### DIFF
--- a/ResearchKit/ActiveTasks/ORKSpatialSpanMemoryStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKSpatialSpanMemoryStepViewController.m
@@ -247,6 +247,7 @@ typedef void (^_ORKStateHandler)(ORKState *fromState, ORKState *_toState, id con
             if (record.gameStatus != ORKSpatialSpanMemoryGameStatusSuccess) {
                 numberOfFailures++;
             }
+            
         }
     }];
     

--- a/ResearchKit/ActiveTasks/ORKSpatialSpanMemoryStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKSpatialSpanMemoryStepViewController.m
@@ -247,7 +247,6 @@ typedef void (^_ORKStateHandler)(ORKState *fromState, ORKState *_toState, id con
             if (record.gameStatus != ORKSpatialSpanMemoryGameStatusSuccess) {
                 numberOfFailures++;
             }
-            
         }
     }];
     

--- a/samples/ORKParkinsonStudy/ORKParkinsonStudy.xcodeproj/project.pbxproj
+++ b/samples/ORKParkinsonStudy/ORKParkinsonStudy.xcodeproj/project.pbxproj
@@ -119,7 +119,6 @@
 		BA87DBF920B81E3D004ACAFF /* ConsentDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentDocument.swift; sourceTree = "<group>"; };
 		BA87DBFD20B81EBF004ACAFF /* ResearchKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ResearchKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BA87DC0920B8334C004ACAFF /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = ORKParkinsonStudy/Base.lproj/Localizable.strings; sourceTree = SOURCE_ROOT; };
-		BA87DC0B20B83350004ACAFF /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = ../en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		BA87DC0D20B83642004ACAFF /* HeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
 		BA87DC1020B8BA08004ACAFF /* GraphViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphViewController.swift; sourceTree = "<group>"; };
 		BA907FAD20C07558003E7BE9 /* tremor.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = tremor.json; sourceTree = "<group>"; };
@@ -367,7 +366,6 @@
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				en,
 				Base,
 			);
 			mainGroup = BA87DB9520B80FFB004ACAFF;
@@ -488,7 +486,6 @@
 			isa = PBXVariantGroup;
 			children = (
 				BA87DC0920B8334C004ACAFF /* Base */,
-				BA87DC0B20B83350004ACAFF /* en */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/samples/ORKParkinsonStudy/ORKParkinsonStudy/Base.lproj/Localizable.strings
+++ b/samples/ORKParkinsonStudy/ORKParkinsonStudy/Base.lproj/Localizable.strings
@@ -28,7 +28,50 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// CONSENT
+
 "CONSENT_DATA" = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam et orci eleifend, pretium sapien vel, mattis est. Vestibulum sit amet blandit leo. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Ut tincidunt orci vitae laoreet hendrerit. Morbi blandit commodo vestibulum. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Pellentesque mattis aliquet sapien eu lobortis.";
+
 "CONSENT_PRIVACY" = "Ut tincidunt orci vitae laoreet hendrerit. Morbi blandit commodo vestibulum. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Pellentesque mattis aliquet sapien eu lobortis.";
+
+
 "CONSENT_DATA_USE" = "Vestibulum dolor augue, porttitor et sapien vitae, dictum eleifend justo. Phasellus nec sollicitudin enim. Nunc vel scelerisque justo, at vehicula eros. Vestibulum tristique felis at quam suscipit, ac blandit nulla volutpat.";
 "CONSENT_WITHDRAW" = "Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Aenean sagittis vehicula risus, vehicula gravida purus laoreet at. Morbi euismod tempor urna nec placerat. Vestibulum dolor augue, porttitor et sapien vitae, dictum eleifend justo. Phasellus nec sollicitudin enim. Nunc vel scelerisque justo, at vehicula eros. Vestibulum tristique felis at quam suscipit, ac blandit nulla volutpat.";
+
+// ONBOARDING
+
+// ONBOARDING WELCOME
+
+"ONBOARDING_WELCOME_INTRO_TITLE" = "Welcome";
+
+"ONBOARDING_WELCOME_INTRO_DETAIL" = "Welcome to the ResearchKit Example Study. This sample app is an example of how to utilize the ResearchKit modules and views to create a great study.\n\nTo provide the best user experience for your study participants consider only using the necessary steps in the onboarding and consent process. This helps reduce the number of steps required to get into your main application.";
+
+// ONBOARDING EXPECTATIONS
+
+"ONBOARDING_WELCOME_EXPECTATIONS_TITLE" = "Study Expectations";
+
+"ONBOARDING_WELCOME_EXPECTATIONS_BODY" = "You should expect the following items when participating in the ResearchKit study.";
+
+"ONBOARDING_WELCOME_EXPECTATIONS_FOREGROUND" = "The study will continue to run on your device even if the study app is not in the foreground.";
+
+"ONBOARDING_WELCOME_EXPECTATIONS_STUDY_DURATION" = "The study will last for 2-4 weeks.";
+
+"ONBOARDING_WELCOME_EXPECTATIONS_STUDY_OWNER" = "ResearchKit study data will be sent to the study owner.";
+
+"ONBOARDING_WELCOME_REQUIREMENTS_TITLE" = "Study Requirements";
+
+"ONBOARDING_WELCOME_REQUIREMENTS_BODY" = "In order to participate in this study you must meet the following critera:";
+
+"ONBOARDING_WELCOME_REQUIREMENTS_AGE_LIMIT" = "Be over the age of 18";
+
+"ONBOARDING_WELCOME_REQUIREMENTS_SIMILAR_STUDY" = "Have not participated in a prior or similar version of this study";
+
+"ONBOARDING_WELCOME_REQUIREMENTS_CARRY_IPHONE" = "Carry your iPhone or Apple device around with you regularly";
+
+"ONBOARDING_WELCOME_REVIEW_BODY" = "Review the consent agreement and begin the agreement process by entering your first and last name below.";
+
+"ONBOARDING_WELCOME_REVIEW_CONSENT_AFFIRM" = "Consent to join the ResearchKit Study";
+
+"ONBOARDING_WELCOME_REVIEW_COMPLETION_TITLE" = "Success";
+
+"ONBOARDING_WELCOME_REVIEW_COMPLETION_BODY" = "Thank you for enrolling in the ResearchKit study.For the best results please stay enrolled in the study for its entire duration.";

--- a/samples/ORKParkinsonStudy/ORKParkinsonStudy/Onboarding/ConsentDocument.swift
+++ b/samples/ORKParkinsonStudy/ORKParkinsonStudy/Onboarding/ConsentDocument.swift
@@ -68,8 +68,14 @@ class ConsentDocument: ORKConsentDocument {
             }
         }
         
-        let signature = ORKConsentSignature(forPersonWithTitle: nil, dateFormatString: nil, identifier: "ConsentDocumentParticipantSignature")
-        signature.title = "Participant Signiature"
+        let signature = ORKConsentSignature(
+            forPersonWithTitle: nil,
+            dateFormatString: nil,
+            identifier: "ConsentDocumentParticipantSignature"
+        )
+        
+        signature.title = "Participant Signature"
+        
         addSignature(signature)
     }
     

--- a/samples/ORKParkinsonStudy/ORKParkinsonStudy/Onboarding/OnboardingViewController.swift
+++ b/samples/ORKParkinsonStudy/ORKParkinsonStudy/Onboarding/OnboardingViewController.swift
@@ -32,13 +32,13 @@
 import Foundation
 import ResearchKit
 
-protocol OnboardingManagerDelegate {
+protocol OnboardingManagerDelegate: class {
     func didCompleteOnboarding()
 }
 
 class OnboardingViewController: ORKTaskViewController, ORKTaskViewControllerDelegate {
     
-    var onboardingManagerDelegate: OnboardingManagerDelegate?
+    weak var onboardingManagerDelegate: OnboardingManagerDelegate?
     
     override init(task: ORKTask?, taskRun taskRunUUID: UUID?) {
         super.init(task: task, taskRun: taskRunUUID)
@@ -57,27 +57,31 @@ class OnboardingViewController: ORKTaskViewController, ORKTaskViewControllerDele
         
         // Welcome View Controller
         let welcomeStep = ORKInstructionStep(identifier: "welcomeStepIdentifier")
-        welcomeStep.title = "Welcome"
-        welcomeStep.detailText = "Welcome to the ResearchKit Example Study. This sample app is an example of how to utilize the ResearchKit modules and views to create a great study.\n\nTo provide the best user experience for your study participants consider only using the necessary steps in the onboarding and consent process. This helps reduce the number of steps required to get into your main application."
+        welcomeStep.title = NSLocalizedString("ONBOARDING_WELCOME_INTRO_TITLE", comment: "")
+        welcomeStep.detailText = NSLocalizedString("ONBOARDING_WELCOME_INTRO_DETAIL", comment: "")
         welcomeStep.iconImage = UIImage(named: "graph")!.withRenderingMode(.alwaysTemplate)
         
         // What to Expect
         let whatToExpectStep = ORKTableStep(identifier: "whatToExpectStep")
-        whatToExpectStep.title = "Study Expectations"
-        whatToExpectStep.text = "You should expect the following items when participating in the ResearchKit study."
-        whatToExpectStep.items = ["The study will continue to run on your device even if the study app is not in the foreground." as NSCopying & NSSecureCoding & NSObjectProtocol,
-                                  "The study will last for 2-4 weeks." as NSCopying & NSSecureCoding & NSObjectProtocol,
-                                  "ResearchKit study data will be sent to the study owner." as NSCopying & NSSecureCoding & NSObjectProtocol]
+        whatToExpectStep.title = NSLocalizedString("ONBOARDING_WELCOME_EXPECTATIONS_TITLE", comment: "")
+        whatToExpectStep.text = NSLocalizedString("ONBOARDING_WELCOME_EXPECTATIONS_BODY", comment: "")
+        whatToExpectStep.items = [
+            NSLocalizedString("ONBOARDING_WELCOME_EXPECTATIONS_FOREGROUND", comment: "") as NSString,
+            NSLocalizedString("ONBOARDING_WELCOME_EXPECTATIONS_STUDY_DURATION", comment: "") as NSString,
+            NSLocalizedString("ONBOARDING_WELCOME_EXPECTATIONS_STUDY_OWNER", comment: "") as NSString
+        ]
         whatToExpectStep.bulletIconNames = ["phone", "calendar", "share"]
         whatToExpectStep.isBulleted = true
         
         // Requirements
         let requirementsStep = ORKTableStep(identifier: "requirementsStep")
-        requirementsStep.title = "Study Requirements"
-        requirementsStep.text = "In order to participate in this study you must meet the following critera:"
-        requirementsStep.items = ["Be over the age of 18" as NSCopying & NSSecureCoding & NSObjectProtocol,
-                                  "Have not participated in a prior or similar version of this study" as NSCopying & NSSecureCoding & NSObjectProtocol,
-                                  "Carry your iPhone or Apple device around with you regularly" as NSCopying & NSSecureCoding & NSObjectProtocol]
+        requirementsStep.title = NSLocalizedString("ONBOARDING_WELCOME_REQUIREMENTS_TITLE", comment: "")
+        requirementsStep.text = NSLocalizedString("ONBOARDING_WELCOME_REQUIREMENTS_BODY", comment: "")
+        requirementsStep.items = [
+            NSLocalizedString("ONBOARDING_WELCOME_REQUIREMENTS_AGE_LIMIT", comment: "") as NSString,
+            NSLocalizedString("ONBOARDING_WELCOME_REQUIREMENTS_SIMILAR_STUDY", comment: "") as NSString,
+            NSLocalizedString("ONBOARDING_WELCOME_REQUIREMENTS_CARRY_IPHONE", comment: "") as NSString
+        ]
         requirementsStep.isBulleted = true
         
         // Consent document including data gathering
@@ -85,53 +89,84 @@ class OnboardingViewController: ORKTaskViewController, ORKTaskViewControllerDele
         let consentStep = ORKVisualConsentStep(identifier: "consentStep", document: consentDoc)
         
         // Review step
-        let signiature = consentDoc.signatures!.first!
-        let reviewStep = ORKConsentReviewStep(identifier: "reviewStep", signature: signiature, in: consentDoc)
-        reviewStep.text = "Review the consent agreement and begin the agreement process by entering your first and last name below."
-        reviewStep.reasonForConsent = "Consent to join the ResearchKit Study"
+        let signature = consentDoc.signatures!.first!
+        let reviewStep = ORKConsentReviewStep(identifier: "reviewStep", signature: signature, in: consentDoc)
+        reviewStep.text =  NSLocalizedString("ONBOARDING_WELCOME_REVIEW_BODY", comment: "")
+        reviewStep.reasonForConsent = NSLocalizedString(
+            "ONBOARDING_WELCOME_REVIEW_CONSENT_AFFIRM", comment: ""
+        )
         
         // Completion
         let completionStep = ORKCompletionStep(identifier: "CompletionStep")
-        completionStep.title = "Success"
-        completionStep.text = "Thank you for enrolling in the ResearchKit study.For the best results please stay enrolled in the study for its entire duration."
+        completionStep.title = NSLocalizedString("ONBOARDING_WELCOME_REVIEW_COMPLETION_TITLE", comment: "")
+        completionStep.text = NSLocalizedString("ONBOARDING_WELCOME_REVIEW_COMPLETION_BODY", comment: "")
         
         // Create task and present it
-        let task = ORKNavigableOrderedTask(identifier: "JoinTask", steps: [welcomeStep, whatToExpectStep, requirementsStep, consentStep, reviewStep, completionStep])
+        let task = ORKNavigableOrderedTask(
+            identifier: "JoinTask", steps: [
+                welcomeStep,
+                whatToExpectStep,
+                requirementsStep,
+                consentStep,
+                reviewStep,
+                completionStep
+            ]
+        )
         
         return task
     }
     
-    public func taskViewController(_ taskViewController: ORKTaskViewController, didFinishWith reason: ORKTaskViewControllerFinishReason, error: Error?) {
+    func signatureResult(taskViewController: ORKTaskViewController) -> ORKConsentSignatureResult? {
+        
+        let taskResults: [ORKResult]? = taskViewController.result.results
+        let reviewStepResult = taskResults?.filter { $0.identifier == "reviewStep" }.first
+        let reviewStepResults = (reviewStepResult as? ORKStepResult)?.results
+        let signatureResult = reviewStepResults?.first as? ORKConsentSignatureResult
+        
+        return signatureResult
+        
+    }
+    
+    func taskViewController(_ taskViewController: ORKTaskViewController, didChange result: ORKTaskResult) {
+        
+        // If there is a signature result, and no consent, exit onboarding.
+        if
+            let _signatureResult = signatureResult(taskViewController: taskViewController),
+            _signatureResult.consented == false {
+            
+            self.presentingViewController?.dismiss(animated: false, completion: nil)
+            
+        }
+        
+    }
+    
+    public func taskViewController(
+        _ taskViewController: ORKTaskViewController,
+        didFinishWith reason: ORKTaskViewControllerFinishReason, error: Error?) {
+        
         switch reason {
         case .discarded, .failed, .saved:
-            self.dismiss(animated: false, completion: nil)
-            break;
+            
+            self.presentingViewController?.dismiss(animated: false, completion: nil)
+            
         case .completed:
+            
             OnboardingStateManager.shared.setOnboardingCompletedState(state: true)
             
-            if (taskViewController.result.results != nil) {
-                let results: [ORKResult] = taskViewController.result.results!
+            // Access the first and last name from the review step
+            
+            if
+                let _signatureResult = signatureResult(taskViewController: taskViewController),
+                let signature = _signatureResult.signature {
                 
-                for result in results {
-                    if (result.identifier == "reviewStep") {
-                        let stepResult: ORKStepResult = result as! ORKStepResult;
-                        if (stepResult.results != nil && stepResult.results!.count > 0) {
-                            let signarureResult: ORKConsentSignatureResult = stepResult.results![0] as! ORKConsentSignatureResult
-                            if (signarureResult.signature != nil) {
-                                let defaults = UserDefaults.standard;
-                                defaults.set(signarureResult.signature!.givenName, forKey: "firstName")
-                                defaults.set(signarureResult.signature!.familyName, forKey: "lastName");
-                            }
-                        }
-                    }
-                }
+                let defaults = UserDefaults.standard
+                defaults.set(signature.givenName, forKey: "firstName")
+                defaults.set(signature.familyName, forKey: "lastName")
+                
             }
             
-            dismiss(animated: true, completion: {
-                if ((self.onboardingManagerDelegate != nil) && (self.onboardingManagerDelegate?.didCompleteOnboarding != nil)) {
-                }
-            })
-            break;
+            self.presentingViewController?.dismiss(animated: true, completion: nil)
+
         }
     }
 }


### PR DESCRIPTION
- Fix broken “Disagree” button in example onboarding consent flow
- Delegate reference cycle
- Tidy up localized strings
- Remove unused language config
- Tidy signature access at end of onboarding
- Minor syntax tidy