### PR TITLE
Add spacing below ORKTableContainerView header

### DIFF
--- a/ResearchKit/Common/ORKTableContainerView.m
+++ b/ResearchKit/Common/ORKTableContainerView.m
@@ -102,7 +102,9 @@ static const CGFloat SectionHeaderTopPadding = 20.0;
     _tableView.preservesSuperviewLayoutMargins = YES;
     _tableView.layer.masksToBounds = YES;
     [_tableView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
-    [_tableView setSectionHeaderTopPadding:SectionHeaderTopPadding];
+    if (@available(iOS 15.0, *)) {
+        [_tableView setSectionHeaderTopPadding:SectionHeaderTopPadding];
+    }
     _tableView.scrollIndicatorInsets = ORKScrollIndicatorInsetsForScrollView(self);
     [self addSubview:_tableView];
     [self setupFooterView];

--- a/ResearchKit/Common/ORKTableContainerView.m
+++ b/ResearchKit/Common/ORKTableContainerView.m
@@ -51,6 +51,7 @@
 @end
 
 static const CGFloat FooterViewHeightOffset = 20.0;
+static const CGFloat SectionHeaderTopPadding = 20.0;
 
 @implementation ORKTableContainerView {
     CGFloat _leftRightPadding;
@@ -101,6 +102,7 @@ static const CGFloat FooterViewHeightOffset = 20.0;
     _tableView.preservesSuperviewLayoutMargins = YES;
     _tableView.layer.masksToBounds = YES;
     [_tableView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
+    [_tableView setSectionHeaderTopPadding:SectionHeaderTopPadding];
     _tableView.scrollIndicatorInsets = ORKScrollIndicatorInsetsForScrollView(self);
     [self addSubview:_tableView];
     [self setupFooterView];


### PR DESCRIPTION
The new iOS 15 changes that were pushed a few days ago caused the spacing below form headers to be removed. See screenshots for before (current main branch), and after (my PR). I tested before and after on a couple different devices and the change appears to hold up well. The example shown here is the "Form Survey Example" in the ORKCatalog app.

| Current Main Branch | My PR |
| --------------------- | ------ |
| ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-02-22 at 17 56 40](https://user-images.githubusercontent.com/5024663/155233910-28c3bcb6-60a9-4721-8729-215dc6799ab0.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-02-22 at 17 57 08](https://user-images.githubusercontent.com/5024663/155233920-fa430144-aedf-4aac-b56e-20b5b9d4cc57.png) |