### PR TITLE
fix choice selection tint color

### DIFF
--- a/ResearchKitUI/Common/CheckmarkView/ORKCheckmarkView.m
+++ b/ResearchKitUI/Common/CheckmarkView/ORKCheckmarkView.m
@@ -90,18 +90,11 @@
 }
 
 - (void)updateCheckView {
-    UIColor *existingTintColor = self.tintColor;
-    if (_checked) {
-        self.image = _checkedImage;
-        if (existingTintColor != ORKViewTintColor(self)) {
-            self.tintColor = ORKViewTintColor(self);
-        }
-    }
-    else {
-        self.image = _uncheckedImage;
-        if (existingTintColor != ORKViewTintColor(self)) {
-            self.tintColor = _shouldIgnoreDarkMode ? [UIColor lightGrayColor] : [UIColor systemGray3Color];
-        }
+    self.image = _checked ? _checkedImage : _uncheckedImage;
+    // NOTE that we intentionally obtain the superview's tint color here, since we might've set our own to gray already.
+    UIColor *newTintColor = _checked ? ORKViewTintColor(self.superview) : _shouldIgnoreDarkMode ? [UIColor lightGrayColor] : [UIColor systemGray3Color];
+    if (![self.tintColor isEqual:newTintColor]) {
+        self.tintColor = newTintColor;
     }
 }
 


### PR DESCRIPTION
fixes #1611; see the issue for more details


i'm not actually sure what the underlying cause here is tbh, but the changes in this PR are a non-invasive solution that fixes it w/out accidentally affecting other parts of RK.

the PR also fixes another bug, where the tintColor comparison for the `!_checked` branch incorrectly compared against the current tintColor we'd want to have if `_checked` were true, as opposed to the actual current one, leading to the tintColor never getting set to the gray one we'd actually want to have. (and, additionally, was comparing the raw pointers instead of the actual objects.)