### PR TITLE
Fix incorrect parameter passed to activeStepDuration in tremorTestTaskWithIdentifier

### DIFF
--- a/ResearchKitActiveTask/Common/ORKOrderedTask+ORKPredefinedActiveTask.m
+++ b/ResearchKitActiveTask/Common/ORKOrderedTask+ORKPredefinedActiveTask.m
@@ -3253,7 +3253,7 @@ NSString *const ORKTremorTestTurnWristStepIdentifier = @"tremor.handQueenWave";
                                                   options:(ORKPredefinedTaskOption)options {
     return [ORKOrderedTask tremorTestTaskWithIdentifier:identifier
                           intendedUseDescription:intendedUseDescription
-                              activeStepDuration:activeTaskOptions
+                              activeStepDuration:activeStepDuration
                                activeTaskOptions:activeTaskOptions
                                      handOptions:handOptions
                                          options:options


### PR DESCRIPTION
Fixes a typo in (#1615)

`+tremorTestTaskWithIdentifier:intendedUseDescription:activeStepDuration:activeTaskOptions:handOptions:options:`

The method was forwarding `activeTaskOptions` instead of `activeStepDuration` to
`ORKOrderedTask tremorTestTaskWithIdentifier:…`, resulting in an invalid active step duration at runtime.

---

Found when tried to use .NET iOS Binding with exception:
Exception Type: ObjCRuntime.ObjCException

Message:
Objective-C exception thrown.  Name: NSRangeException Reason: *** -[__NSArrayI objectAtIndexedSubscript:]: index 18446744073709551615 beyond bounds [0 .. 4]
