### PR TITLE
Add answer validation with NSError

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -445,6 +445,14 @@ ORK_CLASS_AVAILABLE
 #if TARGET_OS_IOS
 @interface ORKAnswerFormat()
 
+/**
+ Validates the given answer. If it is invalid, returns NO and provides an NSError with a description of the reason.
+ @param answer The answer to validate.
+ @param error  If the answer is invalid, an NSError with details is placed here.
+ @return YES if the answer is valid; NO otherwise.
+ **/
+- (BOOL)validateAnswer:(id)answer error:(NSError **)error;
+
 /// @name Factory methods
 + (ORKScaleAnswerFormat *)scaleAnswerFormatWithMaximumValue:(NSInteger)scaleMaximum
                                                minimumValue:(NSInteger)scaleMinimum

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -631,6 +631,15 @@ static NSNumberFormatterStyle ORKNumberFormattingStyleConvert(ORKNumberFormattin
 - (BOOL)isAnswerValid:(id)answer {
     ORKAnswerFormat *impliedFormat = [self impliedAnswerFormat];
     return impliedFormat == self ? YES : [impliedFormat isAnswerValid:answer];
+    return YES;
+}
+
+- (BOOL)validateAnswer:(id)answer error:(NSError **)error {
+    BOOL isValid = [self isAnswerValid:answer];
+    if (!isValid && error != NULL) {
+        *error = [NSError errorWithDomain:@"ORKAnswerValid" code:1001 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"The answer is not valid.", nil)}];
+    }
+    return isValid;
 }
 
 - (BOOL)isAnswerValidWithString:(NSString *)text {

--- a/ResearchKitUI/Stale/ORKQuestionStepViewController.m
+++ b/ResearchKitUI/Stale/ORKQuestionStepViewController.m
@@ -626,6 +626,12 @@ static const NSTimeInterval DelayBeforeAutoScroll = 0.25;
 }
 
 - (void)saveAnswer:(id)answer {
+    NSError *validationError = nil;
+    if (![self.answerFormat validateAnswer:answer error:&validationError]) {
+        [self showValidityAlertWithMessage:validationError.localizedDescription];
+        return;
+    }
+    
     self.answer = answer;
     _savedSystemCalendar = [NSCalendar currentCalendar];
     _savedSystemTimeZone = [NSTimeZone systemTimeZone];
@@ -737,6 +743,12 @@ static const NSTimeInterval DelayBeforeAutoScroll = 0.25;
 #pragma mark - ORKQuestionStepCustomViewDelegate
 
 - (void)customQuestionStepView:(ORKQuestionStepCustomView *)customQuestionStepView didChangeAnswer:(id)answer {
+    NSError *validationError = nil;
+    if (![self.answerFormat validateAnswer:answer error:&validationError]) {
+        [self showValidityAlertWithMessage:validationError.localizedDescription];
+        return;
+    }
+    
     [self saveAnswer:answer];
     self.hasChangedAnswer = YES;
 }
@@ -909,6 +921,12 @@ static const NSTimeInterval DelayBeforeAutoScroll = 0.25;
 }
 
 - (void)goForward {
+    NSError *validationError = nil;
+    if (![self.answerFormat validateAnswer:self.answer error:&validationError]) {
+        [self showValidityAlertWithMessage:validationError.localizedDescription];
+        return;
+    }
+    
     if (![self shouldContinue]) {
         return;
     }
@@ -927,6 +945,12 @@ static const NSTimeInterval DelayBeforeAutoScroll = 0.25;
 
 - (void)continueAction:(id)sender {
     if (self.continueActionButton.enabled) {
+        NSError *validationError = nil;
+        if (![self.answerFormat validateAnswer:self.answer error:&validationError]) {
+            [self showValidityAlertWithMessage:validationError.localizedDescription];
+            return;
+        }
+        
         if (![self shouldContinue]) {
             return;
         }


### PR DESCRIPTION
Improved answer validation for question steps in the ResearchKit UI, ensuring that invalid answers are caught and users receive helpful feedback. The main change is the addition of a new validation method in `ORKAnswerFormat`, which is now used throughout the question step view controller to check answers before saving or continuing.
**Answer validation improvements:**
* Added a new `- (BOOL)validateAnswer:error:` method to `ORKAnswerFormat`, which checks if an answer is valid and provides an `NSError` with a descriptive message if not. [[1]](diffhunk://#diff-b6f69cc029a45409bf773da4a5d9c17a48912532da41e88221e3264ea11f689bR448-R455) [[2]](diffhunk://#diff-dc9a385b259c55b36a3afcf8528871a28b8b8a406b4ea51ef5b4b470467d1126R634-R642)
* Updated `ORKQuestionStepViewController` methods (`saveAnswer`, custom view delegate, `goForward`, and `continueAction`) to use the new validation method, showing an alert with the error message when an invalid answer is detected.