### PR TITLE
Fix ORKTableContainerView footer in fullScreen modals

### DIFF
--- a/ResearchKit/Common/ORKTableContainerView.m
+++ b/ResearchKit/Common/ORKTableContainerView.m
@@ -222,7 +222,7 @@ static const CGFloat FooterViewHeightOffset = 20.0;
         CGFloat newHeight = tableViewHeight - self.tableView.contentSize.height + FooterViewHeightOffset;
         CGRect footerBounds = newHeight < minHeight ? CGRectMake(0.0, 0.0, _tableView.bounds.size.width, minHeight) : CGRectMake(0.0, 0.0, _tableView.bounds.size.width, newHeight);
 
-        [_footerView setBounds:footerBounds];
+        [_footerView setFrame:footerBounds];
         _tableView.tableFooterView = _footerView;
     }
 }


### PR DESCRIPTION
My second PR for the day! I figured it'd be better to split them up into two separate requests. I've noticed a bug where the continue and skip buttons are not displayed correctly when an `ORKTaskViewController` is presented with `modalPresentationStyle = .fullscreen`. Namely, the following code produces the visual issue seen below:

```
let taskViewController = ORKTaskViewController(task: task, taskRun: nil)
taskViewController.modalPresentationStyle = .fullScreen
present(taskViewController, animated: true, completion: nil)
```

The form shown in the screenshots below is the "Form Survey Example" in the ORKCatalog app. You can test this issue by adding `taskViewController.modalPresentationStyle = .fullScreen` below line 117 in `ORKCatalog/Presenting Tasks/TaskListViewController.swift`, right after the `taskViewController` is instantiated.

| Current Main Branch | My PR |
| ---- | --- |
| ![Simulator Screen Shot - iPhone 13 - 2022-02-22 at 18 16 17](https://user-images.githubusercontent.com/5024663/155235880-5b34f6e2-d45e-43fd-ba6e-84b85e06f261.png) | ![Simulator Screen Shot - iPhone 13 - 2022-02-22 at 18 16 37](https://user-images.githubusercontent.com/5024663/155235888-c1216cce-3146-416f-8a06-bad9e26fb813.png) |
| ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2022-02-22 at 18 04 04](https://user-images.githubusercontent.com/5024663/155235906-ce259e40-918e-4229-b817-d7c3608a68ec.png) | ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2022-02-22 at 18 04 22](https://user-images.githubusercontent.com/5024663/155235916-b748c6a0-a87f-4177-8938-b9c5742599a5.png) |

When the devices are rotated, this change does not prevent the buttons from adjusting their size, and it does not appear to cause issues for how the footer view was displayed with other modal presentation styles. However, if there is a better solution for this issue, please let me know. Thank you!