### PR TITLE
Prevent isPasscodeStoredInKeychain crash, correct warnings

### DIFF
--- a/ResearchKit/Common/ORKKeychainWrapper.h
+++ b/ResearchKit/Common/ORKKeychainWrapper.h
@@ -66,7 +66,7 @@ ORK_CLASS_AVAILABLE
  
  @return An object or `nil` if key is not valid.
  */
-+ (nullable id<NSSecureCoding>)objectOfClass:(Class)objectClass forKey:(NSString *)key error:(NSError * __autoreleasing _Nullable *)errorOut;
++ (nullable id<NSSecureCoding>)objectsOfClasses:objectClass forKey:(NSString *)key error:(NSError * __autoreleasing _Nullable *)errorOut;
 
 /**
  Removes the object in the keychain for the provided key.

--- a/ResearchKit/Common/ORKKeychainWrapper.m
+++ b/ResearchKit/Common/ORKKeychainWrapper.m
@@ -60,14 +60,14 @@ static NSString *ORKKeychainWrapperDefaultService() {
                    error:errorOut];
 }
 
-+ (id<NSSecureCoding>)objectOfClass:(Class)objectClass forKey:(NSString *)key
++ (id<NSSecureCoding>)objectsOfClasses:objectClasses forKey:(NSString *)key
        error:(NSError **)errorOut {
   NSData *data = [self dataForKey:key
               service:ORKKeychainWrapperDefaultService()
             accessGroup:nil
                error:errorOut];
   
-  return data ? [NSKeyedUnarchiver unarchivedObjectOfClass:objectClass fromData:data error:errorOut] : nil;
+  return data ? [NSKeyedUnarchiver unarchivedObjectOfClasses:objectClasses fromData:data error:errorOut] : nil;
 }
 
 + (BOOL)removeObjectForKey:(NSString *)key

--- a/ResearchKit/Common/ORKPasscodeStepViewController.m
+++ b/ResearchKit/Common/ORKPasscodeStepViewController.m
@@ -499,7 +499,12 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
 
 - (void)removePasscodeFromKeychain {
     NSError *error;
-    id storedValue = [ORKKeychainWrapper objectOfClass:NSDictionary.self forKey:PasscodeKey error:&error];
+    NSSet<Class> *classes = [NSSet setWithArray:@[
+        NSDictionary.class,
+        NSString.class,
+        NSNumber.class,
+    ]];
+    id storedValue = [ORKKeychainWrapper objectsOfClasses:classes forKey:PasscodeKey error:&error];
     
     if (storedValue != nil) {
         [ORKKeychainWrapper removeObjectForKey:PasscodeKey error:&error];
@@ -512,9 +517,14 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
 
 - (BOOL)passcodeMatchesKeychain {
     NSError *error;
-    NSDictionary *dictionary = (NSDictionary *) [ORKKeychainWrapper objectOfClass:NSDictionary.self
-                                                                           forKey:PasscodeKey
-                                                                            error:&error];
+    NSSet<Class> *classes = [NSSet setWithArray:@[
+        NSDictionary.class,
+        NSString.class,
+        NSNumber.class,
+    ]];
+    NSDictionary *dictionary = (NSDictionary *) [ORKKeychainWrapper objectsOfClasses:classes
+                                                                              forKey:PasscodeKey
+                                                                               error:&error];
     if (dictionary == nil) {
         [self throwExceptionWithKeychainError:error];
     }
@@ -525,9 +535,14 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
 
 - (void)setValuesFromKeychain {
     NSError *error;
-    NSDictionary *dictionary = (NSDictionary*) [ORKKeychainWrapper objectOfClass:NSDictionary.self
-                                                                          forKey:PasscodeKey
-                                                                           error:&error];
+    NSSet<Class> *classes = [NSSet setWithArray:@[
+        NSDictionary.class,
+        NSString.class,
+        NSNumber.class,
+    ]];
+    NSDictionary *dictionary = (NSDictionary*) [ORKKeychainWrapper objectsOfClasses:classes
+                                                                             forKey:PasscodeKey
+                                                                              error:&error];
     
     if (dictionary == nil) {
         [self throwExceptionWithKeychainError:error];

--- a/ResearchKit/Common/ORKPasscodeViewController.m
+++ b/ResearchKit/Common/ORKPasscodeViewController.m
@@ -106,11 +106,7 @@
                                                                            error:&error];
     
     if (dictionary == nil) {
-        NSString *errorReason = error.localizedDescription;
-        if (error.code == errSecItemNotFound) {
-            errorReason = @"There is no passcode stored in the keychain.";
-        }
-        @throw [NSException exceptionWithName:NSGenericException reason:errorReason userInfo:nil];
+        return NO;
     }
     
     return ([dictionary objectForKey:KeychainDictionaryPasscodeKey]) ? YES : NO;

--- a/ResearchKit/Common/ORKPasscodeViewController.m
+++ b/ResearchKit/Common/ORKPasscodeViewController.m
@@ -101,9 +101,14 @@
 
 + (BOOL)isPasscodeStoredInKeychain {
     NSError *error;
-    NSDictionary *dictionary = (NSDictionary *)[ORKKeychainWrapper objectOfClass:NSDictionary.self
-                                                                          forKey:PasscodeKey
-                                                                           error:&error];
+    NSSet<Class> *classes = [NSSet setWithArray:@[
+        NSDictionary.class,
+        NSString.class,
+        NSNumber.class,
+    ]];
+    NSDictionary *dictionary = (NSDictionary *)[ORKKeychainWrapper objectsOfClasses:classes
+                                                                             forKey:PasscodeKey
+                                                                              error:&error];
     
     if (dictionary == nil) {
         return NO;


### PR DESCRIPTION
This PR updates `isPasscodeStoredInKeychain` in `ResearchKit/Common/ORKPasscodeViewController.m` to remove the `@throw NSException` called when the dictionary is `nil`, and instead just return `NO` here.

This prevents a crash when `isPasscodeStoredInKeychain` is called in certain circumstances, such as when called at the very first launch of the application.

---

It also updates the invocation of
```
(id<NSSecureCoding>)objectOfClass:(Class)objectClass forKey:(NSString *)key error:(NSError **)errorOut
```
to be
```
(id<NSSecureCoding>)objectsOfClasses:objectClasses forKey:(NSString *)key error:(NSError **)errorOut
```
\- thus taking an `NSSet<Class>` input and ensuring that `NSString` and `NSNumber` are included in the allowed classes set. This prevents warnings in the console, such as
```
[general] *** -[NSKeyedUnarchiver validateAllowedClass:forKey:] allowed unarchiving safe plist type ''NSString' (0x1f697e4f0) [/System/Library/Frameworks/Foundation.framework]' for key 'NS.objects', even though it was not explicitly included in the client allowed classes set: '{(
    "'NSDictionary' (0x1f6973850) [/System/Library/Frameworks/CoreFoundation.framework]"
)}'. This will be disallowed in the future.
```
and
```
[general] *** -[NSKeyedUnarchiver validateAllowedClass:forKey:] allowed unarchiving safe plist type ''NSNumber' (0x1f697ed38) [/System/Library/Frameworks/Foundation.framework]' for key 'NS.objects', even though it was not explicitly included in the client allowed classes set: '{(
    "'NSDictionary' (0x1f6973850) [/System/Library/Frameworks/CoreFoundation.framework]"
)}'. This will be disallowed in the future.
```

---

All unit tests still pass as expected.

---

Closes #1504 