### PR TITLE
Add answer validation with NSError

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -445,6 +445,14 @@ ORK_CLASS_AVAILABLE
 #if TARGET_OS_IOS
 @interface ORKAnswerFormat()
 
+/**
+ Validates the given answer. If it is invalid, returns NO and provides an NSError with a description of the reason.
+ @param answer The answer to validate.
+ @param error  If the answer is invalid, an NSError with details is placed here.
+ @return YES if the answer is valid; NO otherwise.
+ **/
+- (BOOL)validateAnswer:(id)answer error:(NSError **)error;
+
 /// @name Factory methods
 + (ORKScaleAnswerFormat *)scaleAnswerFormatWithMaximumValue:(NSInteger)scaleMaximum
                                                minimumValue:(NSInteger)scaleMinimum

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -631,6 +631,15 @@ static NSNumberFormatterStyle ORKNumberFormattingStyleConvert(ORKNumberFormattin
 - (BOOL)isAnswerValid:(id)answer {
     ORKAnswerFormat *impliedFormat = [self impliedAnswerFormat];
     return impliedFormat == self ? YES : [impliedFormat isAnswerValid:answer];
+    return YES;
+}
+
+- (BOOL)validateAnswer:(id)answer error:(NSError **)error {
+    BOOL isValid = [self isAnswerValid:answer];
+    if (!isValid && error != NULL) {
+        *error = [NSError errorWithDomain:@"ORKAnswerValid" code:1001 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"The answer is not valid.", nil)}];
+    }
+    return isValid;
 }
 
 - (BOOL)isAnswerValidWithString:(NSString *)text {

--- a/ResearchKitUI/Stale/ORKQuestionStepViewController.m
+++ b/ResearchKitUI/Stale/ORKQuestionStepViewController.m
@@ -626,6 +626,12 @@ static const NSTimeInterval DelayBeforeAutoScroll = 0.25;
 }
 
 - (void)saveAnswer:(id)answer {
+    NSError *validationError = nil;
+    if (![self.answerFormat validateAnswer:answer error:&validationError]) {
+        [self showValidityAlertWithMessage:validationError.localizedDescription];
+        return;
+    }
+    
     self.answer = answer;
     _savedSystemCalendar = [NSCalendar currentCalendar];
     _savedSystemTimeZone = [NSTimeZone systemTimeZone];
@@ -737,6 +743,12 @@ static const NSTimeInterval DelayBeforeAutoScroll = 0.25;
 #pragma mark - ORKQuestionStepCustomViewDelegate
 
 - (void)customQuestionStepView:(ORKQuestionStepCustomView *)customQuestionStepView didChangeAnswer:(id)answer {
+    NSError *validationError = nil;
+    if (![self.answerFormat validateAnswer:answer error:&validationError]) {
+        [self showValidityAlertWithMessage:validationError.localizedDescription];
+        return;
+    }
+    
     [self saveAnswer:answer];
     self.hasChangedAnswer = YES;
 }
@@ -909,6 +921,12 @@ static const NSTimeInterval DelayBeforeAutoScroll = 0.25;
 }
 
 - (void)goForward {
+    NSError *validationError = nil;
+    if (![self.answerFormat validateAnswer:self.answer error:&validationError]) {
+        [self showValidityAlertWithMessage:validationError.localizedDescription];
+        return;
+    }
+    
     if (![self shouldContinue]) {
         return;
     }
@@ -927,6 +945,12 @@ static const NSTimeInterval DelayBeforeAutoScroll = 0.25;
 
 - (void)continueAction:(id)sender {
     if (self.continueActionButton.enabled) {
+        NSError *validationError = nil;
+        if (![self.answerFormat validateAnswer:self.answer error:&validationError]) {
+            [self showValidityAlertWithMessage:validationError.localizedDescription];
+            return;
+        }
+        
         if (![self shouldContinue]) {
             return;
         }


### PR DESCRIPTION
**Key changes:**
- Introduced a new method `validateAnswer:error:` to ORKAnswerFormat for detailed answer validation using NSError.
- Updated ORKQuestionStepViewController and related flows to leverage the new validation, providing clear feedback to users when answers are invalid.
- Improved user experience and code maintainability by centralizing error handling and enabling detailed, user-friendly error messages.