### PR TITLE
Use implied answer format for cells

### DIFF
--- a/ResearchKit/Common/ORKSurveyAnswerCellForImageSelection.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForImageSelection.m
@@ -35,6 +35,7 @@
 
 #import "ORKAnswerFormat_Internal.h"
 #import "ORKQuestionStep.h"
+#import "ORKQuestionStep_Internal.h"
 
 #import "ORKHelpers_Internal.h"
 #import "ORKSkin.h"
@@ -52,7 +53,7 @@
 - (void)prepareView {
     [super prepareView];
     
-    _selectionView = [[ORKImageSelectionView alloc] initWithImageChoiceAnswerFormat:(ORKImageChoiceAnswerFormat *)self.step.answerFormat answer:self.answer];
+    _selectionView = [[ORKImageSelectionView alloc] initWithImageChoiceAnswerFormat:(ORKImageChoiceAnswerFormat *)self.step.impliedAnswerFormat answer:self.answer];
     _selectionView.delegate = self;
     _selectionView.frame = self.bounds;
     

--- a/ResearchKit/Common/ORKSurveyAnswerCellForLocation.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForLocation.m
@@ -67,7 +67,7 @@
 
 - (void)prepareView {
     _selectionView = [[ORKLocationSelectionView alloc] initWithFormMode:NO
-                                                     useCurrentLocation:((ORKLocationAnswerFormat *)self.step.answerFormat).useCurrentLocation
+                                                     useCurrentLocation:((ORKLocationAnswerFormat *)self.step.impliedAnswerFormat).useCurrentLocation
                                                           leadingMargin:self.separatorInset.left];
     _selectionView.delegate = self;
     _selectionView.tintColor = self.tintColor;

--- a/ResearchKit/Common/ORKSurveyAnswerCellForNumber.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForNumber.m
@@ -76,7 +76,7 @@ static const CGFloat DontKnowButtonTopBottomPadding = 16.0;
    
     _dontKnowButtonActive = NO;
     
-    ORKNumericAnswerFormat *numericAnswerFormat = (ORKNumericAnswerFormat *)self.step.answerFormat;
+    ORKNumericAnswerFormat *numericAnswerFormat = (ORKNumericAnswerFormat *)[self.step impliedAnswerFormat];
 
     _textFieldView = [[ORKTextFieldView alloc] init];
     _textFieldView.hideUnitWhenAnswerEmpty = numericAnswerFormat.hideUnitWhenAnswerIsEmpty;

--- a/ResearchKit/Common/ORKSurveyAnswerCellForSES.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForSES.m
@@ -31,6 +31,7 @@
 #import "ORKSurveyAnswerCellForSES.h"
 #import "ORKSESSelectionView.h"
 #import "ORKQuestionStep.h"
+#import "ORKQuestionStep_Internal.h"
 
 
 @interface ORKSurveyAnswerCellForSES() <ORKSESSelectionViewDelegate>
@@ -50,7 +51,7 @@
 
 - (void)prepareView {
     [super prepareView];
-    _selectionView = [[ORKSESSelectionView alloc] initWithAnswerFormat:(ORKSESAnswerFormat *)self.step.answerFormat answer:self.answer];
+    _selectionView = [[ORKSESSelectionView alloc] initWithAnswerFormat:(ORKSESAnswerFormat *)self.step.impliedAnswerFormat answer:self.answer];
     _selectionView.delegate = self;
     _selectionView.translatesAutoresizingMaskIntoConstraints = NO;
     [self addSubview:_selectionView];

--- a/ResearchKit/Common/ORKSurveyAnswerCellForText.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCellForText.m
@@ -69,7 +69,7 @@ static const CGFloat CellBottomPadding = 5.0;
 }
 
 - (void)applyAnswerFormat {
-    ORKAnswerFormat *answerFormat = [self.step.answerFormat impliedAnswerFormat];
+    ORKAnswerFormat *answerFormat = [self.step impliedAnswerFormat];
     
     if ([answerFormat isKindOfClass:[ORKTextAnswerFormat class]]) {
         ORKTextAnswerFormat *textAnswerFormat = (ORKTextAnswerFormat *)answerFormat;


### PR DESCRIPTION
Use the `impliedAnswerFormat` for cells. Otherwise, the explicit conversion may fail since the original `answerFormat` is not an instance of the desired class type. Thus lead an exception.

For example, let us create an answer format:
```
let answerFormat = ORKHealthKitQuantityTypeAnswerFormat(quantityType: quantityType, unit: unit, style: .integer)
```
And create a task which encapsulates the format:
```
let step = ORKQuestionStep(identifier: "step0", title: title, question: text, answer: answerFormat)
let task = ORKOrderedTask(identifier: "task0", steps: [step])
```
When any cell (`ORKSurveyAnswerCellForNumber`) renders these task, it will assume the the answer format is `ORKNumericAnswerFormat`. And invoke `ORKNumericAnswerFormat` exclusive methods, lead to an exception.

@srinathtm-apple @erik-apple 