### PR TITLE
Set ORKTaskViewController nav background color

### DIFF
--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -184,6 +184,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     [_childNavigationController.navigationBar setShadowImage:[UIImage new]];
     [_childNavigationController.navigationBar setTranslucent:NO];
     [_childNavigationController.navigationBar setBarTintColor:ORKColor(ORKBackgroundColorKey)];
+    [_childNavigationController.navigationBar setBackgroundColor:ORKColor(ORKBackgroundColorKey)];
     
     if (@available(iOS 13.0, *)) {
         [_childNavigationController.navigationBar setTitleTextAttributes:@{NSForegroundColorAttributeName : [UIColor secondaryLabelColor]}];


### PR DESCRIPTION
When presenting this view, the navigation bar isn't being set, leaving a clear bar depending on how the ORK task is presented.

This fix simply sets the bar to color of the view so it's not clear.