### PR TITLE
fix crash when answering form question

### DIFF
--- a/ResearchKitUI/Common/Step/Form Step/ORKFormStepViewController.m
+++ b/ResearchKitUI/Common/Step/Form Step/ORKFormStepViewController.m
@@ -1385,7 +1385,7 @@ NSString * const ORKFormStepViewAccessibilityIdentifier = @"ORKFormStepView";
 }
 
 
-/// Determines if we should auto-scroll to the next section
+/// The proposed destination index path for auto-scrolling to the nexr section.
 /// @returns The destination index path that should be used when scrolling to the next question, or `nil` if no auto-scroll should occur.
 - (NSIndexPath *_Nullable)indexPathForAutoScrollingToNextSectionAfter:(NSIndexPath *)indexPath {
     if (![self _isAutoScrollEnabled] || _autoScrollCancelled) {
@@ -1429,6 +1429,7 @@ NSString * const ORKFormStepViewAccessibilityIdentifier = @"ORKFormStepView";
         return nil;
     }
 }
+
 
 /// Determines if we should auto-scroll to the next section
 - (BOOL)shouldAutoScrollToNextSectionAfter:(NSIndexPath *)indexPath {

--- a/ResearchKitUI/Common/Step/Form Step/ORKFormStepViewController.m
+++ b/ResearchKitUI/Common/Step/Form Step/ORKFormStepViewController.m
@@ -1110,7 +1110,7 @@ NSString * const ORKFormStepViewAccessibilityIdentifier = @"ORKFormStepView";
 
 #pragma mark Helpers
 
-- (ORKFormStep *)formStep { 
+- (ORKFormStep *)formStep {
     NSAssert(!self.step || [self.step isKindOfClass:[ORKFormStep class]], nil);
     return (ORKFormStep *)self.step;
 }
@@ -1384,52 +1384,65 @@ NSString * const ORKFormStepViewAccessibilityIdentifier = @"ORKFormStepView";
     return YES;
 }
 
-- (BOOL)shouldAutoScrollToNextSection:(NSIndexPath *)indexPath {
-    if (![self _isAutoScrollEnabled]) {
-        return NO;
+
+/// Determines if we should auto-scroll to the next section
+/// @returns The destination index path that should be used when scrolling to the next question, or `nil` if no auto-scroll should occur.
+- (NSIndexPath *_Nullable)shouldAutoScrollToNextSection:(NSIndexPath *)indexPath {
+    if (![self _isAutoScrollEnabled] || _autoScrollCancelled) {
+        return nil;
     }
-    
-    BOOL result = YES;
     
     NSIndexPath *nextIndexPath = [NSIndexPath indexPathForRow:0 inSection:(indexPath.section + 1)];
     
-    // Technically, cellForRowAtIndexPath could return nil if the tableView hasn't decided to cache the cell
-    // Guarantee ourselves a cell by using dequeueReusableCellWithIdentifier—the only reason we need the cell is to test
-    // the cell's type, not for actual display, so using any cell paired with the reuseIdentifier should be fine
-    // do *not* use dequeueReusableCellWithIdentifier:indexPath: since that method should only be called within the dataSource
-    // tableView:cellForRowAtIndexPath: method
-    ORKFormItem *nextFormItem = [self _formItemForIndexPath:nextIndexPath];
     ORKTableCellItemIdentifier *nextItemIdentifier = [_diffableDataSource itemIdentifierForIndexPath:nextIndexPath];
-    NSString *nextReuseIdentifier = [self cellReuseIdentifierFromFormItem:nextFormItem cellItemIdentifier:nextItemIdentifier];
-
-    result = result && (_autoScrollCancelled == NO);
-
-    // can't autoscroll to something that doesn't exist
-    UITableViewCell *nextCell = [_tableView dequeueReusableCellWithIdentifier:nextReuseIdentifier];
-    result = result && (nextCell != nil);
-    
-    // don't autoscroll to a cell that already has an answer
-    result = result && (self.savedAnswers[nextFormItem.identifier] == nil);
-    
-    return result;
+    if (nextItemIdentifier) {
+        // Technically, cellForRowAtIndexPath could return nil if the tableView hasn't decided to cache the cell
+        // Guarantee ourselves a cell by using dequeueReusableCellWithIdentifier—the only reason we need the cell is to test
+        // the cell's type, not for actual display, so using any cell paired with the reuseIdentifier should be fine
+        // do *not* use dequeueReusableCellWithIdentifier:indexPath: since that method should only be called within the dataSource
+        // tableView:cellForRowAtIndexPath: method
+        ORKFormItem *nextFormItem = [self _formItemForIndexPath:nextIndexPath];
+        if (!nextFormItem) {
+            return nil;
+        }
+        NSString *nextReuseIdentifier = [self cellReuseIdentifierFromFormItem:nextFormItem cellItemIdentifier:nextItemIdentifier];
+        // can't autoscroll to something that doesn't exist
+        UITableViewCell *nextCell = [_tableView dequeueReusableCellWithIdentifier:nextReuseIdentifier];
+        if (!nextCell) {
+            return nil;
+        }
+        // don't autoscroll to a cell that already has an answer
+        if (self.savedAnswers[nextFormItem.identifier]) {
+            return nil;
+        }
+        return nextIndexPath;
+    } else {
+        NSString *nextSectionIdentifier = [_diffableDataSource sectionIdentifierForIndex:nextIndexPath.section];
+        ORKFormItem *formItem = [self _formItemForFormItemIdentifier:nextSectionIdentifier];
+        if (!formItem) {
+            return nil;
+        } else {
+            // We need to scroll to a zero-item section. This requires us to adjust the index path.
+            return [NSIndexPath indexPathForRow:NSNotFound inSection:nextIndexPath.section];
+        }
+    }
 }
 
 - (void)autoScrollToNextSection:(NSIndexPath *)indexPath {
     if (![self _isAutoScrollEnabled]) {
         return;
     }
-    
-    NSIndexPath *nextIndexPath = [NSIndexPath indexPathForRow:0 inSection:(indexPath.section + 1)];
-    UITableView *tableView = self.tableView;
-    UITableViewCell *nextCell = [tableView cellForRowAtIndexPath:nextIndexPath];
-    BOOL didChangeFocus = [self focusUnansweredCell:nextCell];
-    
-    if (didChangeFocus == YES) {
+    NSIndexPath *scrollDstIndexPath = [self shouldAutoScrollToNextSection:indexPath];
+    if (!scrollDstIndexPath) {
+        // If the index path returned by -shouldAutoScrollToNextSection: is nil, we're not supposed to auto-scroll to the next section.
+        return;
+    }
+    UITableViewCell *nextCell = [self.tableView cellForRowAtIndexPath:scrollDstIndexPath];
+    if (nextCell && [self focusUnansweredCell:nextCell]) {
         // if we did change focus, then that will perform the scrolling
     } else {
-        // if we didn't change focus, then we need to handle the scrolling here
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, DelayBeforeAutoScroll * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-            [tableView scrollToRowAtIndexPath:nextIndexPath atScrollPosition:UITableViewScrollPositionTop animated:YES];
+            [_tableView scrollToRowAtIndexPath:scrollDstIndexPath atScrollPosition:UITableViewScrollPositionTop animated:YES];
         });
     }
 }

--- a/ResearchKitUI/Common/Step/Form Step/ORKFormStepViewController.m
+++ b/ResearchKitUI/Common/Step/Form Step/ORKFormStepViewController.m
@@ -1411,7 +1411,7 @@ NSString * const ORKFormStepViewAccessibilityIdentifier = @"ORKFormStepView";
         if (!nextCell) {
             return nil;
         }
-        // don't autoscroll to a cell that already has an answer
+        // Don't autoscroll to a cell that already has an answer.
         if (self.savedAnswers[nextFormItem.identifier]) {
             return nil;
         }

--- a/ResearchKitUI/Common/Step/Form Step/ORKFormStepViewController.m
+++ b/ResearchKitUI/Common/Step/Form Step/ORKFormStepViewController.m
@@ -1406,7 +1406,7 @@ NSString * const ORKFormStepViewAccessibilityIdentifier = @"ORKFormStepView";
             return nil;
         }
         NSString *nextReuseIdentifier = [self cellReuseIdentifierFromFormItem:nextFormItem cellItemIdentifier:nextItemIdentifier];
-        // can't autoscroll to something that doesn't exist
+        // Can't autoscroll to something that doesn't exist
         UITableViewCell *nextCell = [_tableView dequeueReusableCellWithIdentifier:nextReuseIdentifier];
         if (!nextCell) {
             return nil;


### PR DESCRIPTION
fixes a crash in the `ORKFormStepViewController` when answering the last question in a form, but there's subsequent informational (non-question) sections

the issue here is caused by the fact that the informational sections in the UITableView consist of only a header (which displays the informational content), but no actual cells.
meaning that when you attempt to scroll to the section, it'll try to scroll to a non-existent index path, which'll cause the table view to crash.

we work around this by explicitly handling this situation and adjusting the destination index path to scroll to the section as a whole instead.