### PR TITLE
fix: Propagate ORKLearnMoreView tintColor

### DIFF
--- a/ResearchKitUI/Common/Container Views/Learn More/ORKLearnMoreView.m
+++ b/ResearchKitUI/Common/Container Views/Learn More/ORKLearnMoreView.m
@@ -122,6 +122,7 @@ ORK_CLASS_AVAILABLE
     if (!_learnMoreButton) {
         _learnMoreButton = [ORKLearnMoreButton learnMoreCustomButtonWithText:text];
     }
+    [self setLearnMoreButtonColor];
     [self addSubview:_learnMoreButton];
     [_learnMoreButton addTarget:self action:@selector(presentLearnMoreViewController) forControlEvents:UIControlEventTouchUpInside];
     [self setupConstraints];
@@ -131,6 +132,7 @@ ORK_CLASS_AVAILABLE
     if (!_learnMoreButton) {
         _learnMoreButton = [ORKLearnMoreButton learnMoreDetailDisclosureButton];
     }
+    [self setLearnMoreButtonColor];
     [self addSubview:_learnMoreButton];
     [_learnMoreButton addTarget:self action:@selector(presentLearnMoreViewController) forControlEvents:UIControlEventTouchUpInside];
     [self setupConstraints];
@@ -139,6 +141,13 @@ ORK_CLASS_AVAILABLE
 - (void)setLearnMoreButtonFont: (UIFont *)font {
     if (_learnMoreButton) {
         [_learnMoreButton.titleLabel setFont:font];
+    }
+}
+
+- (void)setLearnMoreButtonColor {
+    if (_learnMoreButton) {
+        [_learnMoreButton setTitleColor:self.tintColor forState:UIControlStateNormal];
+        _learnMoreButton.tintColor = self.tintColor;
     }
 }
 
@@ -193,6 +202,11 @@ ORK_CLASS_AVAILABLE
 - (void)presentLearnMoreViewController {
     NSAssert(_delegate, @"Learn More View requires a delegate");
     [_delegate learnMoreButtonPressedWithStep:_learnMoreInstructionStep];
+}
+
+- (void)tintColorDidChange {
+    [super tintColorDidChange];
+    [self setLearnMoreButtonColor];
 }
 
 @end

--- a/ResearchKitUI/Common/Step/Instruction Step/LearnMore Step/ORKLearnMoreStepViewController.m
+++ b/ResearchKitUI/Common/Step/Instruction Step/LearnMore Step/ORKLearnMoreStepViewController.m
@@ -53,7 +53,8 @@ static const CGFloat ORKScrollViewCustomContentInset = 40.0;
     
     self.view.backgroundColor = [UIColor systemBackgroundColor];
     self.navigationController.navigationBar.backgroundColor = UIColor.systemBackgroundColor;
-    
+    self.navigationController.navigationBar.tintColor = self.view.tintColor;
+
     [self.navigationController.navigationBar setBackgroundImage:[UIImage new] forBarMetrics:UIBarMetricsDefault];
     self.navigationController.navigationBar.shadowImage = [UIImage new];
 

--- a/ResearchKitUI/Common/Task/ORKTaskViewController.m
+++ b/ResearchKitUI/Common/Task/ORKTaskViewController.m
@@ -1048,7 +1048,9 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
     if (!learnMoreViewController) {
         learnMoreViewController = [[ORKLearnMoreStepViewController alloc] initWithStep:step];
     }
-    
+
+    learnMoreViewController.view.tintColor = ORKViewTintColor(self.view);
+
     return learnMoreViewController;
 }
 


### PR DESCRIPTION
There is an issue leftover from #1519 with `ORKLearnMoreItem` in which the link and the `ORKLearnMoreItem` view has the wrong `tintColor` basically it always uses the default blue. It occurs when constructing a `ORKLearnMoreInstructionStep` and adding a `ORKBodyItem` with `ORKLearnMoreItem` inside of a `ORKOrderedTask`. The link color of "Learn More" and the `tintColor` of the view is incorrect. 

- [x] Propagate tint color correctly for `ORKLearnMoreView`

You can see the issue in screenshots below:

![Simulator Screen Shot - iPhone 14 Pro - 2023-02-13 at 17 24 41](https://user-images.githubusercontent.com/8621344/218588316-fae0dcfa-9529-4557-a840-748fabc3ea67.png)

![Simulator Screen Shot - iPhone 14 Pro - 2023-02-13 at 17 25 07](https://user-images.githubusercontent.com/8621344/218588395-146e5c67-eeb4-4d14-9522-3da67932e528.png)