### PR TITLE
Fixed: Picker View Label text getting cropped on longer text.

### DIFF
--- a/ResearchKit/Common/ORKHeightPicker.m
+++ b/ResearchKit/Common/ORKHeightPicker.m
@@ -209,6 +209,7 @@ static const CGFloat PickerMinimumHeight = 34.0;
         [valueLabel setFont:[self defaultFont]];
         [valueLabel setTextAlignment:NSTextAlignmentCenter];
     }
+    valueLabel.adjustsFontSizeToFitWidth = YES;
     valueLabel.text = [self pickerView:pickerView titleForRow:row forComponent:component];
     return valueLabel;
 }

--- a/ResearchKit/Common/ORKMultipleValuePicker.m
+++ b/ResearchKit/Common/ORKMultipleValuePicker.m
@@ -273,6 +273,7 @@ static const CGFloat PickerMinimumHeight = 34.0;
         [valueLabel setFont:[self defaultFont]];
         [valueLabel setTextAlignment:NSTextAlignmentCenter];
     }
+    valueLabel.adjustsFontSizeToFitWidth = YES;
     valueLabel.text = [self pickerView:pickerView titleForRow:row forComponent:component];
     NSAttributedString *attributedText = [self pickerView:pickerView attributedTitleForRow:row forComponent:component];
     if (attributedText) {

--- a/ResearchKit/Common/ORKValuePicker.m
+++ b/ResearchKit/Common/ORKValuePicker.m
@@ -163,6 +163,7 @@ static const CGFloat PickerMinimumHeight = 34.0;
         [valueLabel setFont:[self defaultFont]];
         [valueLabel setTextAlignment:NSTextAlignmentCenter];
     }
+    valueLabel.adjustsFontSizeToFitWidth = YES;
     valueLabel.text = [self pickerView:pickerView titleForRow:row forComponent:component];
     NSAttributedString *attributedText = [self pickerView:pickerView attributedTitleForRow:row forComponent:component];
     if (attributedText) {

--- a/ResearchKit/Common/ORKWeightPicker.m
+++ b/ResearchKit/Common/ORKWeightPicker.m
@@ -288,6 +288,7 @@ static const CGFloat PickerMinimumHeight = 34.0;
         [valueLabel setFont:[self defaultFont]];
         [valueLabel setTextAlignment:NSTextAlignmentCenter];
     }
+    valueLabel.adjustsFontSizeToFitWidth = YES;
     valueLabel.text = [self pickerView:pickerView titleForRow:row forComponent:component];
     return valueLabel;
 }


### PR DESCRIPTION
While adding values with larger text for the **ORKValuePickerAnswerFormat**, there was an issue with the picker values as they were getting trimmed as shown below.

![ CroppedValue](https://user-images.githubusercontent.com/30460873/84372490-ceeb7d00-abf8-11ea-92f7-7eccf579f044.jpeg)

So I fixed it for my App and thought it will be helpful for others too. 

Thankyou 