### PR TITLE
dbHL Tone Audiometry requires valid values for "Sensitivity per frequency" and `_retspl` to work

### DIFF
--- a/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryAudioGenerator.m
+++ b/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryAudioGenerator.m
@@ -173,14 +173,18 @@ static OSStatus ORKdBHLAudioGeneratorZeroTone(void *inRefCon,
         _lastNodeInput = 0;
         
 //        _sensitivityPerFrequency = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle bundleForClass:[self class]] pathForResource:[NSString stringWithFormat:@"frequency_dBSPL_%@", [headphones uppercaseString]]  ofType:@"plist"]];
-        
         if ([[headphones uppercaseString] isEqualToString:@"AIRPODS"]) {
             _sensitivityPerFrequency = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle bundleForClass:[self class]] pathForResource:@"frequency_dBSPL_AIRPODS" ofType:@"plist"]];
         } else {
             _sensitivityPerFrequency = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle bundleForClass:[self class]] pathForResource:@"frequency_dBSPL_EARPODS" ofType:@"plist"]];
         }
 
-        _retspl = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle bundleForClass:[self class]] pathForResource:[NSString stringWithFormat:@"retspl_%@", [headphones uppercaseString]] ofType:@"plist"]];
+//        _retspl = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle bundleForClass:[self class]] pathForResource:[NSString stringWithFormat:@"retspl_%@", [headphones uppercaseString]] ofType:@"plist"]];
+        if ([[headphones uppercaseString] isEqualToString:@"AIRPODS"]) {
+            _retspl = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle bundleForClass:[self class]] pathForResource:@"retspl_AIRPODS" ofType:@"plist"]];
+        } else {
+            _retspl = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle bundleForClass:[self class]] pathForResource:@"retspl_EARPODS" ofType:@"plist"]];
+        }
         
         if ([[headphones uppercaseString] isEqualToString:@"AIRPODS"]) {
             _volumeCurve = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle bundleForClass:[self class]] pathForResource:@"volume_curve_AIRPODS" ofType:@"plist"]];

--- a/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryAudioGenerator.m
+++ b/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryAudioGenerator.m
@@ -172,7 +172,13 @@ static OSStatus ORKdBHLAudioGeneratorZeroTone(void *inRefCon,
     if (self) {
         _lastNodeInput = 0;
         
-        _sensitivityPerFrequency = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle bundleForClass:[self class]] pathForResource:[NSString stringWithFormat:@"frequency_dBSPL_%@", [headphones uppercaseString]]  ofType:@"plist"]];
+//        _sensitivityPerFrequency = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle bundleForClass:[self class]] pathForResource:[NSString stringWithFormat:@"frequency_dBSPL_%@", [headphones uppercaseString]]  ofType:@"plist"]];
+        
+        if ([[headphones uppercaseString] isEqualToString:@"AIRPODS"]) {
+            _sensitivityPerFrequency = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle bundleForClass:[self class]] pathForResource:@"frequency_dBSPL_AIRPODS" ofType:@"plist"]];
+        } else {
+            _sensitivityPerFrequency = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle bundleForClass:[self class]] pathForResource:@"frequency_dBSPL_EARPODS" ofType:@"plist"]];
+        }
 
         _retspl = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle bundleForClass:[self class]] pathForResource:[NSString stringWithFormat:@"retspl_%@", [headphones uppercaseString]] ofType:@"plist"]];
         


### PR DESCRIPTION
The generation of tones to be used in the dbHL Tone Audiometry Active Task requires valid dictionaries for `_sensitivityPerFrequency` and `_retspl` to work. 
Currently the value of the `headphones` is checked to set these values. 
Appropriate values for "WIRED" headphones may be required, and at least the changes proposed in this pull request make the task run again.