### PR TITLE
Fix issue where urls with special characters were not correctly deserialized

### DIFF
--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -288,6 +288,7 @@
 		65EF3C0721B7BAE6007BE0D6 /* ORKTouchAbilitySwipeTrial.m in Sources */ = {isa = PBXBuildFile; fileRef = 65EF3C0521B7BAE6007BE0D6 /* ORKTouchAbilitySwipeTrial.m */; };
 		65EF3C0A21B7BE2C007BE0D6 /* ORKTouchAbilitySwipeContentView.h in Headers */ = {isa = PBXBuildFile; fileRef = 65EF3C0821B7BE2C007BE0D6 /* ORKTouchAbilitySwipeContentView.h */; };
 		65EF3C0B21B7BE2C007BE0D6 /* ORKTouchAbilitySwipeContentView.m in Sources */ = {isa = PBXBuildFile; fileRef = 65EF3C0921B7BE2C007BE0D6 /* ORKTouchAbilitySwipeContentView.m */; };
+		67C6B8B125BA2D61009B2E89 /* ORKHelpersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 67C6B8B025BA2D61009B2E89 /* ORKHelpersTests.m */; };
 		7118AC6720BF6A3A00D7A6BB /* Sentence7.wav in Resources */ = {isa = PBXBuildFile; fileRef = 7118AC6020BF6A3900D7A6BB /* Sentence7.wav */; };
 		7118AC6820BF6A3A00D7A6BB /* Sentence4.wav in Resources */ = {isa = PBXBuildFile; fileRef = 7118AC6120BF6A3A00D7A6BB /* Sentence4.wav */; };
 		7118AC6920BF6A3A00D7A6BB /* Sentence6.wav in Resources */ = {isa = PBXBuildFile; fileRef = 7118AC6220BF6A3A00D7A6BB /* Sentence6.wav */; };
@@ -1225,6 +1226,7 @@
 		65EF3C0521B7BAE6007BE0D6 /* ORKTouchAbilitySwipeTrial.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ORKTouchAbilitySwipeTrial.m; sourceTree = "<group>"; };
 		65EF3C0821B7BE2C007BE0D6 /* ORKTouchAbilitySwipeContentView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ORKTouchAbilitySwipeContentView.h; sourceTree = "<group>"; };
 		65EF3C0921B7BE2C007BE0D6 /* ORKTouchAbilitySwipeContentView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ORKTouchAbilitySwipeContentView.m; sourceTree = "<group>"; };
+		67C6B8B025BA2D61009B2E89 /* ORKHelpersTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ORKHelpersTests.m; sourceTree = "<group>"; };
 		7118AC5920BF6A0000D7A6BB /* Noise.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = Noise.wav; sourceTree = "<group>"; };
 		7118AC5B20BF6A1200D7A6BB /* Window.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = Window.wav; sourceTree = "<group>"; };
 		7118AC6020BF6A3900D7A6BB /* Sentence7.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = Sentence7.wav; sourceTree = "<group>"; };
@@ -2825,6 +2827,7 @@
 				86CC8EA91AC09383001CCD89 /* ORKChoiceAnswerFormatHelperTests.m */,
 				86CC8EAB1AC09383001CCD89 /* ORKDataLoggerManagerTests.m */,
 				86CC8EAC1AC09383001CCD89 /* ORKDataLoggerTests.m */,
+				67C6B8B025BA2D61009B2E89 /* ORKHelpersTests.m */,
 				86CC8EAD1AC09383001CCD89 /* ORKHKSampleTests.m */,
 				86D348001AC16175006DB02B /* ORKRecorderTests.m */,
 				86CC8EAF1AC09383001CCD89 /* ORKResultTests.m */,
@@ -4623,6 +4626,7 @@
 			files = (
 				248604061B4C98760010C8A0 /* ORKAnswerFormatTests.m in Sources */,
 				86CC8EBA1AC09383001CCD89 /* ORKResultTests.m in Sources */,
+				67C6B8B125BA2D61009B2E89 /* ORKHelpersTests.m in Sources */,
 				FA7A9D391B0969A7005A2BEA /* ORKConsentSignatureFormatterTests.m in Sources */,
 				86CC8EB81AC09383001CCD89 /* ORKHKSampleTests.m in Sources */,
 				BCB96C131B19C0EC002A0B96 /* ORKStepTests.m in Sources */,

--- a/ResearchKit/Common/ORKHelpers.m
+++ b/ResearchKit/Common/ORKHelpers.m
@@ -450,16 +450,7 @@ NSURL *ORKURLForRelativePath(NSString *relativePath) {
     }
     
     NSURL *homeDirectoryURL = ORKHomeDirectoryURL();
-    NSURL *url = [NSURL fileURLWithFileSystemRepresentation:relativePath.fileSystemRepresentation isDirectory:NO relativeToURL:homeDirectoryURL];
-    
-    if (url != nil) {
-        BOOL isDirectory = NO;;
-        BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:url.path isDirectory:&isDirectory];
-        if (fileExists && isDirectory) {
-            url = [NSURL fileURLWithFileSystemRepresentation:relativePath.fileSystemRepresentation isDirectory:YES relativeToURL:homeDirectoryURL];
-        }
-    }
-    return url;
+    return [NSURL URLWithString:relativePath relativeToURL:homeDirectoryURL];
 }
 NSString *ORKRelativePathForURL(NSURL *url) {
     if (!url) {

--- a/ResearchKitTests/ORKHelpersTests.m
+++ b/ResearchKitTests/ORKHelpersTests.m
@@ -1,0 +1,74 @@
+//
+/*
+ Copyright (c) 2021, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <XCTest/XCTest.h>
+#import "ORKHelpers_Internal.h"
+
+@interface ORKHelpersTests : XCTestCase
+
+@end
+
+@implementation ORKHelpersTests
+
+- (void)testURLForRelativePath {
+    {
+        NSURL *url = [NSURL fileURLWithPath:NSHomeDirectory()];
+        NSString *path = ORKRelativePathForURL(url);
+        NSURL *resolvedUrl = ORKURLForRelativePath(path);
+        XCTAssertEqualObjects(url.absoluteString, resolvedUrl.absoluteString);
+    }
+    {
+        NSURL *url = [[NSURL fileURLWithPath:NSHomeDirectory()] URLByAppendingPathComponent:@"test"];
+        NSString *path = ORKRelativePathForURL(url);
+        NSURL *resolvedUrl = ORKURLForRelativePath(path);
+        XCTAssertEqualObjects(url.absoluteString, resolvedUrl.absoluteString);
+    }
+    {
+        NSURL *url = [[NSURL fileURLWithPath:NSHomeDirectory()] URLByAppendingPathComponent:@" !\"#$%&'()*+,-./:;<=>?"];
+        NSString *path = ORKRelativePathForURL(url);
+        NSURL *resolvedUrl = ORKURLForRelativePath(path);
+        XCTAssertEqualObjects(url.absoluteString, resolvedUrl.absoluteString);
+    }
+    {
+        NSURL *url = [[NSURL fileURLWithPath:NSHomeDirectory()] URLByAppendingPathComponent:@"a/a/a/a/a/a/a/a/a/"];
+        NSString *path = ORKRelativePathForURL(url);
+        NSURL *resolvedUrl = ORKURLForRelativePath(path);
+        XCTAssertEqualObjects(url.absoluteString, resolvedUrl.absoluteString);
+    }
+    {
+        NSURL *url = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
+        NSString *path = ORKRelativePathForURL(url);
+        NSURL *resolvedUrl = ORKURLForRelativePath(path);
+        XCTAssertEqualObjects(url.absoluteString, resolvedUrl.absoluteString);
+    }
+}
+
+@end


### PR DESCRIPTION
`ORKPathRelativeToURL` and `ORKURLForRelativePath` do not correctly mirror each other. `ORKPathRelativeToURL` percent encodes it's output whereas `ORKURLForRelativePath` does not percent decode it's input. These methods are used during serialization/deserialization, causing a restored `ORKFileResult` to not point at the same path as the original file result.

Fix is to replace the call to `[NSURL fileURLWithFileSystemRepresentation:...]` with `[NSURL URLWithString:...]`. This matches with the `[standardizedURL absoluteString]` call in `ORKPathRelativeToURL`.  I do not believe it is necessary to check if the file is a directory given that we are not modifying the relative path. If the original url had a trailing slash, then the output path will have a trailing slash and vice versa.