### PR TITLE
Missing embedded summary in ORKReviewStep

### DIFF
--- a/ResearchKit/Common/ORKReviewStep.m
+++ b/ResearchKit/Common/ORKReviewStep.m
@@ -116,7 +116,7 @@
 }
 
 - (BOOL)isStandalone {
-    return _steps != nil;
+    return _steps.count > 0;
 }
 
 @end


### PR DESCRIPTION
Bug introduced here:

commit 9ef1876c45f874ba04d67dd9c5ba7ae5d88a52c3
Author: Brian Ganninger <coder@infinitenexus.com>
Date:   Sun Nov 25 20:44:22 2018 -0800

    [code cleanup] Review mismatched nil returns (issue #1214)

——

Impact:
Causes an embedded ORKReviewStep to return no steps