### PR TITLE
Clip step image

### DIFF
--- a/ResearchKit/Common/ORKStepContentView.m
+++ b/ResearchKit/Common/ORKStepContentView.m
@@ -188,6 +188,7 @@ typedef NS_CLOSED_ENUM(NSInteger, ORKUpdateConstraintSequence) {
     }
     _topContentImageView.contentMode = UIViewContentModeScaleAspectFit;
     [_topContentImageView setBackgroundColor:ORKColor(ORKTopContentImageViewBackgroundColorKey)];
+    [_topContentImageView setClipsToBounds:YES];
     [self addSubview:_topContentImageView];
     [self setTopContentImageViewConstraints];
 }


### PR DESCRIPTION
Clip the image at the top of the step for cases when the aspect ratio pushes the image outside of the frame.