### PR TITLE
Fix the ORKValuePickerAnswerFormat can not popup the picker controller in the Form

### DIFF
--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -692,9 +692,11 @@
             BOOL multilineTextEntry = (answerFormat.questionType == ORKQuestionTypeText && [(ORKTextAnswerFormat *)answerFormat multipleLines]);
 
             BOOL scale = (answerFormat.questionType == ORKQuestionTypeScale);
+         
+            BOOL valuePicker = [answerFormat isKindOfClass:[ORKValuePickerAnswerFormat class]];
 
             // Items require individual section
-            if (multiCellChoices || multilineTextEntry || scale) {
+            if (multiCellChoices || multilineTextEntry || scale || valuePicker) {
                 // Add new section
                 section = [[ORKTableSection alloc]  initWithSectionIndex:_allSections.count];
                 [_allSections addObject:section];


### PR DESCRIPTION
The ORKValuePickerAnswerFormat in the form should be in an individual section. 
Because it can not popup the picker controller when it is in the same section with others.