### PR TITLE
Bugfix - Index needs to be _allSections

### DIFF
--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -647,7 +647,7 @@
     for (ORKFormItem *item in items) {
         if (!item.answerFormat) {
             // Add new section
-            section = [[ORKTableSection alloc] initWithSectionIndex:_sections.count];
+            section = [[ORKTableSection alloc] initWithSectionIndex:_allSections.count];
             [_allSections addObject:section];
             
             // Save title


### PR DESCRIPTION
Fixes #1310 - In certain cases with section headings, this would cause a zero to be used as an index for an `ORKTableSection` which is incorrect and would cause a failure in later processing for `_beginningIndexPath` inside the `ORKTextChoiceCellGroup`.