### PR TITLE
IOS15 Updates

### DIFF
--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -2351,6 +2351,29 @@
 			name = "Custom Vision View";
 			sourceTree = "<group>";
 		};
+		51198798245FC31C004FC2C7 /* 3D Model Manager */ = {
+			isa = PBXGroup;
+			children = (
+				51198799245FC33C004FC2C7 /* ORK3DModelManager.h */,
+				5D26E77724997EA200E53D27 /* ORK3DModelManager_Internal.h */,
+				5119879A245FC33C004FC2C7 /* ORK3DModelManager.m */,
+			);
+			name = "3D Model Manager";
+			sourceTree = "<group>";
+		};
+		511987B624612C95004FC2C7 /* USDZ Model Manager */ = {
+			isa = PBXGroup;
+			children = (
+				51198767245CA50D004FC2C7 /* ORKUSDZModelManagerScene.h */,
+				51198768245CA50D004FC2C7 /* ORKUSDZModelManagerScene.m */,
+				5119879D245FE68D004FC2C7 /* ORKUSDZModelManager.h */,
+				5119879E245FE68D004FC2C7 /* ORKUSDZModelManager.m */,
+				5166E49D247355D500151C57 /* ORKUSDZModelManagerResult.h */,
+				5166E49E247355D500151C57 /* ORKUSDZModelManagerResult.m */,
+			);
+			name = "USDZ Model Manager";
+			sourceTree = "<group>";
+		};
 		511987C024632E33004FC2C7 /* Request Permissions Step */ = {
 			isa = PBXGroup;
 			children = (
@@ -2376,29 +2399,6 @@
 				BA95AA9320ACD05100E7FF8E /* AmslerGrid */,
 			);
 			name = "Vision Tasks";
-			sourceTree = "<group>";
-		};
-		51198798245FC31C004FC2C7 /* 3D Model Manager */ = {
-			isa = PBXGroup;
-			children = (
-				51198799245FC33C004FC2C7 /* ORK3DModelManager.h */,
-				5D26E77724997EA200E53D27 /* ORK3DModelManager_Internal.h */,
-				5119879A245FC33C004FC2C7 /* ORK3DModelManager.m */,
-			);
-			name = "3D Model Manager";
-			sourceTree = "<group>";
-		};
-		511987B624612C95004FC2C7 /* USDZ Model Manager */ = {
-			isa = PBXGroup;
-			children = (
-				51198767245CA50D004FC2C7 /* ORKUSDZModelManagerScene.h */,
-				51198768245CA50D004FC2C7 /* ORKUSDZModelManagerScene.m */,
-				5119879D245FE68D004FC2C7 /* ORKUSDZModelManager.h */,
-				5119879E245FE68D004FC2C7 /* ORKUSDZModelManager.m */,
-				5166E49D247355D500151C57 /* ORKUSDZModelManagerResult.h */,
-				5166E49E247355D500151C57 /* ORKUSDZModelManagerResult.m */,
-			);
-			name = "USDZ Model Manager";
 			sourceTree = "<group>";
 		};
 		5175144B2459EBD3009E8FFC /* 3D Model */ = {
@@ -5319,7 +5319,7 @@
 				GCC_WARN_SHADOW = NO;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = ResearchKitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.researchkit.$(PRODUCT_NAME:rfc1034identifier)";
@@ -5345,7 +5345,7 @@
 				GCC_WARN_SHADOW = NO;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = ResearchKitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.researchkit.$(PRODUCT_NAME:rfc1034identifier)";
@@ -5375,6 +5375,10 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					GLES_SILENCE_DEPRECATION,
+					"$(inherited)",
+				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES;
 				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;
@@ -5385,7 +5389,7 @@
 				GCC_WARN_UNUSED_LABEL = YES;
 				INFOPLIST_FILE = ResearchKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = ResearchKit/ResearchKit.modulemap;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -5421,6 +5425,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = GLES_SILENCE_DEPRECATION;
 				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
 				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES;
 				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;
@@ -5431,7 +5436,7 @@
 				GCC_WARN_UNUSED_LABEL = YES;
 				INFOPLIST_FILE = ResearchKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = ResearchKit/ResearchKit.modulemap;
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/ResearchKit/ActiveTasks/ORKFrontFacingCameraStepContentView.m
+++ b/ResearchKit/ActiveTasks/ORKFrontFacingCameraStepContentView.m
@@ -109,7 +109,6 @@
     _submitVideoButton.titleLabel.font = [UIFont systemFontOfSize:20.0];
     [_submitVideoButton setTitleColor:UIColor.whiteColor forState:UIControlStateNormal];
     [_submitVideoButton setBackgroundColor:[UIColor systemBlueColor]];
-    [_submitVideoButton setTitleEdgeInsets:UIEdgeInsetsMake(5.0, 8.0, 5.0, 8.0)];
     [_submitVideoButton setTitle:ORKLocalizedString(@"FRONT_FACING_CAMERA_SUBMIT_VIDEO", nil) forState:UIControlStateNormal];
     [self.contentView addSubview:_submitVideoButton];
 }
@@ -194,9 +193,14 @@ typedef NS_CLOSED_ENUM(NSInteger, ORKStartStopButtonState) {
 
 - (void)setupSubviews {
     _startStopButton = [UIButton new];
+    
+    UIButtonConfiguration *buttonConfiguration = [UIButtonConfiguration plainButtonConfiguration];
+    [buttonConfiguration setContentInsets:NSDirectionalEdgeInsetsMake(0, 6, 0, 6)];
+    
+    [_startStopButton setConfiguration:buttonConfiguration];
     _startStopButton.layer.cornerRadius = 14.0;
     _startStopButton.clipsToBounds = YES;
-    _startStopButton.contentEdgeInsets = (UIEdgeInsets){.left = 6, .right = 6};
+    
     UIFontDescriptor *descriptorOne = [UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleHeadline];
     _startStopButton.titleLabel.font = [UIFont boldSystemFontOfSize:[[descriptorOne objectForKey: UIFontDescriptorSizeAttribute] doubleValue] + 1.0];
     [self.contentView addSubview:_startStopButton];

--- a/ResearchKit/ActiveTasks/ORKLocationRecorder.m
+++ b/ResearchKit/ActiveTasks/ORKLocationRecorder.m
@@ -88,7 +88,8 @@
     }
     
     self.locationManager = [self createLocationManager];
-    if ([CLLocationManager authorizationStatus] <= kCLAuthorizationStatusDenied) {
+
+    if (self.locationManager.authorizationStatus == kCLAuthorizationStatusRestricted || self.locationManager.authorizationStatus == kCLAuthorizationStatusNotDetermined) {
         [self.locationManager requestWhenInUseAuthorization];
     }
     self.locationManager.pausesLocationUpdatesAutomatically = NO;
@@ -156,7 +157,8 @@
 }
 
 - (BOOL)isRecording {
-    return [CLLocationManager locationServicesEnabled] && (self.locationManager != nil) && ([CLLocationManager authorizationStatus] > kCLAuthorizationStatusDenied);
+    
+    return [CLLocationManager locationServicesEnabled] && (self.locationManager != nil) && (self.locationManager.authorizationStatus > kCLAuthorizationStatusDenied);
 }
 
 - (void)reset {

--- a/ResearchKit/ActiveTasks/ORKRangeOfMotionStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKRangeOfMotionStepViewController.m
@@ -189,7 +189,7 @@
  */
 - (double)getDeviceAngleInDegreesFromAttitude:(CMAttitude *)attitude {
     if (!_orientation) {
-        _orientation = [UIApplication sharedApplication].statusBarOrientation;
+        _orientation = self.view.window.windowScene.interfaceOrientation;
     }
     double angle;
     if (UIInterfaceOrientationIsLandscape(_orientation)) {

--- a/ResearchKit/ActiveTasks/ORKSpatialSpanMemoryContentView.m
+++ b/ResearchKit/ActiveTasks/ORKSpatialSpanMemoryContentView.m
@@ -260,7 +260,7 @@
 - (void)setButtonItem:(ORKBorderedButton *)buttonItem {
     _buttonItem = buttonItem;
     if (buttonItem) {
-        buttonItem.contentEdgeInsets = (UIEdgeInsets){.top = 2, .bottom = 2, .left = 8, .right = 8};
+        [buttonItem updateContentInsets:NSDirectionalEdgeInsetsMake(2, 8, 2, 8)];
         buttonItem.translatesAutoresizingMaskIntoConstraints = NO;
         [_continueView addSubview:buttonItem];
         [[NSLayoutConstraint constraintWithItem:_buttonItem

--- a/ResearchKit/ActiveTasks/ORKUSDZModelManager.m
+++ b/ResearchKit/ActiveTasks/ORKUSDZModelManager.m
@@ -140,7 +140,7 @@
     [self setContinueEnabled:!self.enableContinueAfterSelection];
     _parentView = view;
     
-    _spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
+    _spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
     [_parentView addSubview:_spinner];
     [self setSpinnerConstraints];
     [_spinner startAnimating];

--- a/ResearchKit/Common/ORKCollector.m
+++ b/ResearchKit/Common/ORKCollector.m
@@ -220,7 +220,11 @@ static NSString *const ItemIdentifierFormatWithTwoPlaceholders = @"org.researchk
     self = [super initWithCoder:aDecoder];
     if (self) {
         ORK_DECODE_OBJ_CLASS(aDecoder, correlationType, HKCorrelationType);
-        ORK_DECODE_OBJ_ARRAY(aDecoder, sampleTypes, HKSampleType);
+
+        {
+            NSSet<Class> *allowedClasses = [NSSet setWithObjects:HKSampleType.self, nil];
+            _sampleTypes = [aDecoder decodeArrayOfObjectsOfClasses:allowedClasses forKey:@ORK_STRINGIFY(sampleTypes)];
+        }
         ORK_DECODE_OBJ_ARRAY(aDecoder, units, HKUnit);
         ORK_DECODE_OBJ_CLASS(aDecoder, startDate, NSDate);
         ORK_DECODE_OBJ_CLASS(aDecoder, lastAnchor, HKQueryAnchor);

--- a/ResearchKit/Common/ORKContinueButton.m
+++ b/ResearchKit/Common/ORKContinueButton.m
@@ -46,7 +46,7 @@ static const CGFloat ContinueButtonHeight = 50.0;
     if (self) {
         [self setTitle:title forState:UIControlStateNormal];
         self.isDoneButton = isDoneButton;
-        self.contentEdgeInsets = (UIEdgeInsets){.left = 6, .right = 6};
+        [self updateContentInsets:NSDirectionalEdgeInsetsMake(0, 6, 0, 6)];
 
         [self setUpConstraints];
     }

--- a/ResearchKit/Common/ORKDataCollectionManager.m
+++ b/ResearchKit/Common/ORKDataCollectionManager.m
@@ -36,7 +36,18 @@
 #import <HealthKit/HealthKit.h>
 
 
-static  NSString *const ORKDataCollectionPersistenceFileName = @".dataCollection.ork.data";
+@interface ORKDataCollectionState : NSObject <NSSecureCoding>
+
+@property(nonatomic, nullable, readwrite) NSString *archiveVersion;
+
+@property(nonatomic, nonnull, readwrite) NSArray<ORKCollector *> *collectors;
+
+@end
+
+
+// The file names for persisting the state of our collectors
+static  NSString *const ORKDataCollectionPersistenceFileNamev1 = @".dataCollection.ork.data"; // pre-secureCoding
+static  NSString *const ORKDataCollectionPersistenceFileNamev2 = @".dataCollection.ork.archive"; // current
 
 @implementation ORKDataCollectionManager {
     dispatch_queue_t _queue;
@@ -133,27 +144,45 @@ static inline void dispatch_sync_if_not_on_queue(dispatch_queue_t queue, dispatc
 
 - (NSArray<ORKCollector *> *)collectors {
     if (_collectors == nil) {
-        _collectors = [NSKeyedUnarchiver unarchiveObjectWithFile:[self persistFilePath]];
-        if (_collectors == nil) {
-            @throw [NSException exceptionWithName:NSGenericException reason: [NSString stringWithFormat:@"Failed to read from path %@", [self persistFilePath]] userInfo:nil];
+        NSError *error;
+        NSData *data = [NSData dataWithContentsOfFile:[self persistFilePath]];
+        ORKDataCollectionState *state = [NSKeyedUnarchiver unarchivedObjectOfClass:ORKDataCollectionState.self fromData:data error:&error];
+        
+        if (state == nil) {
+            NSDictionary *userInfo = @{NSUnderlyingErrorKey:error};
+            @throw [NSException exceptionWithName:NSGenericException reason: [NSString stringWithFormat:@"Failed to read from path %@", [self persistFilePath]] userInfo:userInfo];
+        } else {
+            _collectors = state.collectors ? : @[];
         }
     }
     return _collectors;
 }
 
 - (NSString * _Nonnull)persistFilePath {
-    return [_managedDirectory stringByAppendingPathComponent:ORKDataCollectionPersistenceFileName];
+    return [_managedDirectory stringByAppendingPathComponent:ORKDataCollectionPersistenceFileNamev2];
 }
 
 - (void)persistCollectors {
     NSArray *collectors = self.collectors;
     
-    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:collectors];
-    NSError *error;
-    [data writeToFile:[self persistFilePath] options:NSDataWritingAtomic|NSDataWritingFileProtectionComplete error:&error];
+    NSError *error = nil;
+
+    ORKDataCollectionState* state = [[ORKDataCollectionState alloc] init];
+    state.collectors = collectors;
+    state.archiveVersion = (NSString *)[[NSBundle bundleForClass:ORKDataCollectionManager.self] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:state requiringSecureCoding:YES error:&error];
     
-    if (error) {
-        @throw [NSException exceptionWithName:NSGenericException reason: [NSString stringWithFormat:@"Failed to write to path %@", [self persistFilePath]] userInfo:nil];
+    if (data == nil) {
+        NSDictionary *userInfo = @{NSUnderlyingErrorKey:error};
+        @throw [NSException exceptionWithName:NSGenericException reason:@"Failed to archive collectors" userInfo:userInfo];
+    }
+    
+    error = nil;
+    BOOL success = [data writeToFile:[self persistFilePath] options:NSDataWritingAtomic|NSDataWritingFileProtectionComplete error:&error];
+
+    if (success != YES) {
+        NSDictionary *userInfo = @{NSUnderlyingErrorKey:error};
+        @throw [NSException exceptionWithName:NSGenericException reason: [NSString stringWithFormat:@"Failed to write to path %@", [self persistFilePath]] userInfo:userInfo];
     }
 }
 
@@ -337,6 +366,40 @@ static inline void dispatch_sync_if_not_on_queue(dispatch_queue_t queue, dispatc
         return NO;
     }];
 
+}
+
+@end
+
+@implementation ORKDataCollectionState
+
+/// Sentinel value for archiveVersion to indicate missing version info
++ (NSString *)absentVersionInfoSentinelValue {
+    return @"0.0.0";
+}
+
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
+- (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
+    if (aDecoder.allowsKeyedCoding != YES) {
+        return nil;
+    }
+
+    self = [super init];
+    
+    NSSet<Class> *decodableClasses = [NSSet setWithObjects:
+                                      ORKCollector.self,
+                                      nil];
+    _collectors = [aDecoder decodeArrayOfObjectsOfClasses:decodableClasses forKey:@ORK_STRINGIFY(collectors)];
+    ORK_DECODE_OBJ_CLASS(aDecoder, archiveVersion, NSString);
+
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    ORK_ENCODE_OBJ(aCoder, archiveVersion ? : [self.class absentVersionInfoSentinelValue]);
+    ORK_ENCODE_OBJ(aCoder, collectors);
 }
 
 @end

--- a/ResearchKit/Common/ORKImageCaptureStepViewController.m
+++ b/ResearchKit/Common/ORKImageCaptureStepViewController.m
@@ -177,7 +177,8 @@
         photoSettings = [AVCapturePhotoSettings photoSettingsWithRawPixelFormatType:rawPixelFormatType
                                                                     processedFormat:@{AVVideoCodecKey: AVVideoCodecTypeJPEG}];
     }
-    [photoSettings setAutoStillImageStabilizationEnabled:NO];
+
+    [photoSettings setPhotoQualityPrioritization:AVCapturePhotoQualityPrioritizationSpeed];
     [photoSettings setFlashMode:(([_photoOutput.supportedFlashModes containsObject:[NSNumber numberWithInt:AVCaptureFlashModeOn]] ? AVCaptureFlashModeAuto : AVCaptureFlashModeOff))];
     
     return photoSettings;
@@ -194,7 +195,7 @@
         _imageDataExtension = @"jpeg";
     }
     
-    [photoSettings setAutoStillImageStabilizationEnabled: [_photoOutput isStillImageStabilizationSupported]];
+    [photoSettings setPhotoQualityPrioritization:AVCapturePhotoQualityPrioritizationSpeed];
     [photoSettings setFlashMode:(([_photoOutput.supportedFlashModes containsObject:[NSNumber numberWithInt:AVCaptureFlashModeOn]] ? AVCaptureFlashModeAuto : AVCaptureFlashModeOff))];
 
     return photoSettings;
@@ -288,6 +289,14 @@
     }
     
     [super viewWillDisappear:animated];
+}
+
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    
+    if (_imageCaptureView) {
+        [_imageCaptureView orientationDidChange];
+    }
 }
 
 - (void)queue_SetupCaptureSession {

--- a/ResearchKit/Common/ORKImageCaptureView.h
+++ b/ResearchKit/Common/ORKImageCaptureView.h
@@ -56,6 +56,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) UIImage *capturedImage;
 @property (nonatomic, strong, nullable) NSError *error;
 
+- (void)orientationDidChange;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKKeychainWrapper.h
+++ b/ResearchKit/Common/ORKKeychainWrapper.h
@@ -66,7 +66,7 @@ ORK_CLASS_AVAILABLE
  
  @return An object or `nil` if key is not valid.
  */
-+ (nullable id<NSSecureCoding>)objectForKey:(nonnull NSString *)key error:(NSError * __autoreleasing _Nullable *)error;
++ (nullable id<NSSecureCoding>)objectOfClass:(Class)objectClass forKey:(NSString *)key error:(NSError * __autoreleasing _Nullable *)errorOut;
 
 /**
  Removes the object in the keychain for the provided key.

--- a/ResearchKit/Common/ORKKeychainWrapper.m
+++ b/ResearchKit/Common/ORKKeychainWrapper.m
@@ -60,13 +60,14 @@ static NSString *ORKKeychainWrapperDefaultService() {
                    error:errorOut];
 }
 
-+ (id<NSSecureCoding>)objectForKey:(NSString *)key
-             error:(NSError **)errorOut {
-    NSData *data = [self dataForKey:key
-                            service:ORKKeychainWrapperDefaultService()
-                        accessGroup:nil
-                              error:errorOut];
-    return data ? [NSKeyedUnarchiver unarchiveObjectWithData:data] : nil;
++ (id<NSSecureCoding>)objectOfClass:(Class)objectClass forKey:(NSString *)key
+       error:(NSError **)errorOut {
+  NSData *data = [self dataForKey:key
+              service:ORKKeychainWrapperDefaultService()
+            accessGroup:nil
+               error:errorOut];
+  
+  return data ? [NSKeyedUnarchiver unarchivedObjectOfClass:objectClass fromData:data error:errorOut] : nil;
 }
 
 + (BOOL)removeObjectForKey:(NSString *)key

--- a/ResearchKit/Common/ORKLearnMoreView.m
+++ b/ResearchKit/Common/ORKLearnMoreView.m
@@ -60,7 +60,12 @@ ORK_CLASS_AVAILABLE
     button.titleLabel.numberOfLines = 0;
     button.titleLabel.lineBreakMode = NSLineBreakByWordWrapping;
     button.titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
-    [button setContentEdgeInsets:UIEdgeInsetsMake(CGFLOAT_MIN, CGFLOAT_MIN, CGFLOAT_MIN, CGFLOAT_MIN)];
+    
+    UIButtonConfiguration *buttonConfig = [UIButtonConfiguration filledButtonConfiguration];
+    [buttonConfig setContentInsets:NSDirectionalEdgeInsetsMake(0, 0, 0, 0)];
+    
+    [button setConfiguration:buttonConfig];
+    
     return button;
 }
 

--- a/ResearchKit/Common/ORKLocationSelectionView.m
+++ b/ResearchKit/Common/ORKLocationSelectionView.m
@@ -278,14 +278,16 @@ static const NSString *FormattedAddressLines = @"FormattedAddressLines";
 
 - (void)loadCurrentLocationIfNecessary {
     if (_useCurrentLocation) {
-        CLAuthorizationStatus status = [CLLocationManager authorizationStatus];
-        
+        CLAuthorizationStatus status = _locationManager.authorizationStatus;
+
         if (status == kCLAuthorizationStatusAuthorizedAlways || status == kCLAuthorizationStatusAuthorizedWhenInUse) {
             _userLocationNeedsUpdate = YES;
             _mapView.showsUserLocation = YES;
-        } else {
+        } else if (_locationManager == nil) {
             _locationManager = [[CLLocationManager alloc] init];
             _locationManager.delegate = self;
+        }
+        if (status == kCLAuthorizationStatusNotDetermined) {
             [_locationManager requestWhenInUseAuthorization];
         }
     }
@@ -433,10 +435,8 @@ static const NSString *FormattedAddressLines = @"FormattedAddressLines";
 
 # pragma mark CLLocationManagerDelegate
 
-- (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
-    if (status == kCLAuthorizationStatusAuthorizedAlways || status == kCLAuthorizationStatusAuthorizedWhenInUse) {
+- (void)locationManagerDidChangeAuthorization:(CLLocationManager *)manager {
         [self loadCurrentLocationIfNecessary];
-    }
 }
 
 #pragma mark MKMapViewDelegate

--- a/ResearchKit/Common/ORKNavigationContainerView.m
+++ b/ResearchKit/Common/ORKNavigationContainerView.m
@@ -294,9 +294,9 @@ static const CGFloat activityIndicatorPadding = 24.0;
 
     if (showActivityIndicator == YES) {
         if (_activityIndicatorView == nil) {
-            _activityIndicatorView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhite];
+            _activityIndicatorView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
             [_activityIndicatorView startAnimating];
-            
+
             [_continueButton addSubview:_activityIndicatorView];
             CGPoint center = CGPointMake(_continueButton.titleLabel.frame.origin.x - activityIndicatorPadding, _continueButton.titleLabel.center.y);
             [_activityIndicatorView setCenter:center];

--- a/ResearchKit/Common/ORKPDFViewerStepView.m
+++ b/ResearchKit/Common/ORKPDFViewerStepView.m
@@ -161,7 +161,7 @@ const CGFloat PDFhideViewAnimationDuration = 0.5;
     if (!_clearAnnotationsButton) {
         _clearAnnotationsButton = [ORKBorderedButton new];
     }
-    _clearAnnotationsButton.contentEdgeInsets = (UIEdgeInsets){.left = 6, .right = 6};
+    [_clearAnnotationsButton updateContentInsets:NSDirectionalEdgeInsetsMake(0, 6, 0, 6)];
     _clearAnnotationsButton.translatesAutoresizingMaskIntoConstraints = NO;
     _clearButtonView = [UIView new];
     _clearButtonView.translatesAutoresizingMaskIntoConstraints = NO;
@@ -197,7 +197,7 @@ const CGFloat PDFhideViewAnimationDuration = 0.5;
     if (!_applyAnnotationsButton) {
         _applyAnnotationsButton = [ORKBorderedButton new];
     }
-    _applyAnnotationsButton.contentEdgeInsets = (UIEdgeInsets){.left = 6, .right = 6};
+    [_applyAnnotationsButton updateContentInsets:NSDirectionalEdgeInsetsMake(0, 6, 0, 6)];
     _applyAnnotationsButton.translatesAutoresizingMaskIntoConstraints = NO;
     _applyButtonView = [UIView new];
     _applyButtonView.translatesAutoresizingMaskIntoConstraints = NO;

--- a/ResearchKit/Common/ORKPasscodeStepViewController.m
+++ b/ResearchKit/Common/ORKPasscodeStepViewController.m
@@ -126,8 +126,8 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
             _originalForgotPasscodeY = self.view.bounds.size.height - kForgotPasscodeVerticalPadding - kForgotPasscodeHeight;
             CGFloat width = self.view.bounds.size.width - 2 * kForgotPasscodeHorizontalPadding;
 
-            UIButton *forgotPasscodeButton = [ORKTextButton new];
-            forgotPasscodeButton.contentEdgeInsets = (UIEdgeInsets){12, 10, 8, 10};
+            ORKTextButton *forgotPasscodeButton = [ORKTextButton new];
+            [forgotPasscodeButton updateContentInsets: NSDirectionalEdgeInsetsMake(12, 10, 8, 10)];
             forgotPasscodeButton.frame = CGRectMake(x, _originalForgotPasscodeY, width, kForgotPasscodeHeight);
             
             NSString *buttonTitle = [self forgotPasscodeButtonText];
@@ -499,9 +499,9 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
 
 - (void)removePasscodeFromKeychain {
     NSError *error;
-    [ORKKeychainWrapper objectForKey:PasscodeKey error:&error];
+    id storedValue = [ORKKeychainWrapper objectOfClass:NSDictionary.self forKey:PasscodeKey error:&error];
     
-    if (!error) {
+    if (storedValue != nil) {
         [ORKKeychainWrapper removeObjectForKey:PasscodeKey error:&error];
     
         if (error) {
@@ -512,8 +512,10 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
 
 - (BOOL)passcodeMatchesKeychain {
     NSError *error;
-    NSDictionary *dictionary = (NSDictionary *) [ORKKeychainWrapper objectForKey:PasscodeKey error:&error];
-    if (error) {
+    NSDictionary *dictionary = (NSDictionary *) [ORKKeychainWrapper objectOfClass:NSDictionary.self
+                                                                           forKey:PasscodeKey
+                                                                            error:&error];
+    if (dictionary == nil) {
         [self throwExceptionWithKeychainError:error];
     }
     
@@ -523,8 +525,11 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
 
 - (void)setValuesFromKeychain {
     NSError *error;
-    NSDictionary *dictionary = (NSDictionary*) [ORKKeychainWrapper objectForKey:PasscodeKey error:&error];
-    if (error) {
+    NSDictionary *dictionary = (NSDictionary*) [ORKKeychainWrapper objectOfClass:NSDictionary.self
+                                                                          forKey:PasscodeKey
+                                                                           error:&error];
+    
+    if (dictionary == nil) {
         [self throwExceptionWithKeychainError:error];
     }
     

--- a/ResearchKit/Common/ORKPasscodeViewController.m
+++ b/ResearchKit/Common/ORKPasscodeViewController.m
@@ -100,7 +100,19 @@
 }
 
 + (BOOL)isPasscodeStoredInKeychain {
-    NSDictionary *dictionary = (NSDictionary *)[ORKKeychainWrapper objectForKey:PasscodeKey error:nil];
+    NSError *error;
+    NSDictionary *dictionary = (NSDictionary *)[ORKKeychainWrapper objectOfClass:NSDictionary.self
+                                                                          forKey:PasscodeKey
+                                                                           error:&error];
+    
+    if (dictionary == nil) {
+        NSString *errorReason = error.localizedDescription;
+        if (error.code == errSecItemNotFound) {
+            errorReason = @"There is no passcode stored in the keychain.";
+        }
+        @throw [NSException exceptionWithName:NSGenericException reason:errorReason userInfo:nil];
+    }
+    
     return ([dictionary objectForKey:KeychainDictionaryPasscodeKey]) ? YES : NO;
 }
 

--- a/ResearchKit/Common/ORKSignatureStepViewController.m
+++ b/ResearchKit/Common/ORKSignatureStepViewController.m
@@ -72,7 +72,9 @@
     if (self) {
         {
             _clearButton = [ORKTextButton new];
-            _clearButton.contentEdgeInsets = (UIEdgeInsets){12,10,8,10}; // insets adjusted to get correct vertical height from bottom of screen when aligned to margin
+
+            // insets adjusted to get correct vertical height from bottom of screen when aligned to margin
+            [_clearButton updateContentInsets:NSDirectionalEdgeInsetsMake(12, 10, 8, 10)];
             _clearButton.exclusiveTouch = YES;
             [_clearButton setTitle:ORKLocalizedString(@"BUTTON_CLEAR", nil) forState:UIControlStateNormal];
             _clearButton.translatesAutoresizingMaskIntoConstraints = NO;

--- a/ResearchKit/Common/ORKSkin.m
+++ b/ResearchKit/Common/ORKSkin.m
@@ -236,7 +236,14 @@ static UIWindow *ORKDefaultWindowIfWindowIsNil(UIWindow *window) {
         // Use this method instead of UIApplication's keyWindow or UIApplication's delegate's window
         // because we may need the window before the keyWindow is set (e.g., if a view controller
         // loads programmatically on the app delegate to be assigned as the root view controller)
-        window = [UIApplication sharedApplication].windows.firstObject;
+        
+        for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+            if ([scene.delegate conformsToProtocol:@protocol(UIWindowSceneDelegate)]) {
+                window = [(id<UIWindowSceneDelegate>)scene.delegate window];
+                break;
+            }
+        }
+        
     }
     return window;
 }
@@ -435,7 +442,7 @@ void ORKUpdateScrollViewBottomInset(UIScrollView *scrollView, CGFloat bottomInse
         insets.bottom = bottomInset;
         scrollView.contentInset = insets;
         
-        insets = scrollView.scrollIndicatorInsets;
+        insets = scrollView.verticalScrollIndicatorInsets;
         insets.bottom = bottomInset;
         scrollView.scrollIndicatorInsets = insets;
         

--- a/ResearchKit/Common/ORKStepHeaderView.m
+++ b/ResearchKit/Common/ORKStepHeaderView.m
@@ -98,12 +98,13 @@
         {
             _learnMoreButton = [ORKTextButton new];
             _learnMoreButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeading;
-            _learnMoreButton.contentEdgeInsets = (UIEdgeInsets){10,0,10,10};
             [_learnMoreButton setTitle:nil forState:UIControlStateNormal];
             [_learnMoreButton addTarget:self action:@selector(learnMoreAction:) forControlEvents:UIControlEventTouchUpInside];
             _learnMoreButton.exclusiveTouch = YES;
             _learnMoreButton.titleLabel.lineBreakMode = NSLineBreakByWordWrapping;
             _learnMoreButton.titleLabel.textAlignment = NSTextAlignmentNatural;
+            [_learnMoreButton updateContentInsets:NSDirectionalEdgeInsetsMake(10, 0, 10, 10)];
+            
             [self addSubview:_learnMoreButton];
             self.learnMoreButtonItem = nil;
         }

--- a/ResearchKit/Common/ORKStepViewController.m
+++ b/ResearchKit/Common/ORKStepViewController.m
@@ -434,7 +434,7 @@ static const CGFloat iPadStepTitleLabelFontSize = 50.0;
     // The default values for a view controller's supported interface orientations is set to
     // UIInterfaceOrientationMaskAll for the iPad idiom and UIInterfaceOrientationMaskAllButUpsideDown for the iPhone idiom.
     UIInterfaceOrientationMask supportedOrientations = UIInterfaceOrientationMaskAllButUpsideDown;
-    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+    if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) {
         supportedOrientations = UIInterfaceOrientationMaskAll;
     }
     return supportedOrientations;

--- a/ResearchKit/Common/ORKSurveyAnswerCell.m
+++ b/ResearchKit/Common/ORKSurveyAnswerCell.m
@@ -142,7 +142,7 @@
     UITableView *tableView = ORKFirstObjectOfClass(UITableView, cell, superview);
     
     _cachedContentInsets = tableView.contentInset;
-    _cachedScrollIndicatorInsets = tableView.scrollIndicatorInsets;
+    _cachedScrollIndicatorInsets = tableView.verticalScrollIndicatorInsets;
     
     NSDictionary *userInfo = aNotification.userInfo;
     CGSize keyboardSize = ((NSValue *)userInfo[UIKeyboardFrameEndUserInfoKey]).CGRectValue.size;
@@ -187,7 +187,7 @@
                              tableView.contentInset = _cachedContentInsets;
                          }
                          
-                         if (UIEdgeInsetsEqualToEdgeInsets(tableView.scrollIndicatorInsets, _cachedScrollIndicatorInsets) == NO) {
+                         if (UIEdgeInsetsEqualToEdgeInsets(tableView.verticalScrollIndicatorInsets, _cachedScrollIndicatorInsets) == NO) {
                              tableView.scrollIndicatorInsets = _cachedScrollIndicatorInsets;
                          }
                      }

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -101,18 +101,20 @@ typedef void (^_ORKLocationAuthorizationRequestHandler)(BOOL success);
     }
     
     _started = YES;
-    NSString *whenInUseKey = (NSString *)[[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"];
-    NSString *alwaysKey = (NSString *)[[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"];
+    NSString *allowedWhenInUse = (NSString *)[[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"];
+    NSString *allowedAlways = (NSString *)[[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"];
     
-    CLAuthorizationStatus status = [CLLocationManager authorizationStatus];
-    if ((status == kCLAuthorizationStatusNotDetermined) && (whenInUseKey || alwaysKey)) {
-        if (alwaysKey) {
-            [_manager requestAlwaysAuthorization];
+    if (_manager) {
+        CLAuthorizationStatus status = _manager.authorizationStatus;
+        if ((status == kCLAuthorizationStatusNotDetermined) && (allowedWhenInUse || allowedAlways)) {
+            if (allowedAlways) {
+                [_manager requestAlwaysAuthorization];
+            } else {
+                [_manager requestWhenInUseAuthorization];
+            }
         } else {
-            [_manager requestWhenInUseAuthorization];
+            [self finishWithResult:(status != kCLAuthorizationStatusDenied)];
         }
-    } else {
-        [self finishWithResult:(status != kCLAuthorizationStatusDenied)];
     }
 }
 
@@ -123,8 +125,10 @@ typedef void (^_ORKLocationAuthorizationRequestHandler)(BOOL success);
     }
 }
 
-- (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
-    if (_handler && _started && status != kCLAuthorizationStatusNotDetermined) {
+- (void)locationManagerDidChangeAuthorization:(CLLocationManager *)manager {
+    CLAuthorizationStatus status = manager.authorizationStatus;
+    
+    if (_started && status != kCLAuthorizationStatusNotDetermined) {
         [self finishWithResult:(status != kCLAuthorizationStatusDenied)];
     }
 }

--- a/ResearchKit/Common/ORKTextButton.h
+++ b/ResearchKit/Common/ORKTextButton.h
@@ -47,6 +47,8 @@ ORK_CLASS_AVAILABLE
 
 - (void)init_ORKTextButton;
 
+- (void)updateContentInsets:(NSDirectionalEdgeInsets)contentInsets;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKTextButton.m
+++ b/ResearchKit/Common/ORKTextButton.m
@@ -72,6 +72,12 @@
     [self setTitleColor:[[self tintColor] colorWithAlphaComponent:0.7] forState:UIControlStateHighlighted];
 }
 
+- (void)updateContentInsets:(NSDirectionalEdgeInsets)contentInsets {
+    UIButtonConfiguration *buttonConfiguration = [UIButtonConfiguration plainButtonConfiguration];
+    [buttonConfiguration setContentInsets:contentInsets];
+    [self setConfiguration:buttonConfiguration];
+}
+
 - (void)updateAppearance {
     
     self.titleLabel.font = [[self class] defaultFont];
@@ -87,30 +93,6 @@
     // regular, 14
     UIFontDescriptor *descriptor = [UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleCaption1];
     return [UIFont systemFontOfSize:((NSNumber *)[descriptor objectForKey: UIFontDescriptorSizeAttribute]).doubleValue + 2.0];
-}
-
-- (CGSize)intrinsicContentSize {
-    UILabel *label = nil;
-    
-    for (UIView *view in self.subviews) {
-        if ([view isKindOfClass:[UILabel class]]) {
-            label = (UILabel *)view;
-            break;
-        }
-    }
-    
-    // This is to avoid calling self.titleLabel when recalculation of content size is not needed.
-    // Calling self.titleLabel at here can cause weird layout error.
-    if (label && label.preferredMaxLayoutWidth > 0 && self.currentTitle.length > 0) {
-        CGSize labelSize = [self.titleLabel sizeThatFits:CGSizeMake(self.titleLabel.preferredMaxLayoutWidth, CGFLOAT_MAX)];
-        
-        CGFloat verticalPadding = MAX(self.contentEdgeInsets.top, self.titleEdgeInsets.top) +  MAX(self.contentEdgeInsets.bottom, self.titleEdgeInsets.bottom);
-        CGFloat horizontalPadding = MAX(self.contentEdgeInsets.left, self.titleEdgeInsets.left) + MAX(self.contentEdgeInsets.right, self.titleEdgeInsets.right);
-        
-        return CGSizeMake(labelSize.width+horizontalPadding,
-                          labelSize.height+verticalPadding);
-    }
-    return [super intrinsicContentSize];
 }
 
 - (UIAccessibilityTraits)accessibilityTraits {

--- a/ResearchKit/Common/ORKVideoCaptureStepViewController.m
+++ b/ResearchKit/Common/ORKVideoCaptureStepViewController.m
@@ -194,6 +194,14 @@
     [super viewWillDisappear:animated];
 }
 
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    
+    if (_videoCaptureView) {
+        [_videoCaptureView orientationDidChange];
+    }
+}
+
 - (void)queue_SetupCaptureSession {
     // Create the session
     _captureSession = [AVCaptureSession new];

--- a/ResearchKit/Common/ORKVideoCaptureView.h
+++ b/ResearchKit/Common/ORKVideoCaptureView.h
@@ -61,6 +61,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) ORKVideoCaptureCameraPreviewView *previewView;
 @property (nonatomic, strong, readonly) AVPlayerViewController *playerViewController;
 
+- (void)orientationDidChange;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKVideoCaptureView.m
+++ b/ResearchKit/Common/ORKVideoCaptureView.m
@@ -100,7 +100,6 @@
         [_navigationFooterView setAlpha:0.8];
         [self addSubview:_navigationFooterView];
         
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationDidChange) name:UIApplicationDidChangeStatusBarOrientationNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(queue_sessionRunning) name:AVCaptureSessionDidStartRunningNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sessionWasInterrupted:) name:AVCaptureSessionWasInterruptedNotification object:self.session];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sessionInterruptionEnded:) name:AVCaptureSessionInterruptionEndedNotification object:self.session];
@@ -121,24 +120,30 @@
 }
 
 - (void)orientationDidChange {
+    __weak typeof(self) weakSelf = self;
     dispatch_async(dispatch_get_main_queue(), ^{
         AVCaptureVideoOrientation orientation = AVCaptureVideoOrientationPortrait;
-        switch ([[UIApplication sharedApplication] statusBarOrientation]) {
-            case UIInterfaceOrientationLandscapeRight:
-                orientation = AVCaptureVideoOrientationLandscapeRight;
-                break;
-            case UIInterfaceOrientationLandscapeLeft:
-                orientation = AVCaptureVideoOrientationLandscapeLeft;
-                break;
-            case UIInterfaceOrientationPortraitUpsideDown:
-                orientation = AVCaptureVideoOrientationPortraitUpsideDown;
-                break;
-            case UIInterfaceOrientationPortrait:
-                orientation = AVCaptureVideoOrientationPortrait;
-                break;
-            case UIInterfaceOrientationUnknown:
-                // Do nothing in these cases, since we don't need to change display orientation.
-                return;
+        
+        UIWindowScene *windowScene = weakSelf.window.windowScene;
+        
+        if (windowScene) {
+            switch (windowScene.interfaceOrientation) {
+                case UIInterfaceOrientationLandscapeRight:
+                    orientation = AVCaptureVideoOrientationLandscapeRight;
+                    break;
+                case UIInterfaceOrientationLandscapeLeft:
+                    orientation = AVCaptureVideoOrientationLandscapeLeft;
+                    break;
+                case UIInterfaceOrientationPortraitUpsideDown:
+                    orientation = AVCaptureVideoOrientationPortraitUpsideDown;
+                    break;
+                case UIInterfaceOrientationPortrait:
+                    orientation = AVCaptureVideoOrientationPortrait;
+                    break;
+                case UIInterfaceOrientationUnknown:
+                    // Do nothing in these cases, since we don't need to change display orientation.
+                    return;
+            }
         }
         
         [_previewView setVideoOrientation:orientation];

--- a/ResearchKit/Common/ORKWaitStepView.m
+++ b/ResearchKit/Common/ORKWaitStepView.m
@@ -71,7 +71,7 @@
                 if (@available(iOS 13.0, *)) {
                     _activityIndicatorView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
                 } else {
-                    _activityIndicatorView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
+                    _activityIndicatorView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
                 }
                 [_activityIndicatorView startAnimating];
                 self.customContentView = _activityIndicatorView;

--- a/ResearchKit/Common/ORKWebViewStepViewController.m
+++ b/ResearchKit/Common/ORKWebViewStepViewController.m
@@ -397,10 +397,6 @@ static const CGFloat ORKSignatureTopPadding = 37.0;
 
 // MARK: WKWebViewDelegate
 
-- (void)webView:(WKWebView *)webView didStartProvisionalNavigation:(null_unspecified WKNavigation *)navigation {
-    [UIApplication sharedApplication].networkActivityIndicatorVisible = true;
-}
-
 - (void)webView:(WKWebView *)webView didFinishNavigation:(null_unspecified WKNavigation *)navigation {
     [webView evaluateJavaScript:@"document.readyState" completionHandler:^(id complete, NSError *readyError) {
         if (complete != nil) {
@@ -421,8 +417,6 @@ static const CGFloat ORKSignatureTopPadding = 37.0;
             }
         }
     }];
-    
-    [UIApplication sharedApplication].networkActivityIndicatorVisible = false;
 }
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {

--- a/ResearchKit/Consent/ORKConsentSection.m
+++ b/ResearchKit/Consent/ORKConsentSection.m
@@ -46,7 +46,7 @@ NSURL *ORKMovieURLForConsentSectionType(ORKConsentSectionType type) {
     CGFloat scale = [UIScreen mainScreen].scale;
     
     // For iPad, use the movie for the next scale up
-    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad && scale < 3) {
+    if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad && scale < 3) {
         scale++;
     }
     

--- a/ResearchKit/Consent/ORKEAGLMoviePlayerView.h
+++ b/ResearchKit/Consent/ORKEAGLMoviePlayerView.h
@@ -34,6 +34,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+//__attribute__((unavailable("ORKEAGLMoviePlayerView has been deprecated. Please use ORKInstructionStep instead.")))
+API_DEPRECATED("Use ORKInstructionStep for obtaining consent.", ios(2.0, 11.0)) API_UNAVAILABLE(tvos, watchos, macos)
 @interface ORKEAGLMoviePlayerView : UIView
 
 @property (nonatomic) CGSize presentationSize;

--- a/ResearchKit/Consent/ORKEAGLMoviePlayerView.m
+++ b/ResearchKit/Consent/ORKEAGLMoviePlayerView.m
@@ -123,6 +123,8 @@ static const GLfloat ColorConversion709[] = {
 @end
 
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation ORKEAGLMoviePlayerView
 
 const GLfloat DefaultPreferredRotation = 0;
@@ -732,3 +734,4 @@ const GLfloat DefaultPreferredRotation = 0;
 }
 
 @end
+#pragma clang diagnostic pop

--- a/ResearchKit/Consent/ORKVisualConsentStep.h
+++ b/ResearchKit/Consent/ORKVisualConsentStep.h
@@ -51,7 +51,8 @@ NS_ASSUME_NONNULL_BEGIN
  
  An `ORKVisualConsentStep` object produces an `ORKStepResult` object, in which the dates indicate the total amount of time participants have spent in the consent process, and the route by which they can exit the consent process.
  */
-ORK_CLASS_AVAILABLE
+
+API_DEPRECATED("Use ORKInstructionStep for obtaining consent.", ios(3.0, 11.0)) API_UNAVAILABLE(watchos, tvos)
 @interface ORKVisualConsentStep : ORKStep
 
 /**

--- a/ResearchKit/Consent/ORKVisualConsentStep.m
+++ b/ResearchKit/Consent/ORKVisualConsentStep.m
@@ -38,7 +38,8 @@
 
 #import "ORKHelpers_Internal.h"
 
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation ORKVisualConsentStep
 
 + (Class)stepViewControllerClass {
@@ -90,3 +91,4 @@
 }
 
 @end
+#pragma clang diagnostic pop

--- a/ResearchKit/Consent/ORKVisualConsentStepViewController.m
+++ b/ResearchKit/Consent/ORKVisualConsentStepViewController.m
@@ -88,8 +88,10 @@
 
 @interface ORKAnimationPlaceholderView : UIView
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 @property (nonatomic, strong) ORKEAGLMoviePlayerView *playerView;
-
+#pragma clang diagnostic pop
 - (void)scrollToTopAnimated:(BOOL)animated completion:(void (^)(BOOL finished))completion;
 
 @end
@@ -100,7 +102,10 @@
 - (instancetype)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         _playerView = [ORKEAGLMoviePlayerView new];
+#pragma clang diagnostic pop
         _playerView.hidden = YES;
         [self addSubview:_playerView];
     }
@@ -176,9 +181,12 @@
     [self showViewController:[self viewControllerForIndex:0] forward:YES animated:NO];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (ORKEAGLMoviePlayerView *)animationPlayerView {
     return [(ORKAnimationPlaceholderView *)_animationView playerView];
 }
+#pragma clang diagnostic pop
 
 - (void)viewDidLoad {
     [super viewDidLoad];
@@ -208,10 +216,13 @@
     [self updatePageIndex];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (ORKVisualConsentStep *)visualConsentStep {
     assert(!self.step || [self.step isKindOfClass:[ORKVisualConsentStep class]]);
     return (ORKVisualConsentStep *)self.step;
 }
+#pragma clang diagnostic pop
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];

--- a/ResearchKit/Consent/ORKVisualConsentStepViewController_Internal.h
+++ b/ResearchKit/Consent/ORKVisualConsentStepViewController_Internal.h
@@ -37,8 +37,10 @@ NS_ASSUME_NONNULL_BEGIN
 @class ORKEAGLMoviePlayerView;
 
 @interface ORKVisualConsentStepViewController ()
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (nullable ORKEAGLMoviePlayerView *)animationPlayerView;
+#pragma clang diagnostic pop
 
 @end
 

--- a/ResearchKit/Consent/ORKVisualConsentTransitionAnimator.m
+++ b/ResearchKit/Consent/ORKVisualConsentTransitionAnimator.m
@@ -229,9 +229,12 @@
 - (void)initialFrameDidDisplay {
     // Once our initial frame has definitely been drawn, we make ourselves visible
     // and signal the caller that the animation has started.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     ORKEAGLMoviePlayerView *playerView = [_stepViewController animationPlayerView];
     playerView.hidden = NO;
-    
+#pragma clang diagnostic pop
+
     if (_pendingContext && !_pendingContext.hasCalledLoadHandler) {
         if (_pendingContext.loadHandler) {
             _pendingContext.loadHandler(self, _pendingContext.direction);
@@ -257,7 +260,11 @@
         CVPixelBufferRef pixelBuffer = NULL;
         pixelBuffer = [_videoOutput copyPixelBufferForItemTime:outputItemTime itemTimeForDisplay:NULL];
         
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         ORKEAGLMoviePlayerView *playerView = [_stepViewController animationPlayerView];
+#pragma clang diagnostic pop
+
         CGSize playerItemPresentationSize = _playerItem.presentationSize;
         if (!CGSizeEqualToSize(playerView.presentationSize, playerItemPresentationSize)) {
             playerView.presentationSize = playerItemPresentationSize;

--- a/ResearchKitTests/ORKContinueButtonTests.swift
+++ b/ResearchKitTests/ORKContinueButtonTests.swift
@@ -33,15 +33,14 @@ import UIKit
 
 class ORKContinueButtonTests: XCTestCase {
     
-    var button: ORKContinueButton!
+    var button = ORKContinueButton(title: "BUTTON", isDoneButton: true)
     
     override func setUp() {
         super.setUp()
-        button = ORKContinueButton(title: "BUTTON", isDoneButton: true)
     }
 
     func testAttributes() {
-        XCTAssertEqual(button.titleLabel?.text, "BUTTON")
+        XCTAssertEqual(button.currentTitle, "BUTTON")
         XCTAssertEqual(button.isDoneButton, true)
     }
 }

--- a/ResearchKitTests/ORKResultTests.m
+++ b/ResearchKitTests/ORKResultTests.m
@@ -124,7 +124,7 @@
     ORKTaskResult *taskResult1 = [self createTaskResultTree];
     
     // Archive
-    id data = [NSKeyedArchiver archivedDataWithRootObject:taskResult1];
+    id data = [NSKeyedArchiver archivedDataWithRootObject:taskResult1 requiringSecureCoding:YES error:nil];
     NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:data error:nil];
     unarchiver.requiresSecureCoding = YES;
     ORKTaskResult *taskResult2 = [unarchiver decodeObjectOfClass:[ORKTaskResult class] forKey:NSKeyedArchiveRootObjectKey];

--- a/Testing/ORKTest/ORKTest.xcodeproj/project.pbxproj
+++ b/Testing/ORKTest/ORKTest.xcodeproj/project.pbxproj
@@ -757,7 +757,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/ORKTest/Supporting Files/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.example.researchkit-samplecode.ORKTest";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -780,7 +780,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/ORKTest/Supporting Files/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.example.researchkit-samplecode.ORKTest";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Testing/ORKTest/ORKTestTests/ORKESerialization.m
+++ b/Testing/ORKTest/ORKTestTests/ORKESerialization.m
@@ -2531,7 +2531,7 @@ static id jsonObjectForObject(id object, ORKESerializationContext *context) {
     NSMutableArray *a = [NSMutableArray array];
     NSDictionary *table = ORKESerializationEncodingTable();
     for (NSString *key in [table allKeys]) {
-        if ([key containsString:@"SwiftStroop"]) {
+        if ([key containsString:@"SwiftStroop"] || [key containsString:@"DataCollectionState"]) {
             continue;
         }
         [a addObject:NSClassFromString(key)];

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -543,6 +543,38 @@ ORK_MAKE_TEST_INIT(UIColor, (^{ return [self initWithRed:1 green:1 blue:1 alpha:
     [stringsForClassesExcluded addObject:@"ORKUSDZModelManagerScene"];
     [stringsForClassesExcluded addObject:@"ORKBlurFooterView"];
     [stringsForClassesExcluded addObject:@"ORKFrontFacingCameraStepOptionsView"];
+    [stringsForClassesExcluded addObject:@"ORKDataCollectionState"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityTouch"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityTouch"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityTrack"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityTrial"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityTapStep"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityTapTrial"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityPinchStep"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilitySwipeStep"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityTapResult"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityPinchTrial"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityLongPressTrial"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityScrollTrial"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityRotationTrial"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilitySwipeTrial"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityGestureRecoginzerEvent"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityRotationGestureRecoginzerEvent"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityPinchGestureRecoginzerEvent"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilitySwipeGestureRecoginzerEvent"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityPanGestureRecoginzerEvent"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityLongPressGestureRecoginzerEvent"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityTapGestureRecoginzerEvent"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityRotationStep"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityLongPressStep"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityScrollStep"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityPinchResult"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityRotationResult"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityLongPressResult"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilitySwipeResult"];
+    [stringsForClassesExcluded addObject:@"ORKTouchAbilityScrollResult"];
+    
+
     
     // Find all classes that conform to NSSecureCoding
     NSMutableArray<Class> *classesWithSecureCoding = [NSMutableArray new];

--- a/Testing/ORKTest/ORKTestTests/ORKKeychainWrapperTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKKeychainWrapperTests.m
@@ -55,8 +55,10 @@ static NSString *const invalidKey = @"RK invalid key";
     XCTAssertTrue(success);
     
     // Test that the object set is equal to the object retrieved.
-    NSString *outObject = (NSString *) [ORKKeychainWrapper objectForKey:key
-                                                                  error:&error];
+    NSString *outObject = (NSString *) [ORKKeychainWrapper objectOfClass:NSString.self
+                                                                  forKey:key
+                                                                   error:&error];
+   
     XCTAssertNil(error);
     XCTAssertEqualObjects(inObject, outObject);
     
@@ -73,14 +75,16 @@ static NSString *const invalidKey = @"RK invalid key";
     XCTAssertTrue(success);
     
     // Test that the object set is equal to the object retrieved.
-    NSString *outObject = (NSString *) [ORKKeychainWrapper objectForKey:key
-                                                                  error:&error];
+    NSString *outObject = (NSString *) [ORKKeychainWrapper objectOfClass:NSString.self
+                                                                  forKey:key
+                                                                   error:&error];
     XCTAssertNil(error);
     XCTAssertEqualObjects(inObject, outObject);
     
     // Test that there is an error for invalid key.
-    id object = [ORKKeychainWrapper objectForKey:invalidKey
-                               error:&error];
+    id object = [ORKKeychainWrapper objectOfClass:NSDictionary.class
+                                           forKey:invalidKey
+                                            error:&error];
     XCTAssertNotNil(error);
     XCTAssertNil(object);
 }
@@ -102,8 +106,9 @@ static NSString *const invalidKey = @"RK invalid key";
     XCTAssertTrue(success);
     
     // Test that there is no object for the key.
-    id object = [ORKKeychainWrapper objectForKey:key
-                                           error:&error];
+    id object = [ORKKeychainWrapper objectOfClass:NSString.self
+                                           forKey:key
+                                            error:&error];
     XCTAssertNotNil(error);
     XCTAssertNil(object);
 }
@@ -124,8 +129,9 @@ static NSString *const invalidKey = @"RK invalid key";
     XCTAssertTrue(success);
     
     // Test that there is no object for the key.
-    id object = [ORKKeychainWrapper objectForKey:key
-                                           error:&error];
+    id object = [ORKKeychainWrapper objectOfClass:NSString.self
+                                           forKey:key
+                                            error:&error];
     XCTAssertNotNil(error);
     XCTAssertNil(object);
 }

--- a/samples/ORKCatalog/ORKCatalog.xcodeproj/project.pbxproj
+++ b/samples/ORKCatalog/ORKCatalog.xcodeproj/project.pbxproj
@@ -541,7 +541,7 @@
 				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/ORKCatalog/Supporting Files/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.example.researchkit-samplecode.ORKCatalog";
 				PRODUCT_NAME = ORKCatalog;
@@ -563,7 +563,7 @@
 				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/ORKCatalog/Supporting Files/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.example.researchkit-samplecode.ORKCatalog";
 				PRODUCT_NAME = ORKCatalog;

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -84,7 +84,6 @@ enum TaskListRow: Int, CustomStringConvertible {
     case PDFViewer
     case requestPermissions
     case eligibilityTask
-    case consent
     case accountCreation
     case login
     case passcode
@@ -166,7 +165,6 @@ enum TaskListRow: Int, CustomStringConvertible {
             TaskListRowSection(title: "Onboarding", rows:
                 [
                     .eligibilityTask,
-                    .consent,
                     .accountCreation,
                     .login,
                     .passcode
@@ -287,9 +285,6 @@ enum TaskListRow: Int, CustomStringConvertible {
 
         case .eligibilityTask:
             return NSLocalizedString("Eligibility Task Example", comment: "")
-            
-        case .consent:
-            return NSLocalizedString("Consent-Obtaining Example", comment: "")
 
         case .accountCreation:
             return NSLocalizedString("Account Creation", comment: "")
@@ -523,8 +518,6 @@ enum TaskListRow: Int, CustomStringConvertible {
         case eligibilityEligibleStep
         
         // Consent task specific identifiers.
-        case consentTask
-        case visualConsentStep
         case consentSharingStep
         case consentReviewStep
         case consentDocumentParticipantSignature
@@ -664,9 +657,6 @@ enum TaskListRow: Int, CustomStringConvertible {
         
         case .eligibilityTask:
             return eligibilityTask
-            
-        case .consent:
-            return consentTask
             
         case .accountCreation:
             return accountCreationTask
@@ -1517,50 +1507,6 @@ enum TaskListRow: Int, CustomStringConvertible {
         return eligibilityTask
     }
     
-    /// A task demonstrating how the ResearchKit framework can be used to obtain informed consent.
-    private var consentTask: ORKTask {
-        /*
-        Informed consent starts by presenting an animated sequence conveying
-        the main points of your consent document.
-        */
-        let visualConsentStep = ORKVisualConsentStep(identifier: String(describing: Identifier.visualConsentStep), document: consentDocument)
-        
-        let investigatorShortDescription = NSLocalizedString("Institution", comment: "")
-        let investigatorLongDescription = NSLocalizedString("Institution and its partners", comment: "")
-        let localizedLearnMoreHTMLContent = NSLocalizedString("Your sharing learn more content here.", comment: "")
-        
-        /*
-        If you want to share the data you collect with other researchers for
-        use in other studies beyond this one, it is best practice to get
-        explicit permission from the participant. Use the consent sharing step
-        for this.
-        */
-        let sharingConsentStep = ORKConsentSharingStep(identifier: String(describing: Identifier.consentSharingStep), investigatorShortDescription: investigatorShortDescription, investigatorLongDescription: investigatorLongDescription, localizedLearnMoreHTMLContent: localizedLearnMoreHTMLContent)
-        
-        /*
-        After the visual presentation, the consent review step displays
-        your consent document and can obtain a signature from the participant.
-        
-        The first signature in the document is the participant's signature.
-        This effectively tells the consent review step which signatory is
-        reviewing the document.
-        */
-        let signature = consentDocument.signatures!.first
-        
-        let reviewConsentStep = ORKConsentReviewStep(identifier: String(describing: Identifier.consentReviewStep), signature: signature, in: consentDocument)
-        reviewConsentStep.requiresScrollToBottom = true
-        
-        // In a real application, you would supply your own localized text.
-        reviewConsentStep.title = NSLocalizedString("Consent Document", comment: "")
-        reviewConsentStep.text = loremIpsumText
-        reviewConsentStep.reasonForConsent = loremIpsumText
-
-        return ORKOrderedTask(identifier: String(describing: Identifier.consentTask), steps: [
-            visualConsentStep,
-            sharingConsentStep,
-            reviewConsentStep
-            ])
-    }
     
     /// This task presents the Account Creation process.
     private var accountCreationTask: ORKTask {


### PR DESCRIPTION
This PR addresses issue #1480 where ResearchKit could not build when pointed to IOS 15 due to deprecated APIs within the framework. 

- **contentEdgeInsets:**
no impact for developers 
- **scrollIndicatorInsets:**
no impact for developers 
- **device interface/orientation APIs:**
-no impact for developers
- **CLLocationManager:** 
no impact for developers
- **keyedUnarchiver:**
ResearchKit now adopts secure coding in all archiving code. Developers should be aware that, as a result, the format of ORKCollector state has changed and is not backwards compatible with previous builds of ResearchKit
- **OpenGL ES:**
OS deprecations of OpenGL ES cascades down to ORKVisualConsentStep, which is now also deprecated. Developers should use the ORKInstructionStep moving forward to provide custom content when building out a consent flow.