### PR TITLE
fix: Use accent color instead of hardcoded blue

### DIFF
--- a/ResearchKitSwiftUI/ResearchFormStepContentView.swift
+++ b/ResearchKitSwiftUI/ResearchFormStepContentView.swift
@@ -111,7 +111,7 @@ private struct ResearchFormStepButtonStyle: ButtonStyle {
                 .foregroundStyle(.white)
                 .frame(height: 50)
                 .background(
-                    isEnabled ? Color.blue : Color.blue.opacity(0.5),
+                    isEnabled ? Color.accentColor : Color.accentColor.opacity(0.5),
                     in: RoundedRectangle(cornerRadius: 12)
                 )
         #elseif os(visionOS)

--- a/ResearchKitSwiftUI/ResearchKitSwiftUI/Slider/SliderValueForegroundStyle.swift
+++ b/ResearchKitSwiftUI/ResearchKitSwiftUI/Slider/SliderValueForegroundStyle.swift
@@ -45,7 +45,7 @@ struct SliderValueForegroundStyle: ShapeStyle {
         #if os(visionOS)
             Color(.label)
         #else
-            .blue
+            Color.accentColor
         #endif
     }
 }

--- a/ResearchKitSwiftUI/ResearchKitSwiftUI/Step Views/BodyItemIconForegroundStyle.swift
+++ b/ResearchKitSwiftUI/ResearchKitSwiftUI/Step Views/BodyItemIconForegroundStyle.swift
@@ -45,7 +45,7 @@ struct BodyItemIconForegroundStyle: ShapeStyle {
         #if os(visionOS)
             .white
         #else
-            .blue
+            Color.accentColor
         #endif
     }
 }

--- a/ResearchKitSwiftUI/ResearchKitSwiftUI/Step Views/Question Views/Supporting Views/StickyScrollView.swift
+++ b/ResearchKitSwiftUI/ResearchKitSwiftUI/Step Views/Question Views/Supporting Views/StickyScrollView.swift
@@ -301,7 +301,7 @@ struct ToolbarButton: ButtonStyle {
     }
 
     var buttonColor: Color {
-        return isDisabled ? .gray : .blue
+        return isDisabled ? .gray : .accentColor
     }
 
     public func makeBody(configuration: Configuration) -> some View {

--- a/ResearchKitSwiftUI/ResearchKitSwiftUI/Step Views/Question Views/Supporting Views/TextChoiceOption.swift
+++ b/ResearchKitSwiftUI/ResearchKitSwiftUI/Step Views/Question Views/Supporting Views/TextChoiceOption.swift
@@ -56,7 +56,7 @@ struct TextChoiceOption: View {
 
             Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                 .imageScale(.large)
-                .foregroundColor(isSelected ? .blue : deselectedCheckmarkColor)
+                .foregroundColor(isSelected ? .accentColor : deselectedCheckmarkColor)
                 .font(.body)
         }
         .padding(.vertical, 8)

--- a/ResearchKitSwiftUI/ResearchKitSwiftUI/Step Views/StepIconForegroundStyle.swift
+++ b/ResearchKitSwiftUI/ResearchKitSwiftUI/Step Views/StepIconForegroundStyle.swift
@@ -45,7 +45,7 @@ struct StepIconForegroundStyle: ShapeStyle {
         #if os(visionOS)
             .white
         #else
-            .blue
+            Color.accentColor
         #endif
     }
 


### PR DESCRIPTION
The buttons are hardcoded to blue, preventing the ability to change the color via a modifier. In addition, navigation buttons at the top (e.g. "Cancel") are not hard coded leading to views that don't match when accentColor is passed.

## Before the fix
![image](https://github.com/user-attachments/assets/ecc1441a-b9ad-494b-9663-95519233ad49)


## After the fix
![image](https://github.com/user-attachments/assets/c0b486ea-caef-4323-961f-d2d33cf2bb74)

