### PR TITLE
Fix displaying of Close button in ORKLearnMoreStepViewController

### DIFF
--- a/ResearchKit/Common/ORKInstructionStepViewController.m
+++ b/ResearchKit/Common/ORKInstructionStepViewController.m
@@ -165,7 +165,9 @@
 #pragma mark - ORKStepContainerLearnMoreItemDelegate
 
 - (void)stepViewLearnMoreButtonPressed:(ORKLearnMoreInstructionStep *)learnMoreStep {
-    [self presentViewController:[[ORKLearnMoreStepViewController alloc] initWithStep:learnMoreStep] animated:YES completion:nil];
+    ORKLearnMoreStepViewController *learnMoreViewController = [[ORKLearnMoreStepViewController alloc] initWithStep:learnMoreStep];
+    UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:learnMoreViewController];
+    [self presentViewController:navigationController animated:YES completion:nil];
 }
 
 @end


### PR DESCRIPTION
In the current version of the ORKLearnMoreStepViewController, the **Close** button is not showing up when presented from the ORKInstructionStepViewController. The solution is to wrap ORKLearnMoreStepViewController in UINavigationController, in the same manner as it is in ORKFormStepViewController: https://github.com/ResearchKit/ResearchKit/blob/master/ResearchKit/Common/ORKFormStepViewController.m#L1371-L1373