### PR TITLE
Remove call to missing property: "modalInPresentation"

### DIFF
--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -669,14 +669,6 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     
     // Clear endDate if current TaskVC got presented again
     _dismissedDate = nil;
-    
-    if (@available(iOS 13.0, *)) {
-        if ([self dismissWithoutConfirmation]) {
-            self.modalInPresentation = NO;
-        } else {
-            self.modalInPresentation = YES;
-        }
-    }
 }
 
 - (void)viewDidDisappear:(BOOL)animated {


### PR DESCRIPTION
Framework is not building because of a call to a missing property. We
should be able to add this back in when modalInPresentation is implemented