### PR TITLE
Fix doubled 'the the' in doc comments

### DIFF
--- a/ResearchKit/Common/ORKResultPredicate.h
+++ b/ResearchKit/Common/ORKResultPredicate.h
@@ -195,7 +195,7 @@ ORK_CLASS_AVAILABLE
  For matching a form item result, you need to build a result selector with a `stepIdentifier` (the
  form step identifier) and a `resultIdentifier` (the form item result identifier).
  
- For matching results in the ongoing task, leave the `taskIdentifier` in the the form step identifier
+ For matching results in the ongoing task, leave the `taskIdentifier` in the form step identifier
  as `nil`. For matching results in different tasks, set the `taskIdentifier` appropriately.
 
  */

--- a/ResearchKit/Common/ORKTask.h
+++ b/ResearchKit/Common/ORKTask.h
@@ -83,7 +83,7 @@ typedef struct {
     /// The total number of steps in the task.
     NSUInteger total;
     
-    /// Indicates if the the step should present a progress label
+    /// Indicates if the step should present a progress label
     BOOL shouldBePresented;
 } ORKTaskProgress ORK_AVAILABLE_DECL;
 

--- a/ResearchKitActiveTask/Audio/ORKAudioLevelNavigationRule.m
+++ b/ResearchKitActiveTask/Audio/ORKAudioLevelNavigationRule.m
@@ -136,7 +136,7 @@ Float32 const VolumeClamp = 60.0;
     
     // Check the volume
     if ((audioLevelResult.fileURL != nil) && [self checkAudioLevelFromSoundFile:audioLevelResult.fileURL]) {
-        // Returning nil will drop through to the next step (which should be the the step that has the instructions
+        // Returning nil will drop through to the next step (which should be the step that has the instructions
         // for moving to a quieter room).
         return nil;
     }

--- a/ResearchKitUI/Common/Step/Instruction Step/ORKInstructionStepViewController.m
+++ b/ResearchKitUI/Common/Step/Instruction Step/ORKInstructionStepViewController.m
@@ -199,7 +199,7 @@
      should get handled the same way as other learn more callbacks at the task level. If the app responds to this delegate, it get's
      higher priority and it becomes the responsibility of the developer to handle all cases.
      
-     If not implemented, default to showing the learnMore view controller for the the step.
+     If not implemented, default to showing the learnMore view controller for the step.
      */
     
     [self handleLearnMoreButtonPressed:learnMoreStep];


### PR DESCRIPTION
## Summary

Four trivial doubled-word typos in user-visible doc comments:

| File | Context |
|---|---|
| [`ResearchKit/Common/ORKTask.h`](https://github.com/ResearchKit/ResearchKit/blob/main/ResearchKit/Common/ORKTask.h#L86) | `ORKTaskProgress.shouldBePresented` doc: "Indicates if the the step should present a progress label" |
| [`ResearchKit/Common/ORKResultPredicate.h`](https://github.com/ResearchKit/ResearchKit/blob/main/ResearchKit/Common/ORKResultPredicate.h#L198) | `taskIdentifier` matching doc: "leave the `taskIdentifier` in the the form step identifier" |
| [`ResearchKitActiveTask/Audio/ORKAudioLevelNavigationRule.m`](https://github.com/ResearchKit/ResearchKit/blob/main/ResearchKitActiveTask/Audio/ORKAudioLevelNavigationRule.m#L139) | drop-through comment in the audio-level navigation handler |
| [`ResearchKitUI/Common/Step/Instruction Step/ORKInstructionStepViewController.m`](https://github.com/ResearchKit/ResearchKit/blob/main/ResearchKitUI/Common/Step/Instruction%20Step/ORKInstructionStepViewController.m#L202) | `learnMore` fallback comment: "default to showing the learnMore view controller for the the step" |

All four drop a duplicate "the".

## Test plan

- [x] `grep -rEn '\b(the the|to to|is is)\b' --include='*.m' --include='*.h' --include='*.swift' ResearchKit ResearchKitActiveTask ResearchKitUI` — no remaining hits after the fix.

## Scope

Comment text only — no headers' API surface, no behavior, no build changes.