### PR TITLE
ResearchKit #1316 - Form Fields are not scrolling when keyboard is shown

### DIFF
--- a/Testing/ORKTest/ORKTest/Customization/FooterView.m
+++ b/Testing/ORKTest/ORKTest/Customization/FooterView.m
@@ -75,14 +75,6 @@
                                                         attribute:NSLayoutAttributeBottom
                                                        multiplier:1.0
                                                          constant:-20.0]];
-    [constraints addObject:[NSLayoutConstraint constraintWithItem:_continueButton
-                                                        attribute:NSLayoutAttributeWidth
-                                                        relatedBy:NSLayoutRelationLessThanOrEqual
-                                                           toItem:self
-                                                        attribute:NSLayoutAttributeWidth
-                                                       multiplier:1.0
-                                                         constant:0.0]];
-    
     [NSLayoutConstraint activateConstraints:constraints];
 }
 


### PR DESCRIPTION
The "scrollCellToVisible" method doesn't appear to work any longer.  I used the keyboard notifications to scroll the tableView.  Only issue that I can find is that the headerView jiggles.  I've seen issues with this online, but no good results.  This appears to have been a problem since iOS 9.

Also, removed an extraneous constraint on the FooterView for the Next button.