### PR TITLE
ORKResultPredicates for ORKWebViewStepResult

### DIFF
--- a/ResearchKit/Common/ORKResultPredicate.h
+++ b/ResearchKit/Common/ORKResultPredicate.h
@@ -373,6 +373,32 @@ ORK_CLASS_AVAILABLE
                                                   matchingPattern:(NSString *)pattern;
 
 /**
+ Returns a predicate matching a result of type `ORKWebViewStepResult` whose result is equal to the
+ specified string.
+ 
+ @param resultSelector      The result selector object which specifies the step result you are
+                                interested in.
+ @param expectedString      The expected result string.
+ 
+ @return A result predicate.
+ */
++ (NSPredicate *)predicateForWebViewStepResultWithResultSelector:(ORKResultSelector *)resultSelector
+                                                  expectedString:(NSString *)expectedString;
+
+/**
+ Returns a predicate matching a result of type `ORKWebViewStepResult` whose result matches the
+ specified regular expression pattern.
+ 
+ @param resultSelector      The result selector object which specifies the step result you are
+                                interested in.
+ @param pattern             An ICU-compliant regular expression pattern that matches the result string.
+ 
+ @return A result predicate.
+ */
++ (NSPredicate *)predicateForWebViewStepResultWithResultSelector:(ORKResultSelector *)resultSelector
+                                                 matchingPattern:(NSString *)pattern;
+
+/**
  Returns a predicate matching a result of type `ORKNumericQuestionResult` whose answer is the
  specified integer value.
  

--- a/ResearchKit/Common/ORKResultPredicate.m
+++ b/ResearchKit/Common/ORKResultPredicate.m
@@ -352,6 +352,22 @@ NSString *const ORKResultPredicateTaskIdentifierVariableName = @"ORK_TASK_IDENTI
                  subPredicateFormatArgumentArray:@[ pattern ]];
 }
 
++ (NSPredicate *)predicateForWebViewStepResultWithResultSelector:(ORKResultSelector *)resultSelector
+                                                  expectedString:(NSString *)expectedString {
+    ORKThrowInvalidArgumentExceptionIfNil(expectedString);
+    return [self predicateMatchingResultSelector:resultSelector
+                         subPredicateFormatArray:@[ @"result == %@" ]
+                 subPredicateFormatArgumentArray:@[ expectedString ]];
+}
+
++ (NSPredicate *)predicateForWebViewStepResultWithResultSelector:(ORKResultSelector *)resultSelector
+                                                 matchingPattern:(NSString *)pattern {
+    ORKThrowInvalidArgumentExceptionIfNil(pattern);
+    return [self predicateMatchingResultSelector:resultSelector
+                         subPredicateFormatArray:@[ @"result matches %@" ]
+                 subPredicateFormatArgumentArray:@[ pattern ]];
+}
+
 + (NSPredicate *)predicateForNumericQuestionResultWithResultSelector:(ORKResultSelector *)resultSelector
                                                       expectedAnswer:(NSInteger)expectedAnswer {
     return [self predicateMatchingResultSelector:resultSelector


### PR DESCRIPTION
Adds some new ORKResultPredicate initializers for ORKWebViewStep results. ORKWebViewStepResult has a single `result` NSString property, so these predicates (and the associated unit tests) follow the same pattern as the existing predicates for ORKTextQuestionResult, with options for exact string match and regular expression matching.