### PR TITLE
Propagate tintColor if window not available

### DIFF
--- a/ResearchKit/Common/ORKCheckmarkView.m
+++ b/ResearchKit/Common/ORKCheckmarkView.m
@@ -107,7 +107,7 @@ static const CGFloat CheckmarkViewBorderWidth = 2.0;
         self.image = _checkedImage;
         //        FIXME: Need to be replaced.
         if (@available(iOS 13.0, *)) {
-            self.tintColor = ORKWindowTintcolor(self.window) ? : self.tintColor;
+            self.tintColor = ORKViewTintColor(self);
         } else {
             self.backgroundColor = [self tintColor];
             self.tintColor = UIColor.whiteColor;

--- a/ResearchKit/Common/ORKCheckmarkView.m
+++ b/ResearchKit/Common/ORKCheckmarkView.m
@@ -104,10 +104,10 @@ static const CGFloat CheckmarkViewBorderWidth = 2.0;
 
 - (void)updateCheckView {
     if (_checked) {
-         self.image = _checkedImage;
+        self.image = _checkedImage;
         //        FIXME: Need to be replaced.
         if (@available(iOS 13.0, *)) {
-            self.tintColor = ORKWindowTintcolor(self.window) ? : [UIColor systemBlueColor];
+            self.tintColor = ORKWindowTintcolor(self.window) ? : self.tintColor;
         } else {
             self.backgroundColor = [self tintColor];
             self.tintColor = UIColor.whiteColor;
@@ -143,6 +143,11 @@ static const CGFloat CheckmarkViewBorderWidth = 2.0;
 
 - (void)setChecked:(BOOL)checked {
     _checked = checked;
+    [self updateCheckView];
+}
+
+- (void)tintColorDidChange {
+    [super tintColorDidChange];
     [self updateCheckView];
 }
 

--- a/ResearchKit/Common/ORKChoiceViewCell.m
+++ b/ResearchKit/Common/ORKChoiceViewCell.m
@@ -521,6 +521,7 @@ static const CGFloat LabelCheckViewPadding = 10.0;
 
 - (void)updateCheckView {
     if (_checkView) {
+        _checkView.tintColor = self.tintColor;
         [_checkView setChecked:_cellSelected];
     }
 }

--- a/ResearchKit/Common/ORKDontKnowButton.m
+++ b/ResearchKit/Common/ORKDontKnowButton.m
@@ -332,7 +332,7 @@ static const CGFloat CheckMarkImageTrailingPadding = 2.0;
                     color = [UIColor grayColor];
                 }
             } else {
-                color = ORKWindowTintcolor(self.window) ? : [UIColor systemBlueColor];
+                color = ORKWindowTintcolor(self.window) ? : self.tintColor;
             }
             
             break;

--- a/ResearchKit/Common/ORKDontKnowButton.m
+++ b/ResearchKit/Common/ORKDontKnowButton.m
@@ -332,7 +332,7 @@ static const CGFloat CheckMarkImageTrailingPadding = 2.0;
                     color = [UIColor grayColor];
                 }
             } else {
-                color = ORKWindowTintcolor(self.window) ? : self.tintColor;
+                color = ORKViewTintColor(self);
             }
             
             break;

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -1157,6 +1157,7 @@ static const NSTimeInterval DelayBeforeAutoScroll = 0.25;
                 ORKChoiceOtherViewCell *choiceOtherViewCell = (ORKChoiceOtherViewCell *)choiceViewCell;
                 choiceOtherViewCell.delegate = self;
             }
+            choiceViewCell.tintColor = ORKWindowTintcolor(self.view.window) ? : self.view.tintColor;
             choiceViewCell.useCardView = [self formStep].useCardView;
             choiceViewCell.cardViewStyle = [self formStep].cardViewStyle;
             choiceViewCell.isLastItem = isLastItem;

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -1157,7 +1157,7 @@ static const NSTimeInterval DelayBeforeAutoScroll = 0.25;
                 ORKChoiceOtherViewCell *choiceOtherViewCell = (ORKChoiceOtherViewCell *)choiceViewCell;
                 choiceOtherViewCell.delegate = self;
             }
-            choiceViewCell.tintColor = ORKWindowTintcolor(self.view.window) ? : self.view.tintColor;
+            choiceViewCell.tintColor = ORKViewTintColor(self.view);
             choiceViewCell.useCardView = [self formStep].useCardView;
             choiceViewCell.cardViewStyle = [self formStep].cardViewStyle;
             choiceViewCell.isLastItem = isLastItem;

--- a/ResearchKit/Common/ORKHelpers.m
+++ b/ResearchKit/Common/ORKHelpers.m
@@ -200,6 +200,13 @@ UIColor *ORKWindowTintcolor(UIWindow *window) {
     return windowTintColor;
 }
 
+UIColor *ORKViewTintColor(UIView *view) {
+    UIColor *existingTintColor = view.tintColor ? : [UIColor systemBlueColor];
+    UIColor *tintColor = ORKWindowTintcolor(view.window) ? : existingTintColor;
+
+    return tintColor;
+}
+
 #endif
 
 UIImage *ORKImageWithColor(UIColor *color) {

--- a/ResearchKit/Common/ORKHelpers_Internal.h
+++ b/ResearchKit/Common/ORKHelpers_Internal.h
@@ -178,6 +178,8 @@ CGFloat ORKExpectedLabelHeight(UILabel *label);
 
 UIColor * _Nullable ORKWindowTintcolor(UIWindow *window);
 
+UIColor * ORKViewTintColor(UIView *view);
+
 #endif
 
 // build a image with color

--- a/ResearchKit/Common/ORKNavigationContainerView.m
+++ b/ResearchKit/Common/ORKNavigationContainerView.m
@@ -559,4 +559,9 @@ static const CGFloat detailTextBottomSpacing = 16.0;
     [self setUpConstraints];
 }
 
+- (void)tintColorDidChange {
+    [super tintColorDidChange];
+    [self didMoveToWindow];
+}
+
 @end

--- a/ResearchKit/Common/ORKNavigationContainerView.m
+++ b/ResearchKit/Common/ORKNavigationContainerView.m
@@ -162,7 +162,7 @@ static const CGFloat detailTextBottomSpacing = 16.0;
 }
 
 - (void)didMoveToWindow {
-    _appTintColor = ORKWindowTintcolor(self.window) ? : self.tintColor;
+    _appTintColor = ORKViewTintColor(self);
     
     _continueButton.normalTintColor = _appTintColor;
     _skipButton.normalTintColor = _appTintColor;

--- a/ResearchKit/Common/ORKNavigationContainerView.m
+++ b/ResearchKit/Common/ORKNavigationContainerView.m
@@ -162,7 +162,7 @@ static const CGFloat detailTextBottomSpacing = 16.0;
 }
 
 - (void)didMoveToWindow {
-    _appTintColor = ORKWindowTintcolor(self.window) ? : ORKColor(ORKBlueHighlightColorKey);
+    _appTintColor = ORKWindowTintcolor(self.window) ? : self.tintColor;
     
     _continueButton.normalTintColor = _appTintColor;
     _skipButton.normalTintColor = _appTintColor;

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1042,6 +1042,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
             id<ORKTaskResultSource> resultSource = reviewStep.isStandalone ? reviewStep.resultSource : self.result;
             stepViewController = [[ORKReviewStepViewController alloc] initWithReviewStep:(ORKReviewStep *) step steps:steps resultSource:resultSource];
             ORKReviewStepViewController *reviewStepViewController = (ORKReviewStepViewController *) stepViewController;
+            reviewStepViewController.view.tintColor = ORKWindowTintcolor(self.view.window) ? : self.view.tintColor;
             reviewStepViewController.reviewDelegate = self;
         }
         else {
@@ -1103,7 +1104,8 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
         
         stepViewController.learnMoreButtonItem = [self defaultLearnMoreButtonItem];
     }
-    
+
+    stepViewController.view.tintColor = ORKWindowTintcolor(self.view.window) ? : self.view.tintColor;
     stepViewController.delegate = self;
     return stepViewController;
 }

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1024,7 +1024,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     }
     
     ORKStepViewController *stepViewController = nil;
-    UIColor *tintColor = ORKWindowTintcolor(self.view.window) ? : self.view.tintColor;
+    UIColor *tintColor = ORKViewTintColor(self.view);
     
     if ([self.delegate respondsToSelector:@selector(taskViewController:viewControllerForStep:)]) {
         // NOTE: While the delegate does not have direct access to the defaultResultSource,

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1024,6 +1024,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     }
     
     ORKStepViewController *stepViewController = nil;
+    UIColor *tintColor = ORKWindowTintcolor(self.view.window) ? : self.view.tintColor;
     
     if ([self.delegate respondsToSelector:@selector(taskViewController:viewControllerForStep:)]) {
         // NOTE: While the delegate does not have direct access to the defaultResultSource,
@@ -1042,7 +1043,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
             id<ORKTaskResultSource> resultSource = reviewStep.isStandalone ? reviewStep.resultSource : self.result;
             stepViewController = [[ORKReviewStepViewController alloc] initWithReviewStep:(ORKReviewStep *) step steps:steps resultSource:resultSource];
             ORKReviewStepViewController *reviewStepViewController = (ORKReviewStepViewController *) stepViewController;
-            reviewStepViewController.view.tintColor = ORKWindowTintcolor(self.view.window) ? : self.view.tintColor;
+            reviewStepViewController.view.tintColor = tintColor;
             reviewStepViewController.reviewDelegate = self;
         }
         else {
@@ -1105,7 +1106,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
         stepViewController.learnMoreButtonItem = [self defaultLearnMoreButtonItem];
     }
 
-    stepViewController.view.tintColor = ORKWindowTintcolor(self.view.window) ? : self.view.tintColor;
+    stepViewController.view.tintColor = tintColor;
     stepViewController.delegate = self;
     return stepViewController;
 }


### PR DESCRIPTION
When an app is using the SwiftUI lifecycle (App protocol) and doesn't use the scene delegate, the tintColor isn't properly inherited in surveyViewController in OCKSurveyTaskViewController from the calling view. This occurs with the latest commit on the main of CareKit and the latest commit on the main of ResearchKit (https://github.com/ResearchKit/ResearchKit/commit/a89059f5dc2a91f36785b184f914b5e5fdb05877)

More info about the issue here: https://github.com/carekit-apple/CareKit/pull/676

This preserves the current functionality when `window.tintColor` is available and resorts to `self.view.tintColor` otherwise. Close #1521