### PR TITLE
Retrieve tint color from view's window instead of AppDelegate's window

### DIFF
--- a/ResearchKit/Common/ORKNavigationContainerView.m
+++ b/ResearchKit/Common/ORKNavigationContainerView.m
@@ -117,9 +117,6 @@ static const CGFloat activityIndicatorPadding = 24.0;
     _continueButton.exclusiveTouch = YES;
     _continueButton.translatesAutoresizingMaskIntoConstraints = NO;
     [_continueButton addTarget:self action:@selector(continueButtonAction:) forControlEvents:UIControlEventTouchUpInside];
-    if (_appTintColor) {
-        _continueButton.normalTintColor = _appTintColor;
-    }
     [self addSubview:_continueButton];
 }
 
@@ -131,9 +128,6 @@ static const CGFloat activityIndicatorPadding = 24.0;
     [_skipButton setTitle:nil forState:UIControlStateNormal];
     [_skipButton addTarget:self action:@selector(skipButtonAction:) forControlEvents:UIControlEventTouchUpInside];
     _skipButton.translatesAutoresizingMaskIntoConstraints = NO;
-    if (_appTintColor) {
-        _skipButton.normalTintColor = _appTintColor;
-    }
     [self addSubview:_skipButton];
 }
 
@@ -146,10 +140,15 @@ static const CGFloat activityIndicatorPadding = 24.0;
 }
 
 - (void)setupViews {
-    _appTintColor = [[UIApplication sharedApplication].delegate window].tintColor;
     [self setupContinueButton];
     [self setupSkipButton];
     [self setUpConstraints];
+}
+
+- (void)didMoveToWindow {
+    _appTintColor = self.window.tintColor ? : ORKColor(ORKBlueHighlightColorKey);
+    _continueButton.normalTintColor = _appTintColor;
+    _skipButton.normalTintColor = _appTintColor;
 }
 
 - (void)setSkipButtonStyle:(ORKNavigationContainerButtonStyle)skipButtonStyle {


### PR DESCRIPTION
We used to retrieve the view's tint color from a reference to the window held by the AppDelegate, however, iOS 13 introduced a new SceneDelegate pattern in which there may be more than one window. We now have to retrieve the tint color from window that the view belongs to, as there may be multiple windows with different tint colors.