### PR TITLE
fix: Deprecate ORKTaskViewControllerFinishReason instead of renaming it

### DIFF
--- a/ResearchKit/Common/ORKTask.h
+++ b/ResearchKit/Common/ORKTask.h
@@ -64,7 +64,7 @@ typedef NS_ENUM(NSInteger, ORKTaskFinishReason) {
     ORKTaskFinishReasonEarlyTermination
 };
 
-ORK_TO_BE_DEPRECATED("Use the ORKTaskFinishReason instead")
+ORK_TO_BE_DEPRECATED("Use ORKTaskFinishReason instead")
 typedef ORKTaskFinishReason ORKTaskViewControllerFinishReason;
 
 /**

--- a/ResearchKit/Common/ORKTask.h
+++ b/ResearchKit/Common/ORKTask.h
@@ -64,6 +64,9 @@ typedef NS_ENUM(NSInteger, ORKTaskFinishReason) {
     ORKTaskFinishReasonEarlyTermination
 };
 
+ORK_TO_BE_DEPRECATED("Use the ORKTaskFinishReason instead")
+typedef ORKTaskFinishReason ORKTaskViewControllerFinishReason;
+
 /**
 
  `ORKTaskProgress` is a structure that represents how far a task has progressed.


### PR DESCRIPTION
`ORKTaskViewControllerFinishReason` was renamed to `ORKTaskFinishReason` instead of being deprecated which will break projects dependent on `ORKTaskViewControllerFinishReason`. This PR adds a simple typedef and deprecation warning.