### PR TITLE
Set “Enable Module Verifier” flag to “Yes” only in Release build configuration

### DIFF
--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -5819,7 +5819,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5D000ED12620F27100E5442A /* Project-Debug.xcconfig */;
 			buildSettings = {
-				ENABLE_MODULE_VERIFIER = YES;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 			};
@@ -5897,7 +5896,6 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				CURRENT_PROJECT_VERSION = "";
-				ENABLE_MODULE_VERIFIER = YES;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
 				MODULEMAP_PRIVATE_FILE = ResearchKitUI/ResearchKitUI_Private.modulemap;
 				PRODUCT_NAME = ResearchKitUI;
@@ -5913,7 +5911,6 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				CURRENT_PROJECT_VERSION = "";
-				ENABLE_MODULE_VERIFIER = YES;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
 				MODULEMAP_PRIVATE_FILE = ResearchKitUI/ResearchKitUI_Private.modulemap;
 				PRODUCT_NAME = ResearchKitUI;


### PR DESCRIPTION
- This sets the "Enable Module Verifier" to true only in release in order to speed up build times.

## Changes
- Removed target override setting module verification to Yes for all builds

## Project Settings

<img width="834" alt="Screenshot 2024-08-08 at 3 08 05 PM" src="https://github.com/user-attachments/assets/1632d87a-78df-494e-8885-2443541fa491">

## Inherited Target Settings

<img width="834" alt="Screenshot 2024-08-08 at 3 08 12 PM" src="https://github.com/user-attachments/assets/5d0724b4-4ad9-4b13-80b6-e0f5d32b0bc5">
<img width="840" alt="Screenshot 2024-08-08 at 3 08 15 PM" src="https://github.com/user-attachments/assets/c267808f-09c8-45db-8915-2e1ef0d83e37">
<img width="851" alt="Screenshot 2024-08-08 at 3 08 18 PM" src="https://github.com/user-attachments/assets/4fd5ccef-a6a4-4575-b757-9f50ba39fdef">
<img width="845" alt="Screenshot 2024-08-08 at 3 08 23 PM" src="https://github.com/user-attachments/assets/40f7a334-7a3f-4f1b-bd17-3aab29dace11">
