### PR TITLE
Default value for multipleLines in ORKAnswerFormat.m fixed to YES from NO

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -2610,7 +2610,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     _autocorrectionType = UITextAutocorrectionTypeDefault;
     _spellCheckingType = UITextSpellCheckingTypeDefault;
     _keyboardType = UIKeyboardTypeDefault;
-    _multipleLines = NO;
+    _multipleLines = YES;
     _hideClearButton = NO;
     _hideCharacterCountLabel = NO;
 }
@@ -2767,7 +2767,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
-        _multipleLines = NO;
+        _multipleLines = YES;
         ORK_DECODE_INTEGER(aDecoder, maximumLength);
         ORK_DECODE_OBJ_CLASS(aDecoder, validationRegularExpression, NSRegularExpression);
         ORK_DECODE_OBJ_CLASS(aDecoder, invalidMessage, NSString);


### PR DESCRIPTION
Fix for Issue #1503 

In ORKAnswerFormat.h, the default value for _multipleLines is stated as YES. However, in ORKAnswerFormat.m, this default value is set as NO. This causes the text answer format to not have its own section and be merged into previous sections. 

The fix includes changing the default value from NO -> YES

<img width="568" alt="Multiple_lines_default_val" src="https://user-images.githubusercontent.com/26697640/177248309-03f579ea-a369-402f-8e58-04b1674e4dd4.png">

