### PR TITLE
Add designated initializer to ORKStepViewController

### DIFF
--- a/ResearchKitUI/Common/Step/ORKStepViewController.h
+++ b/ResearchKitUI/Common/Step/ORKStepViewController.h
@@ -227,7 +227,7 @@ ORK_CLASS_AVAILABLE
  
  @return A newly initialized step view controller.
  */
-- (instancetype)initWithStep:(ORKStep *)step result:(nullable ORKResult *)result;
+- (instancetype)initWithStep:(ORKStep *)step result:(nullable ORKResult *)result NS_DESIGNATED_INITIALIZER;
 
 /**
  The step presented by the step view controller.


### PR DESCRIPTION
In order to support subclassing in Swift I added a designated initializer to ORKStepViewController.

I reported this issue [here](https://github.com/ResearchKit/ResearchKit/issues/1575):